### PR TITLE
docs: clarify RELEASE_NOTES is archived and point to CHANGELOG

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,6 @@
-## What's New in v1.6.6-debug
+_Note: These notes are historical. For current release details (including v1.7.0), see `CHANGELOG.md`._
+
+## Release Notes (Archived: v1.6.6-debug)
 
 I've removed the compete button from the post workout stuff so that workouts/steps automatically go into competitions.
 


### PR DESCRIPTION
## Summary
Clarifies that `RELEASE_NOTES.md` contains archived historical notes and points readers to `CHANGELOG.md` for current release info.

## Why
The file currently starts with `v1.6.6-debug`, which can be mistaken for current release notes on `v1.7.0` branches.

## Changes
- Updated heading to indicate archived status.
- Added one note at top directing to `CHANGELOG.md` for latest release details.

## Risk
None (docs-only).
