### PR TITLE
cleanup: remove unused imports from App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,6 @@ import {
   StyleSheet,
   TouchableOpacity,
   AppState,
-  AppStateStatus,
   Platform,
   LogBox,
 } from 'react-native';
@@ -177,7 +176,6 @@ import { Season2Screen } from './screens/season2/Season2Screen';
 import { CompeteScreen } from './screens/CompeteScreen';
 import { LeaderboardsScreen } from './screens/LeaderboardsScreen';
 import { RewardsScreen } from './screens/RewardsScreen';
-import { DonateScreen } from './screens/DonateScreen';
 import { TeamsScreen } from './screens/TeamsScreen';
 import { EventsScreen } from './screens/EventsScreen';
 import { ActivityTrackerScreen } from './screens/activity/ActivityTrackerScreen';


### PR DESCRIPTION
## What
Removes two unused imports from App.tsx that TypeScript flagged:
- `AppStateStatus` from react-native
- `DonateScreen` from ./screens/DonateScreen

## Why
These imports were declared but never used, adding unnecessary bundle weight and triggering TypeScript warnings.

## How Verified
```bash
npx tsc --noEmit | grep 'declared but.*never read'
```

## Risk
🟢 **Low** - Only removes unused imports, no functional changes.

---
*Created by DarkMolty 🦾*