### PR TITLE
fix(security): enforce HTTPS LNURL callback URLs

### DIFF
--- a/src/utils/lnurl.ts
+++ b/src/utils/lnurl.ts
@@ -24,6 +24,22 @@ export interface InvoiceResponse {
   };
 }
 
+function ensureHttpsUrl(urlString: string, fieldName: string): URL {
+  let parsed: URL;
+
+  try {
+    parsed = new URL(urlString);
+  } catch {
+    throw new Error(`Invalid ${fieldName} URL`);
+  }
+
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`${fieldName} must use HTTPS`);
+  }
+
+  return parsed;
+}
+
 /**
  * Fetch LNURL-pay details from Lightning address
  *
@@ -79,6 +95,9 @@ export async function fetchLNURLPayDetails(
       throw new Error('Invalid LNURL response: missing required fields');
     }
 
+    // Security: LNURL callback must use HTTPS
+    ensureHttpsUrl(data.callback, 'LNURL callback');
+
     console.log('[LNURL] ✅ Details fetched successfully');
 
     return data as LNURLPayDetails;
@@ -119,7 +138,7 @@ export async function requestInvoiceFromLNURL(
   zapRequest?: string
 ): Promise<InvoiceResponse> {
   // Build callback URL with amount parameter
-  const url = new URL(callbackUrl);
+  const url = ensureHttpsUrl(callbackUrl, 'LNURL callback');
   url.searchParams.set('amount', amountMillisats.toString());
 
   if (comment) {


### PR DESCRIPTION
## Summary
- add strict HTTPS validation for LNURL callback URLs before invoice requests
- reject invalid/non-HTTPS callback URLs returned by LNURL pay endpoints

## Why
Security analysis identified that `requestInvoiceFromLNURL` accepted callback URLs without scheme validation. A malicious or compromised LNURL endpoint could return an `http://` callback and expose zap request payloads over plaintext transport.

## What changed
- `src/utils/lnurl.ts`
  - Added `ensureHttpsUrl(urlString, fieldName)` helper
  - Validate `data.callback` in `fetchLNURLPayDetails`
  - Validate `callbackUrl` in `requestInvoiceFromLNURL` before request construction

## Live code path evidence
`getInvoiceFromLightningAddress()` is used in active user flows including:
- `src/components/team/CharitySection.tsx`
- `src/screens/TeamsScreen.tsx`
- `src/components/wallet/CoinOSWalletModal.tsx`

## Risk
Low: rejects insecure/malformed callback URLs only; no changes to normal HTTPS LNURL providers.

## Gate checks
- LIVE_CODE_GATE: pass
- REPRO_GATE: pass (exact static fault in `src/utils/lnurl.ts`)
- STALE_BASE_GATE: pass (`origin/main` had `new URL(callbackUrl)` with no HTTPS validation)
- IMPACT_GATE: pass (security hardening, protects payment/zap transport)
- PROOF_GATE: pass (reproduced + validated evidence recorded)
