### PR TITLE
fix(wallet): restore Receive modal alert handling

### DIFF
--- a/src/components/wallet/ReceiveBitcoinForm.tsx
+++ b/src/components/wallet/ReceiveBitcoinForm.tsx
@@ -10,6 +10,7 @@ import {
   TextInput,
   TouchableOpacity,
   StyleSheet,
+  Alert,
 } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { theme } from '../../styles/theme';

--- a/src/components/wallet/ReceiveModal.tsx
+++ b/src/components/wallet/ReceiveModal.tsx
@@ -13,6 +13,7 @@ import {
   Modal,
   ScrollView,
   ActivityIndicator,
+  Alert,
 } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { theme } from '../../styles/theme';
@@ -42,7 +43,7 @@ export const ReceiveModal: React.FC<ReceiveModalProps> = ({
   const [isCheckingPayment, setIsCheckingPayment] = useState(false);
   const [hasNWC, setHasNWC] = useState(false);
   const [isReady, setIsReady] = useState(false);
-  const checkIntervalRef = React.useRef<NodeJS.Timeout>();
+  const checkIntervalRef = React.useRef<NodeJS.Timeout | null>(null);
 
   // Check NWC availability when modal opens
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add missing `Alert` import in `ReceiveBitcoinForm`
- add missing `Alert` import in `ReceiveModal`
- initialize `checkIntervalRef` with `null` (`useRef<NodeJS.Timeout | null>(null)`) to satisfy strict TypeScript usage

## Why
The receive flow was referencing `Alert` without importing it, which can break compile/runtime for wallet receive screens. `useRef` was also declared without an initial value, which triggers a TypeScript error under current config.

## Risk
Low — import and ref initialization only; no business logic changes.

## Test Evidence
- `npm run -s typecheck 2>&1 | rg "ReceiveBitcoinForm|ReceiveModal" -n` produced no matches for these files after this change.
- Full project typecheck still has unrelated existing errors outside this PR scope.
