### PR TITLE
fix(cache): invalidate team leaderboard caches after workout publish

### DIFF
--- a/src/services/nostr/workoutPublishingService.ts
+++ b/src/services/nostr/workoutPublishingService.ts
@@ -395,8 +395,10 @@ export class WorkoutPublishingService {
       // ============================================================================
 
       // Cache invalidation (non-blocking)
+      // Pass competition team so leaderboard/team feed caches are invalidated too.
+      const teamIds = workout.competitionTeam ? [workout.competitionTeam] : undefined;
       fireAndForget(
-        CacheInvalidationService.invalidateWorkout(pubkey),
+        CacheInvalidationService.invalidateWorkout(pubkey, teamIds),
         'cacheInvalidation'
       );
 


### PR DESCRIPTION
## Summary
- pass `workout.competitionTeam` into `CacheInvalidationService.invalidateWorkout(...)`
- ensure leaderboard/team-activity cache invalidation actually runs for the team tied to the submitted workout

## Why
`invalidateWorkout` only clears leaderboard/team activity when `teamIds` are provided.
`WorkoutPublishingService.saveWorkoutToNostr` called it with only `pubkey`, so team leaderboard caches could remain stale after successful workout submissions.

## Risk
Low: narrow change in a non-blocking fire-and-forget invalidation call; no reward routing/auth logic touched.

## Validation
- Static verification of fault on base:
  - caller omitted teamIds: `src/services/nostr/workoutPublishingService.ts:397-401` (origin/main)
  - callee requires teamIds for leaderboard invalidation: `src/services/cache/CacheInvalidationService.ts:49-63`
- Live path verification:
  - `saveWorkoutToNostr` is invoked from active workout/manual-entry flows: `WalkingTrackerScreen`, `ManualEntryScreen`, `StrengthTrackerScreen`, `WorkoutSummaryModal`, etc.
