### PR TITLE
fix(perf): remove NavigationData render-path debug logs

### DIFF
--- a/src/contexts/NavigationDataContext.tsx
+++ b/src/contexts/NavigationDataContext.tsx
@@ -64,7 +64,6 @@ interface NavigationDataProviderProps {
 export const NavigationDataProvider: React.FC<NavigationDataProviderProps> = ({
   children,
 }) => {
-  console.log('🚀 NavigationDataProvider: Initializing...');
   const { currentUser } = useAuth();
   const [user, setUser] = useState<UserWithWallet | null>(null);
   const [teamData, setTeamData] = useState<TeamScreenData | null>(null);
@@ -941,11 +940,5 @@ export const useNavigationData = (): NavigationData => {
       'useNavigationData must be used within a NavigationDataProvider'
     );
   }
-  console.log(
-    '✅ useNavigationData: Context found, isLoading:',
-    context.isLoading,
-    'profileData:',
-    !!context.profileData
-  );
   return context;
 };


### PR DESCRIPTION
## Summary
Removes two debug console.log calls that were executing in hot render paths:
- NavigationDataProvider component body (runs on every provider render)
- useNavigationData() hook success path (runs whenever any consumer calls the hook)

## Why
These logs were identified in the analysis as hot-path console noise with measurable render overhead and log spam on active screens (tabs, events, teams, profile).

## Scope
- src/contexts/NavigationDataContext.tsx

## Validation
- Verified the provider is mounted in active app flow (App.tsx) and hook is consumed by active screens/navigation.
- Verified only render-path debug logs were removed; error logging for invalid provider usage remains intact.

## Risk
Low. No behavior change beyond removing debug output in production/runtime paths.