### PR TITLE
fix(navigation): route team actions to active Teams screen

### DIFF
--- a/src/navigation/BottomTabNavigator.tsx
+++ b/src/navigation/BottomTabNavigator.tsx
@@ -180,12 +180,8 @@ export const BottomTabNavigator: React.FC<BottomTabNavigatorProps> = ({
                     userIsCaptain: profileData.currentTeam.role === 'captain',
                   });
 
-                  navigation.navigate('EnhancedTeamScreen', {
-                    team,
-                    userIsMember: true,
-                    userIsCaptain: profileData.currentTeam.role === 'captain',
-                    currentUserNpub, // Pass npub to ensure proper competition loading
-                  });
+                  // EnhancedTeamScreen route was removed; navigate to active Teams route.
+                  navigation.navigate('Teams');
                 }
               }}
               onCaptainDashboard={() =>

--- a/src/navigation/navigationHandlers.ts
+++ b/src/navigation/navigationHandlers.ts
@@ -140,12 +140,9 @@ export const createNavigationHandlers = (): NavigationHandlers => {
               {
                 text: 'OK',
                 onPress: () => {
-                  // Navigate to team dashboard to show the joined team
-                  navigation.navigate('EnhancedTeamScreen', {
-                    team,
-                    userIsMember: true,
-                    currentUserNpub, // Pass the working npub to avoid component-level AsyncStorage corruption
-                  });
+                  // EnhancedTeamScreen route was removed from AppNavigator.
+                  // Route users to Teams so navigation succeeds in current app flow.
+                  navigation.navigate('Teams');
                 },
               },
             ]
@@ -271,12 +268,9 @@ export const createNavigationHandlers = (): NavigationHandlers => {
         finalUserIsMember: userIsMember,
       });
 
-      navigation.navigate('EnhancedTeamScreen', {
-        team,
-        userIsMember,
-        currentUserNpub, // Pass the working npub to avoid component-level AsyncStorage corruption
-        userIsCaptain, // Pass the correctly calculated captain status
-      });
+      // EnhancedTeamScreen route was removed from AppNavigator.
+      // Route users to Teams so navigation succeeds in current app flow.
+      navigation.navigate('Teams');
     },
 
     handleTeamDiscoveryClose: () => {

--- a/src/screens/CaptainDashboardScreen.tsx
+++ b/src/screens/CaptainDashboardScreen.tsx
@@ -725,20 +725,8 @@ export const CaptainDashboardScreen: React.FC<CaptainDashboardScreenProps> = ({
                     updatedBannerUrl || 'none'
                   );
 
-                  navigation.navigate('EnhancedTeamScreen', {
-                    team: {
-                      ...currentTeamData,
-                      name: editedTeamName.trim(),
-                      description: editedTeamDescription.trim(),
-                      location: editedTeamLocation.trim(),
-                      bannerImage: updatedBannerUrl,
-                      // Include nostrEvent for fallback banner extraction
-                      nostrEvent: currentTeamData.nostrEvent,
-                    },
-                    userIsMember: true,
-                    userIsCaptain: true,
-                    currentUserNpub: userNpub,
-                  });
+                  // EnhancedTeamScreen route was removed; navigate to active Teams route.
+                  navigation.navigate('Teams');
                 }
               },
             },

--- a/src/screens/MyTeamsScreen.tsx
+++ b/src/screens/MyTeamsScreen.tsx
@@ -130,13 +130,8 @@ export const MyTeamsScreen: React.FC = () => {
       userIsCaptain: isCaptain,
     });
 
-    // Navigate to EnhancedTeamScreen with team data and captain status
-    navigation.navigate('EnhancedTeamScreen', {
-      team,
-      userIsMember: true,
-      currentUserNpub: userNpub,
-      userIsCaptain: isCaptain, // Pass captain status for captain dashboard access
-    });
+    // EnhancedTeamScreen route was removed; navigate to active Teams route.
+    navigation.navigate('Teams');
 
     console.log(
       '[MyTeamsScreen] 📍 AFTER navigation.navigate call - this should not print if frozen'


### PR DESCRIPTION
## Summary
This fixes runtime navigation failures caused by calls to a removed route ().

## What changed
- Replaced  with  in active app flows:
  - 
  - 
  - 
  - 

## Why
 explicitly removed the  route, but several live user paths still navigate to it, causing navigation failures.

## Risk
Low: route target changed to an existing active screen only; no data model or business logic changes.

## Validation
- Confirmed  has no  screen registration.
- Confirmed all  call sites were removed from .
