### PR TITLE
fix(analytics): use runtime platform and app version in event metadata

### DIFF
--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -3,6 +3,8 @@
  * Tracks user behavior, team selection, and key conversion events
  */
 
+import Constants from 'expo-constants';
+import { Platform } from 'react-native';
 import { DiscoveryTeam, Team } from '../types';
 
 // Analytics event types
@@ -106,12 +108,18 @@ class Analytics {
 
   // Get base properties for all events
   private getBaseProperties(): BaseAnalyticsProperties {
+    const platform: BaseAnalyticsProperties['platform'] =
+      Platform.OS === 'android' ? 'android' : 'ios';
+
+    const appVersion =
+      Constants.expoConfig?.version || Constants.nativeAppVersion || undefined;
+
     return {
       userId: this.userId,
       timestamp: new Date().toISOString(),
       sessionId: this.sessionId,
-      platform: 'ios', // TODO: Get from Platform.OS
-      appVersion: '1.0.0', // TODO: Get from package.json or config
+      platform,
+      appVersion,
     };
   }
 


### PR DESCRIPTION
## Summary
This PR fixes hardcoded analytics metadata by populating base event properties from runtime values.

### Changes
- Added `Platform` and `expo-constants` imports in `src/utils/analytics.ts`
- Replaced hardcoded `platform: 'ios'` with runtime platform detection (`ios`/`android`)
- Replaced hardcoded `appVersion: '1.0.0'` with runtime app version from Expo config/native app version

## Why
Accurate analytics metadata is required for reliable dashboard segmentation and release-level event analysis.

## Validation
- `npm run typecheck` currently fails on existing repository-wide TypeScript errors unrelated to this file.
- Confirmed changed file compiles syntactically and preserves existing analytics API.
