### PR TITLE
fix(security): use centralized sign-out path from Settings

### DIFF
--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -69,14 +69,13 @@ import { ExportDataModal } from '../components/backup/ExportDataModal';
 import { ImportDataModal } from '../components/backup/ImportDataModal';
 import { SecureNsecStorage } from '../services/auth/SecureNsecStorage';
 import { defaultActivityService, type DefaultActivity } from '../services/activity/DefaultActivityService';
-// useAuth removed - using direct AsyncStorage.clear() + CommonActions.reset()
 
 interface SettingsScreenProps {
   onCaptainDashboard?: () => void;
   onHelp?: () => void;
   onContactSupport?: () => void;
   onPrivacyPolicy?: () => void;
-  onSignOut?: () => void;
+  onSignOut?: () => void | Promise<void>;
 }
 
 interface SettingItemProps {
@@ -456,7 +455,13 @@ export const SettingsScreen: React.FC<SettingsScreenProps> = ({
         onPress: async () => {
           setAlertVisible(false);
 
-          // Clear all auth data
+          // Prefer centralized sign-out path when provided by AuthContext/App
+          if (onSignOut) {
+            await onSignOut();
+            return;
+          }
+
+          // Fallback for legacy callers: clear local auth data and restart
           await AsyncStorage.multiRemove([
             '@runstr:user_nsec',
             '@runstr:npub',
@@ -466,8 +471,6 @@ export const SettingsScreen: React.FC<SettingsScreenProps> = ({
             '@runstr:app_init_completed',
           ]);
           await SecureStore.deleteItemAsync('nwc_string');
-
-          // Restart the app - it will boot fresh and find no auth → show Login
           RNRestart.restart();
         },
       },


### PR DESCRIPTION
## Summary
- route Settings sign-out to the injected `onSignOut` callback when available
- keep legacy local-clear+restart fallback for callers that do not provide `onSignOut`
- widen `onSignOut` prop type to allow async handlers

## Why
Settings had a parallel sign-out path that bypassed the app's centralized sign-out cleanup flow (`AuthContext.signOut -> AuthService.signOut`). This could skip broader cache/session cleanup and create inconsistent logout behavior.

## Validation
- verified Settings screen is in active app flow and receives `onSignOut` from `App.tsx`
- verified base branch implementation did not call `onSignOut` in `handleSignOut`
- verified branch now calls `onSignOut` first and falls back only if callback is absent

## Risk
Low. Change is scoped to sign-out dispatch in one screen and preserves backward-compatible fallback behavior.
