### PR TITLE
fix(nostr): stop reconnect from re-enabling disabled keepalive

### DIFF
--- a/src/services/nostr/GlobalNDKService.ts
+++ b/src/services/nostr/GlobalNDKService.ts
@@ -544,14 +544,16 @@ export class GlobalNDKService {
 
       await this.instance.connect(2000);
 
-      // ✅ NEW: Re-setup monitoring and keepalive after reconnection
+      // ⚠️ Keepalive/monitoring remain intentionally disabled (see connectInBackground)
+      // to avoid timer/listener accumulation crash. Rely on NDK native reconnection.
       const status = this.getStatus();
       if (status.connectedRelays > 0) {
-        this.setupConnectionMonitoring();
-        this.startKeepalive();
+        console.log(
+          '✅ GlobalNDK: Reconnected successfully (keepalive/monitoring disabled)'
+        );
+      } else {
+        console.warn('⚠️ GlobalNDK: Reconnect completed but no relays connected');
       }
-
-      console.log('✅ GlobalNDK: Reconnected successfully');
     } catch (error) {
       console.error('❌ GlobalNDK: Reconnection failed:', error);
       throw error;


### PR DESCRIPTION
## Why
`GlobalNDKService.connectInBackground()` explicitly disables `setupConnectionMonitoring()` and `startKeepalive()` due a known 30-minute crash from timer/listener accumulation.

However, `GlobalNDKService.reconnect()` re-enabled both paths after each pull-to-refresh reconnect, reintroducing the same disabled crash path.

## What changed
- Removed reconnect-time calls to:
  - `this.setupConnectionMonitoring()`
  - `this.startKeepalive()`
- Kept reconnect behavior aligned with the existing policy: rely on NDK native reconnection while keepalive/monitoring remain disabled.
- Added explicit reconnect logging for connected/no-relay outcomes.

## Live code path evidence
- `ProfileScreen` pull-to-refresh calls `GlobalNDKService.reconnect()` (`src/screens/ProfileScreen.tsx`).
- So this bug is reachable in normal app flow by users manually refreshing profile data.

## Risk
Low: scoped to reconnect post-connect behavior; does not alter relay URLs, connect timeout, or error handling.

## Validation
- Static evidence on base:
  - `connectInBackground()` has keepalive/monitoring disabled with crash note
  - `reconnect()` previously re-enabled them
- Post-fix: reconnect no longer re-enables disabled keepalive/monitoring path.
