### PR TITLE
security: replace CoinOS Math.random credential generation

### DIFF
--- a/src/services/wallet/CoinOSAccountService.ts
+++ b/src/services/wallet/CoinOSAccountService.ts
@@ -22,11 +22,26 @@ const COINOS_JWT = '@runstr:coinos_jwt';
 const COINOS_API_BASE = 'https://coinos.io/api';
 const COINOS_API_TIMEOUT = 15000;
 
+function secureRandomInt(maxExclusive: number): number {
+  if (maxExclusive <= 0) {
+    throw new Error('maxExclusive must be greater than 0');
+  }
+
+  // react-native-get-random-values polyfills global crypto.getRandomValues
+  if (typeof global.crypto !== 'undefined' && global.crypto?.getRandomValues) {
+    const random = new Uint32Array(1);
+    global.crypto.getRandomValues(random);
+    return random[0] % maxExclusive;
+  }
+
+  throw new Error('Secure RNG unavailable: crypto.getRandomValues is required');
+}
+
 function generatePassword(length: number = 16): string {
   const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
   let result = '';
   for (let i = 0; i < length; i++) {
-    result += chars.charAt(Math.floor(Math.random() * chars.length));
+    result += chars.charAt(secureRandomInt(chars.length));
   }
   return result;
 }
@@ -121,9 +136,7 @@ export class CoinOSAccountService {
 
         if (response.status === 409) {
           // Username taken — append random suffix
-          const suffix = Math.floor(Math.random() * 1000)
-            .toString()
-            .padStart(3, '0');
+          const suffix = secureRandomInt(1000).toString().padStart(3, '0');
           username = `${baseUsername}${suffix}`;
           attempts++;
           console.log('[CoinOS] Username taken, trying:', username);


### PR DESCRIPTION
## Summary
- replace `Math.random()` usage in CoinOS password generation with `crypto.getRandomValues`
- replace username collision suffix RNG with secure RNG helper
- fail fast if secure RNG is unavailable instead of silently using weak entropy

## Why
Security analysis flagged insecure PRNG usage in CoinOS account credential generation. This path is used when users set up CoinOS wallets from Teams/CoinOS setup flow.

## Validation
- static validation: `CoinOSAccountSetupModal` calls `CoinOSAccountService.createAccount(...)`
- confirmed no remaining `Math.random()` in `CoinOSAccountService`
