### PR TITLE
fix(health-connect): prevent distance/steps/calories double-counting from multiple sources

### DIFF
--- a/src/services/fitness/healthConnectService.ts
+++ b/src/services/fitness/healthConnectService.ts
@@ -518,9 +518,12 @@ export class HealthConnectService {
       let avgHeartRate = 0;
       let maxHeartRate = 0;
 
-      // Fetch distance for this session
+      // Fetch distance for this session using aggregateRecord to avoid double-counting
+      // Per Android docs: "For cumulative types, use aggregate() instead of readRecords()
+      // to avoid double counting from multiple sources" (same issue as steps)
       try {
-        const distanceRecords = await HealthConnect.readRecords('Distance', {
+        const distanceResult = await HealthConnect.aggregateRecord({
+          recordType: 'Distance',
           timeRangeFilter: {
             operator: 'between',
             startTime: session.startTime,
@@ -528,16 +531,17 @@ export class HealthConnectService {
           },
         });
 
-        for (const record of distanceRecords?.records || []) {
-          totalDistance += record.distance?.inMeters || 0;
-        }
+        // DISTANCE_TOTAL contains the properly aggregated distance in meters
+        totalDistance = distanceResult?.DISTANCE_TOTAL?.inMeters || 0;
       } catch (e) {
         debugLog('Health Connect: Could not fetch distance:', e);
       }
 
-      // Fetch calories for this session
+      // Fetch calories for this session using aggregateRecord to avoid double-counting
+      // Same deduplication approach as distance and steps
       try {
-        const caloriesRecords = await HealthConnect.readRecords('ActiveCaloriesBurned', {
+        const caloriesResult = await HealthConnect.aggregateRecord({
+          recordType: 'ActiveCaloriesBurned',
           timeRangeFilter: {
             operator: 'between',
             startTime: session.startTime,
@@ -545,16 +549,18 @@ export class HealthConnectService {
           },
         });
 
-        for (const record of caloriesRecords?.records || []) {
-          totalCalories += record.energy?.inKilocalories || 0;
-        }
+        // ENERGY_TOTAL contains the properly aggregated calories
+        totalCalories = caloriesResult?.ENERGY_TOTAL?.inKilocalories || 0;
       } catch (e) {
         debugLog('Health Connect: Could not fetch calories:', e);
       }
 
-      // Fetch steps for this session
+      // Fetch steps for this session using aggregateRecord to avoid double-counting
+      // Per Android docs: "For cumulative types like StepsRecord, use aggregate()
+      // instead of readRecords() to avoid double counting from multiple sources"
       try {
-        const stepsRecords = await HealthConnect.readRecords('Steps', {
+        const stepsResult = await HealthConnect.aggregateRecord({
+          recordType: 'Steps',
           timeRangeFilter: {
             operator: 'between',
             startTime: session.startTime,
@@ -562,9 +568,8 @@ export class HealthConnectService {
           },
         });
 
-        for (const record of stepsRecords?.records || []) {
-          steps += record.count || 0;
-        }
+        // COUNT_TOTAL contains the properly aggregated step count
+        steps = stepsResult?.COUNT_TOTAL || 0;
       } catch (e) {
         debugLog('Health Connect: Could not fetch steps:', e);
       }


### PR DESCRIPTION
## Summary
Fixes #20

When users have multiple apps writing to Health Connect (e.g., Samsung Health + Garmin watch, or Google Fit + another tracker), distance was being counted 2x because we were using `readRecords()` and summing ALL records in the time range.

## Root Cause
Per Android Health Connect documentation:
> "For cumulative types like StepsRecord, use aggregate() instead of readRecords() to avoid double counting from multiple sources"

The same applies to Distance and Calories. The code was already using `aggregateRecord` correctly for daily step totals in `getTodaySteps()`, but the `transformExerciseSession()` function was still using the incorrect pattern.

## Changes
Changed `transformExerciseSession()` to use `aggregateRecord` for:
- **Distance** → `DISTANCE_TOTAL`
- **Calories** → `ENERGY_TOTAL`  
- **Steps** → `COUNT_TOTAL`

This ensures Health Connect properly deduplicates data from multiple sources before returning the total.

## Testing
- Requires testing on Android device with multiple fitness apps connected to Health Connect
- User reported: "Pixel 9, Android 16" - should verify fix on similar setup

## Notes
The report mentioned "at the moment HR is synced" - this is likely coincidental timing. The actual bug was that any multi-source data would be double-counted. HR data uses `readRecords` still but that's correct since we want all heart rate samples, not a sum.