### PR TITLE
security: harden Nostr key generation RNG

### DIFF
--- a/src/utils/nostr.ts
+++ b/src/utils/nostr.ts
@@ -73,11 +73,18 @@ export interface NostrKeyPair {
  */
 export function generateNostrKeyPair(): NostrKeyPair {
   try {
-    // Generate 32 bytes of random data for private key
+    // Generate 32 bytes of cryptographically secure random data for private key
     const privateKeyBytes = new Uint8Array(32);
-    for (let i = 0; i < 32; i++) {
-      privateKeyBytes[i] = Math.floor(Math.random() * 256);
+
+    const cryptoObj = globalThis.crypto as
+      | { getRandomValues: (array: Uint8Array) => Uint8Array }
+      | undefined;
+
+    if (!cryptoObj?.getRandomValues) {
+      throw new Error('Secure RNG unavailable: crypto.getRandomValues is required');
     }
+
+    cryptoObj.getRandomValues(privateKeyBytes);
 
     const privateKeyHex = Array.from(privateKeyBytes)
       .map((byte) => byte.toString(16).padStart(2, '0'))


### PR DESCRIPTION
## Summary
- replace `Math.random()` entropy source in `generateNostrKeyPair()` with `crypto.getRandomValues()`
- add explicit guard to fail fast if secure RNG API is unavailable

## Why
`generateNostrKeyPair()` was using non-cryptographic randomness for private keys, which weakens key entropy and can make generated keys predictable.

## Scope
Small, single-file security fix in a live auth utility path.

## Validation
- static evidence on latest `origin/main`: `src/utils/nostr.ts` generated each byte with `Math.floor(Math.random() * 256)`
- live path evidence: `GoogleAuthProvider` calls `generateNostrKeyPair()` during auth key generation (`src/services/auth/providers/googleAuthProvider.ts`)
- stale-base check: confirmed this fix did not already exist on fresh `origin/main` before patching
