### PR TITLE
fix(auth): clear stale GlobalNDK signer on sign-out

### DIFF
--- a/src/services/auth/authService.ts
+++ b/src/services/auth/authService.ts
@@ -22,6 +22,16 @@ export class AuthService {
       // Clear Nostr keys and data
       await clearNostrStorage();
 
+      // CRITICAL: Clear GlobalNDK signer to prevent stale signing identity after logout
+      try {
+        const { GlobalNDKService } = await import('../nostr/GlobalNDKService');
+        const ndk = await GlobalNDKService.getInstance();
+        ndk.signer = undefined;
+        console.log('✅ AuthService: GlobalNDK signer cleared');
+      } catch (err) {
+        console.warn('⚠️ AuthService: Failed to clear GlobalNDK signer:', err);
+      }
+
       // Import AsyncStorage for wallet cleanup
       const AsyncStorage = (
         await import('@react-native-async-storage/async-storage')


### PR DESCRIPTION
## Summary
- clear GlobalNDK signer during AuthService.signOut()
- prevent stale signing identity from persisting across account switches
- keep change minimal and isolated to sign-out cleanup flow

## Why
Security analysis flagged that GlobalNDK signer could remain set after logout, which risks unintended event signing as a prior user if any background flow reuses the singleton instance.

## Proof / Hard Gates
- **LIVE_CODE_GATE (pass):** AuthContext.signOut() calls AuthService.signOut() (src/contexts/AuthContext.tsx:627,658), so this path runs in normal app logout flow.
- **REPRO_GATE (pass, static evidence):** On latest base (origin/main), AuthContext sets ndk.signer = signer during login (src/contexts/AuthContext.tsx:532) but AuthService.signOut() had no ndk.signer = undefined cleanup.
- **STALE_BASE_GATE (pass):** Verified in origin/main:src/services/auth/authService.ts there was no GlobalNDKService signer reset.
- **IMPACT_GATE (pass):** security / auth isolation
- **PROOF_GATE (pass):**
  - REPRODUCED_BUG=true (static evidence of missing sign-out signer clear)
  - FIX_VALIDATED=true (sign-out now explicitly sets ndk.signer = undefined)

## Validation
- Ran npm run typecheck (repository currently has many pre-existing TS errors unrelated to this change).
- Confirmed patch is limited to src/services/auth/authService.ts.
