### PR TITLE
fix(perf): memoize TeamsScreen static charity derivations

### DIFF
--- a/src/screens/TeamsScreen.tsx
+++ b/src/screens/TeamsScreen.tsx
@@ -5,7 +5,7 @@
  * Features Lightning zap buttons for donations (tap = QR modal, long-press = quick NWC zap)
  */
 
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef, useMemo } from 'react';
 import {
   View,
   Text,
@@ -461,14 +461,16 @@ const TeamsScreenComponent: React.FC = () => {
     setZapTargetCharity(null);
   };
 
-  // Find selected team object
-  const selectedTeam = selectedTeamId
-    ? CHARITIES.find((c) => c.id === selectedTeamId)
-    : null;
+  // Find selected team object (memoized to avoid repeated linear scans)
+  const selectedTeam = useMemo(
+    () => (selectedTeamId ? CHARITIES.find((c) => c.id === selectedTeamId) : null),
+    [selectedTeamId]
+  );
 
-  // Sort teams alphabetically by name
-  const sortedCharities = [...CHARITIES].sort((a, b) =>
-    a.name.localeCompare(b.name)
+  // Sort teams alphabetically by name once (CHARITIES is static)
+  const sortedCharities = useMemo(
+    () => [...CHARITIES].sort((a, b) => a.name.localeCompare(b.name)),
+    []
   );
 
   return (


### PR DESCRIPTION
## Summary
This PR removes avoidable render-time work in `TeamsScreen` by memoizing static/derived charity data.

### Changes
- add `useMemo` import in `src/screens/TeamsScreen.tsx`
- memoize `selectedTeam` lookup (depends on `selectedTeamId`)
- memoize alphabetical `sortedCharities` array once (static `CHARITIES` source)

## Why
The previous implementation re-ran `CHARITIES.find(...)` and `[...CHARITIES].sort(...)` on every render. `TeamsScreen` has multiple state updates (refreshing, zap flow, modal state), so these derived values were recomputed frequently without benefit.

## Impact
- **Class:** perf (user-facing smoothness / lower JS work)
- **Risk:** low (pure render derivation; no behavior changes)

## Hard-gate evidence
- **LIVE_CODE_GATE:** `TeamsScreen` is part of active app routes in `App.tsx`, `AppNavigator.tsx`, and `BottomTabNavigator.tsx`.
- **REPRO_GATE:** Static evidence on base showed un-memoized derivations at `src/screens/TeamsScreen.tsx` around lines 465-472.
- **STALE_BASE_GATE:** `origin/main` still had `const sortedCharities = [...CHARITIES].sort(...)` and no `useMemo` usage in this file.
- **FIX_VALIDATED:** Post-change file now uses `useMemo` for both `selectedTeam` and `sortedCharities`.
