### PR TITLE
fix(security): use SecureNsecStorage for Running Bitcoin completion signing

### DIFF
--- a/src/services/challenge/RunningBitcoinService.ts
+++ b/src/services/challenge/RunningBitcoinService.ts
@@ -30,6 +30,7 @@ import { SupabaseCompetitionService } from '../backend/SupabaseCompetitionServic
 import { ProfileCache } from '../../cache/ProfileCache';
 import { nip19 } from 'nostr-tools';
 import { PendingSubmissionService, PendingSubmission } from '../competition/PendingSubmissionService';
+import { SecureNsecStorage } from '../auth/SecureNsecStorage';
 
 const JOINED_USERS_KEY = '@runstr:running_bitcoin_joined';
 const REWARDS_CLAIMED_KEY = '@runstr:running_bitcoin_rewards_claimed';
@@ -1063,10 +1064,10 @@ class RunningBitcoinServiceClass {
   private async postCompletionToNostr(_pubkey: string, progress: RunningBitcoinProgress): Promise<string> {
     const ndk = await GlobalNDKService.getInstance();
 
-    // Get user's nsec from storage for signing
-    const nsec = await AsyncStorage.getItem('@runstr:user_nsec');
+    // Get user's nsec from secure storage for signing (with legacy migration fallback)
+    const nsec = await SecureNsecStorage.getNsec();
     if (!nsec) {
-      throw new Error('No nsec found - cannot sign event');
+      throw new Error('No nsec found in secure storage - cannot sign event');
     }
 
     // Create the completion post content


### PR DESCRIPTION
## Summary
- replace legacy `AsyncStorage.getItem('@runstr:user_nsec')` read in `RunningBitcoinService.postCompletionToNostr`
- use `SecureNsecStorage.getNsec()` instead (includes migration fallback)
- preserve existing guard/error behavior when no nsec is available

## Why
`SecureNsecStorage.migrateToSecureStore()` clears legacy plain AsyncStorage nsec keys after migration. The Running Bitcoin completion-post flow still read only the legacy key, so migrated users can hit false "No nsec found" and fail completion posting/reward side-effects in live workout flow.

## Evidence
- Live call path: `src/services/nostr/workoutPublishingService.ts:413` -> `RunningBitcoinService.checkAndAutoPayReward(...)`
- Fault source on base: `src/services/challenge/RunningBitcoinService.ts` read legacy key directly
- Migration behavior: `src/services/auth/SecureNsecStorage.ts:158-166` clears legacy keys after successful migration

## Risk
Low: narrow, single-method storage read alignment with existing auth storage abstraction.
