### PR TITLE
fix(cache): add SimpleCache.delete to stop TeamCacheService clear crash

### DIFF
--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -55,6 +55,11 @@ class SimpleCache {
     });
   }
 
+  async delete(key: string): Promise<void> {
+    this.memoryCache.delete(key);
+    await AsyncStorage.removeItem(`cache_${key}`);
+  }
+
   async clear(pattern?: string): Promise<void> {
     if (!pattern) {
       this.memoryCache.clear();


### PR DESCRIPTION
## Summary
- add `SimpleCache.delete(key)` to `src/utils/cache.ts`
- remove the runtime `TypeError` path when `TeamCacheService.clearCache()` calls `appCache.delete(...)`

## Why
`TeamCacheService.clearCache()` currently invokes `appCache.delete(...)`, but `SimpleCache` had no `delete` method. This causes a runtime crash in live team-management flows that clear team cache after updates.

## Evidence
- Fault site: `src/services/cache/TeamCacheService.ts:88-89`
- Missing method on base: `src/utils/cache.ts` (no `delete` before this PR)
- Live call path: `src/screens/CaptainDashboardScreen.tsx:697-703` calls `teamCache.clearCache()` after successful team edit and publish.

## Risk
Low. Adds a focused cache utility method; no behavior change outside explicit key deletion.
