### PR TITLE
refactor(version): replace stale 1.6.5 fallbacks with runtime/unknown

### DIFF
--- a/src/services/backup/BackupService.ts
+++ b/src/services/backup/BackupService.ts
@@ -14,6 +14,7 @@
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import pako from 'pako';
+import Constants from 'expo-constants';
 import { GlobalNDKService } from '../nostr/GlobalNDKService';
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import type { NDKSigner } from '@nostr-dev-kit/ndk';
@@ -271,6 +272,7 @@ export class BackupService {
    */
   private async collectBackupData(): Promise<WorkoutBackupPayload> {
     const workoutService = LocalWorkoutStorageService.getInstance();
+    const appVersion = Constants.expoConfig?.version || 'unknown';
 
     const [workouts, habits, journalEntries, unitSystem, selectedCharity] = await Promise.all([
       workoutService.getAllWorkouts(),
@@ -283,7 +285,7 @@ export class BackupService {
     return {
       version: BACKUP_VERSION,
       exportedAt: new Date().toISOString(),
-      appVersion: '1.6.5', // TODO: Get from app config
+      appVersion,
       workouts,
       habits: habits.length > 0 ? habits : undefined,
       journal: journalEntries.length > 0 ? journalEntries : undefined,
@@ -356,7 +358,7 @@ export class BackupService {
     // Tags (metadata visible to relays, content is encrypted)
     event.tags = [
       ['d', BACKUP_D_TAG], // Replaceable identifier
-      ['client', 'RUNSTR', '1.6.5'],
+      ['client', 'RUNSTR', payload.appVersion || 'unknown'],
       ['encrypted', 'nip44'],
       ['compression', 'gzip'], // Content is gzip compressed before encryption
       ['backup_version', String(BACKUP_VERSION)],

--- a/src/services/nostr/workoutPublishingService.ts
+++ b/src/services/nostr/workoutPublishingService.ts
@@ -744,7 +744,7 @@ export class WorkoutPublishingService {
       ['exercise', exerciseVerb], // Simple activity type: running, yoga, strength, etc.
       ['duration', durationFormatted], // HH:MM:SS format (always included)
       ['source', sourceTag], // Data source: 'gps' for tracked, 'manual' for manual entry
-      ['client', 'RUNSTR', Constants.expoConfig?.version || '1.6.5'], // Client info with version
+      ['client', 'RUNSTR', Constants.expoConfig?.version || 'unknown'], // Client info with version
       ['t', this.getActivityHashtag(workout.type)], // Primary hashtag
     ];
 

--- a/src/services/verification/PerWorkoutVerificationService.ts
+++ b/src/services/verification/PerWorkoutVerificationService.ts
@@ -151,7 +151,7 @@ class PerWorkoutVerificationServiceClass {
    * Get current app version from Expo config
    */
   private getAppVersion(): string {
-    return Constants.expoConfig?.version || '1.6.5';
+    return Constants.expoConfig?.version || 'unknown';
   }
 
   /**

--- a/src/services/verification/VerificationService.ts
+++ b/src/services/verification/VerificationService.ts
@@ -192,7 +192,7 @@ class VerificationServiceClass {
    * Get current app version from Expo config
    */
   private getAppVersion(): string {
-    return Constants.expoConfig?.version || '1.6.5';
+    return Constants.expoConfig?.version || 'unknown';
   }
 
   /**


### PR DESCRIPTION
## Summary
Removes stale hardcoded `1.6.5` version fallbacks in backup, verification, and workout publishing paths.

## Why
Hardcoded old version literals can produce misleading metadata/tags and make troubleshooting harder after releases.

## Changes
- `BackupService`: derive `appVersion` from `Constants.expoConfig?.version || 'unknown'`
- `BackupService`: use payload app version in client tag fallback
- `VerificationService`: fallback changed to `'unknown'`
- `PerWorkoutVerificationService`: fallback changed to `'unknown'`
- `workoutPublishingService`: fallback changed to `'unknown'`

## Risk
Low — metadata/version fallback only; no behavioral flow changes.
