### PR TITLE
fix(navigation): use authenticated user npub in TeamDiscovery route

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -238,7 +238,7 @@ export const AppNavigator: React.FC<AppNavigatorProps> = ({
             onRefresh={refresh}
             showHeader={true}
             showCloseButton={false}
-            currentUserPubkey={currentUserNpub}
+            currentUserPubkey={user?.npub}
             navigation={navigation}
           />
         )}


### PR DESCRIPTION
## Why
`AppNavigator` passed `currentUserNpub` into `TeamDiscoveryScreen`, but `currentUserNpub` is not defined in component scope. This results in `undefined` being passed for current user pubkey and breaks user-specific team membership detection in Team Discovery flows.

## What changed
- Replaced `currentUserPubkey={currentUserNpub}` with `currentUserPubkey={user?.npub}` in `src/navigation/AppNavigator.tsx`.

## Risk
Low: one-line prop fix in existing screen wiring; no behavior changes outside Team route prop plumbing.

## Validation
- Static fault confirmed on latest `origin/main` in active navigator code path (`AppNavigator` is rendered from `App.tsx` for login/onboarding flows).
- Verified patched file no longer references undefined `currentUserNpub` and now uses runtime navigation data (`user?.npub`).
