### PR TITLE
docs(android): replace stale version examples with placeholders

### DIFF
--- a/docs/ANDROID_BUILD.md
+++ b/docs/ANDROID_BUILD.md
@@ -127,7 +127,7 @@ Version is defined in two places:
    ```json
    {
      "expo": {
-       "version": "0.1.8"
+       "version": "X.Y.Z"
      }
    }
    ```
@@ -136,7 +136,7 @@ Version is defined in two places:
    ```gradle
    android {
      defaultConfig {
-       versionCode 8
+       versionCode <increment-by-1>
        versionName "0.1.8"
      }
    }


### PR DESCRIPTION
## Summary
Updates Android build doc examples to use placeholders instead of stale hardcoded version numbers.

## Why
Hardcoded examples like `0.1.8` / `Build 8` drift quickly and can cause release mistakes.

## Changes
- `"version": "0.1.8"` → `"version": "X.Y.Z"`
- `versionCode 8` → `versionCode <increment-by-1>`
- `Version 0.1.8 (Build 8)` → `Version X.Y.Z (Build N)`

## Risk
None (docs-only).
