### PR TITLE
fix(security): ensure Settings fallback sign-out clears secure session

### DIFF
--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -68,6 +68,7 @@ import { WoTService } from '../services/wot/WoTService';
 import { ExportDataModal } from '../components/backup/ExportDataModal';
 import { ImportDataModal } from '../components/backup/ImportDataModal';
 import { SecureNsecStorage } from '../services/auth/SecureNsecStorage';
+import { AuthService } from '../services/auth/authService';
 import { defaultActivityService, type DefaultActivity } from '../services/activity/DefaultActivityService';
 
 interface SettingsScreenProps {
@@ -461,16 +462,9 @@ export const SettingsScreen: React.FC<SettingsScreenProps> = ({
             return;
           }
 
-          // Fallback for legacy callers: clear local auth data and restart
-          await AsyncStorage.multiRemove([
-            '@runstr:user_nsec',
-            '@runstr:npub',
-            '@runstr:hex_pubkey',
-            '@runstr:auth_method',
-            '@runstr:amber_pubkey',
-            '@runstr:app_init_completed',
-          ]);
-          await SecureStore.deleteItemAsync('nwc_string');
+          // Fallback for legacy callers: still use centralized sign-out
+          // so SecureStore nsec + app caches/stores are fully cleared.
+          await AuthService.signOut();
           RNRestart.restart();
         },
       },


### PR DESCRIPTION
## Summary
- route `SettingsScreen` legacy fallback sign-out path through `AuthService.signOut()`
- remove ad-hoc partial key deletion that left secure nsec/session artifacts behind
- keep restart behavior after centralized sign-out

## Why
Security analysis flagged that the Settings fallback sign-out path only removed a subset of AsyncStorage keys and did **not** clear SecureStore nsec, allowing session carry-over on shared devices.

## Scope
Small, isolated change in `src/screens/SettingsScreen.tsx` only.

## Validation
- static evidence on base: fallback path manually removed specific keys + `nwc_string`, but did not clear SecureNsecStorage
- patch now calls `AuthService.signOut()` in the fallback path, which centralizes secure/session cleanup
- no navigation or UI behavior changes besides stronger cleanup semantics

## Gates
- LIVE_CODE_GATE: pass (Settings route is registered and reachable in `AppNavigator`)
- REPRO_GATE: pass (exact static fault in fallback code path)
- STALE_BASE_GATE: pass (fault present on base before this commit)
- IMPACT_GATE: pass (security/session isolation)
- PROOF_GATE: pass (reproduced_bug + fix_validated included in proof JSON)
