### PR TITLE
refactor(team): remove duplicate TeamMemberCache export

### DIFF
--- a/src/services/team/TeamMemberCache.ts
+++ b/src/services/team/TeamMemberCache.ts
@@ -359,4 +359,3 @@ export class TeamMemberCache {
 // Export class as default (not instance) to prevent blocking module initialization
 // Also keep named export for compatibility
 export default TeamMemberCache;
-export { TeamMemberCache };


### PR DESCRIPTION
## Summary
Remove redundant named export in `TeamMemberCache`.

## Why
`TeamMemberCache` is already exported as a class and as default export. The extra `export { TeamMemberCache };` is duplicate and can trigger TS export conflicts.

## Changes
- Removed only the redundant trailing named export line.

## Risk
Very low (export cleanup, no runtime logic changes).
