### PR TITLE
fix(wallet): add missing Alert imports in receive components

### DIFF
--- a/src/components/wallet/ReceiveBitcoinForm.tsx
+++ b/src/components/wallet/ReceiveBitcoinForm.tsx
@@ -10,6 +10,7 @@ import {
   TextInput,
   TouchableOpacity,
   StyleSheet,
+  Alert,
 } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { theme } from '../../styles/theme';

--- a/src/components/wallet/ReceiveModal.tsx
+++ b/src/components/wallet/ReceiveModal.tsx
@@ -13,6 +13,7 @@ import {
   Modal,
   ScrollView,
   ActivityIndicator,
+  Alert,
 } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { theme } from '../../styles/theme';


### PR DESCRIPTION
## Summary
Adds missing `Alert` imports in two wallet receive components where `Alert.alert(...)` is already used.

## Why
Prevents runtime `ReferenceError` crashes when those alert paths execute.

## Changes
- `src/components/wallet/ReceiveModal.tsx`: import `Alert` from `react-native`
- `src/components/wallet/ReceiveBitcoinForm.tsx`: import `Alert` from `react-native`

## Risk
Very low (import-only change, no behavior changes).
