### PR TITLE
fix(cache): add missing appCache.delete to prevent TeamCacheService crash

### DIFF
--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -55,6 +55,11 @@ class SimpleCache {
     });
   }
 
+  async delete(key: string): Promise<void> {
+    this.memoryCache.delete(key);
+    await AsyncStorage.removeItem(`cache_${key}`);
+  }
+
   async clear(pattern?: string): Promise<void> {
     if (!pattern) {
       this.memoryCache.clear();


### PR DESCRIPTION
## Summary
- add missing `delete(key)` API to `SimpleCache` in `src/utils/cache.ts`
- remove both in-memory and AsyncStorage entries for a single cache key

## Why
`TeamCacheService.clearCache()` calls `appCache.delete(...)`, but `SimpleCache` did not implement that method. At runtime this throws a `TypeError` and prevents team-cache invalidation.

## Risk
Low. Adds one focused method without changing existing cache read/write/clear behavior.

## Validation
- verified `TeamCacheService` calls now map to an implemented `appCache.delete` API
- change is isolated to cache utility; no call-site behavior changes required