### PR TITLE
fix(auth): import UnifiedSigningService in AuthContext

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -18,6 +18,7 @@ import { DirectNostrProfileService } from '../services/user/directNostrProfileSe
 import { locationPermissionService } from '../services/activity/LocationPermissionService';
 import unifiedCache from '../services/cache/UnifiedNostrCache';
 import { CacheKeys } from '../constants/cacheTTL';
+import { UnifiedSigningService } from '../services/auth/UnifiedSigningService';
 import type { User } from '../types';
 import { PerformanceLogger } from '../utils/PerformanceLogger';
 import { NostrFetchLogger } from '../utils/NostrFetchLogger';


### PR DESCRIPTION
## Summary
Add missing UnifiedSigningService import in AuthContext.

## Why
`UnifiedSigningService.getInstance()` is used in Amber sign-in flow but was not imported, which can cause runtime/TS errors.

## Scope
- Import-only change in `src/contexts/AuthContext.tsx`

## Risk
Very low (no logic change).
