### PR TITLE
fix(security): remove partial nsec logging from auth flows

### DIFF
--- a/src/services/auth/providers/nostrAuthProvider.ts
+++ b/src/services/auth/providers/nostrAuthProvider.ts
@@ -353,10 +353,7 @@ export class NostrAuthProvider {
       const npub = ndkUser.npub;
       const hexPubkey = ndkUser.pubkey;
 
-      console.log(
-        '🔑 Generated nsec using custom encoder:',
-        nsec ? nsec.slice(0, 10) + '...' : 'null'
-      );
+      console.log('🔑 Generated nsec using custom encoder:', !!nsec);
       console.log(
         '🔑 NDK provided npub:',
         npub ? npub.slice(0, 20) + '...' : 'null'
@@ -365,8 +362,8 @@ export class NostrAuthProvider {
       // Validate all generated values
       if (!nsec || !nsec.startsWith('nsec1')) {
         console.error(
-          '❌ NostrAuthProvider: Invalid nsec generated:',
-          nsec?.slice(0, 10) || 'null'
+          '❌ NostrAuthProvider: Invalid nsec generated (present):',
+          !!nsec
         );
         console.error(
           '❌ NostrAuthProvider: hex private key was:',
@@ -392,7 +389,7 @@ export class NostrAuthProvider {
       }
 
       console.log('✅ NostrAuthProvider: Generated new Nostr identity:', {
-        nsec: nsec.slice(0, 10) + '...',
+        hasNsec: !!nsec,
         npub: npub.slice(0, 20) + '...',
         hexPubkey: hexPubkey.slice(0, 16) + '...',
       });
@@ -405,8 +402,8 @@ export class NostrAuthProvider {
           '❌ NostrAuthProvider: Failed to store generated authentication data'
         );
         console.error(
-          '❌ NostrAuthProvider: Storage failed for nsec:',
-          nsec.slice(0, 10) + '...'
+          '❌ NostrAuthProvider: Storage failed for nsec (present):',
+          !!nsec
         );
         console.error(
           '❌ NostrAuthProvider: Storage failed for npub:',

--- a/src/utils/nostrAuth.ts
+++ b/src/utils/nostrAuth.ts
@@ -44,7 +44,7 @@ export async function storeAuthenticationData(
     console.log('[Auth] nsec format check:', {
       startsWithNsec: nsec?.startsWith('nsec1'),
       length: nsec?.length,
-      sample: nsec ? nsec.slice(0, 10) + '...' : 'null',
+      present: !!nsec,
     });
 
     // Validate nsec format first
@@ -52,7 +52,7 @@ export async function storeAuthenticationData(
       console.error('[Auth] Invalid nsec format:', {
         startsWithNsec: nsec?.startsWith('nsec1'),
         length: nsec?.length,
-        sample: nsec ? nsec.slice(0, 10) + '...' : 'null',
+        present: !!nsec,
       });
       return false;
     }
@@ -345,16 +345,16 @@ export async function migrateAuthenticationStorage(
         // Try npub as key (old broken method)
         nsec = decryptNsec(encrypted, userNpub);
         console.log(
-          '[Auth] Decrypted with npub:',
-          nsec?.slice(0, 10) || 'failed'
+          '[Auth] Decrypted with npub (valid):',
+          !!nsec?.startsWith('nsec1')
         );
 
         if (!nsec?.startsWith('nsec1')) {
           // Try userId as key (correct method)
           nsec = decryptNsec(encrypted, userId);
           console.log(
-            '[Auth] Decrypted with userId:',
-            nsec?.slice(0, 10) || 'failed'
+            '[Auth] Decrypted with userId (valid):',
+            !!nsec?.startsWith('nsec1')
           );
         }
 
@@ -364,8 +364,8 @@ export async function migrateAuthenticationStorage(
           if (hexPubkey) {
             nsec = decryptNsec(encrypted, hexPubkey);
             console.log(
-              '[Auth] Decrypted with hexPubkey:',
-              nsec?.slice(0, 10) || 'failed'
+              '[Auth] Decrypted with hexPubkey (valid):',
+              !!nsec?.startsWith('nsec1')
             );
           }
         }


### PR DESCRIPTION
## Summary
Removes partial `nsec` value logging from active authentication flows and migration/debug paths.

## Why
Security analysis flagged that logging key substrings can leak sensitive material to Metro logs, crash reporters, and log aggregation systems.

## Changes
- `src/services/auth/providers/nostrAuthProvider.ts`
  - Replaced `nsec.slice(...)` log output with boolean presence checks.
- `src/utils/nostrAuth.ts`
  - Replaced `sample`/decryption logs that exposed nsec prefixes with presence/validity booleans.

## Scope / risk
- No auth logic changes.
- Log-message-only change.
- Minimal regression risk.

## Evidence
- Prior static evidence on `main` showed direct nsec substring logging in both files.
- Post-fix grep confirms no `nsec.slice`/`nsec.substring` logging remains in these paths.
