### PR TITLE
fix(weather): read OpenWeather API key from env

### DIFF
--- a/src/services/activity/WeatherService.ts
+++ b/src/services/activity/WeatherService.ts
@@ -15,9 +15,8 @@ export interface WeatherConditions {
 class WeatherService {
   private static instance: WeatherService;
 
-  // OpenWeather API key - should be in environment variables
-  // For MVP, using a placeholder - replace with actual key
-  private readonly API_KEY = 'YOUR_OPENWEATHER_API_KEY'; // TODO: Move to env
+  // OpenWeather API key - configured via Expo public env vars
+  private readonly API_KEY = process.env.EXPO_PUBLIC_OPENWEATHER_API_KEY || '';
   private readonly BASE_URL = 'https://api.openweathermap.org/data/2.5/weather';
 
   private constructor() {}
@@ -40,8 +39,8 @@ class WeatherService {
     timestamp?: number // Optional - for future historical data support
   ): Promise<WeatherConditions | null> {
     try {
-      // For MVP, check if API key is configured
-      if (!this.API_KEY || this.API_KEY === 'YOUR_OPENWEATHER_API_KEY') {
+      // Check if API key is configured
+      if (!this.API_KEY) {
         console.warn(
           '[WeatherService] API key not configured, skipping weather fetch'
         );


### PR DESCRIPTION
## Summary
- replace hardcoded OpenWeather placeholder key with `process.env.EXPO_PUBLIC_OPENWEATHER_API_KEY`
- simplify API key guard to check only for missing env value

## Why
The service was hardcoded to a placeholder key and contained a TODO to move configuration to env variables. This PR completes that migration with minimal risk.

## Risk
Low. Weather fetch behavior is unchanged when a key is present; when missing, service still logs and returns `null`.

## Validation
- `npm run -s typecheck` *(fails due to existing unrelated repo-wide TypeScript errors; no new weather-service-specific errors introduced)*
