### PR TITLE
fix(health): retry unsent Health sync workouts instead of dropping them

### DIFF
--- a/src/services/fitness/healthConnectService.ts
+++ b/src/services/fitness/healthConnectService.ts
@@ -761,18 +761,6 @@ export class HealthConnectService {
     try {
       const cacheKey = 'healthconnect_workouts_cache';
 
-      // Identify new workouts by comparing with previous cache
-      const previousCache = await AsyncStorage.getItem(cacheKey);
-      const previousIds = new Set<string>();
-      if (previousCache) {
-        try {
-          const parsed = JSON.parse(previousCache);
-          (parsed.workouts || []).forEach((w: HealthConnectWorkout) => {
-            previousIds.add(w.id || '');
-          });
-        } catch { /* ignore parse errors */ }
-      }
-
       const cacheData = {
         workouts,
         timestamp: Date.now(),
@@ -784,7 +772,7 @@ export class HealthConnectService {
       debugLog(`Health Connect: Cached ${workouts.length} workouts`);
 
       // Auto-submit new cardio workouts to Supabase (fire-and-forget)
-      this.submitNewWorkoutsToSupabase(workouts, previousIds).catch((err) => {
+      this.submitNewWorkoutsToSupabase(workouts).catch((err) => {
         console.warn('[HealthConnect] Supabase auto-submit error (silent):', err);
       });
     } catch (error) {
@@ -796,8 +784,7 @@ export class HealthConnectService {
    * Submit newly discovered cardio workouts to Supabase for leaderboard tracking.
    */
   private async submitNewWorkoutsToSupabase(
-    workouts: HealthConnectWorkout[],
-    previousIds: Set<string>
+    workouts: HealthConnectWorkout[]
   ): Promise<void> {
     const CARDIO_TYPES = ['running', 'walking', 'cycling', 'hiking'];
     const npub = await AsyncStorage.getItem('@runstr:npub');
@@ -806,7 +793,10 @@ export class HealthConnectService {
     const submittedIds = await this.getSubmittedIds();
 
     const newCardio = workouts.filter((w) => {
-      if (!w.id || previousIds.has(w.id) || submittedIds.has(w.id)) return false;
+      // Only suppress workouts that are already confirmed submitted.
+      // Do NOT suppress by previous cache presence: if a prior submit failed,
+      // the workout can exist in cache but still needs retry.
+      if (!w.id || submittedIds.has(w.id)) return false;
       if (!w.activityType || !CARDIO_TYPES.includes(w.activityType)) return false;
       if (!w.totalDistance || w.totalDistance <= 0) return false;
       return true;

--- a/src/services/fitness/healthKitService.ts
+++ b/src/services/fitness/healthKitService.ts
@@ -977,18 +977,6 @@ export class HealthKitService {
     try {
       const cacheKey = 'healthkit_workouts_cache';
 
-      // Identify new workouts by comparing with previous cache
-      const previousCache = await AsyncStorage.getItem(cacheKey);
-      const previousIds = new Set<string>();
-      if (previousCache) {
-        try {
-          const parsed = JSON.parse(previousCache);
-          (parsed.workouts || []).forEach((w: HealthKitWorkout) => {
-            previousIds.add(w.UUID || w.id || '');
-          });
-        } catch { /* ignore parse errors */ }
-      }
-
       const cacheData = {
         workouts,
         timestamp: Date.now(),
@@ -999,7 +987,7 @@ export class HealthKitService {
       debugLog(`HealthKit: Cached ${workouts.length} workouts`);
 
       // Auto-submit new cardio workouts to Supabase (fire-and-forget)
-      this.submitNewWorkoutsToSupabase(workouts, previousIds).catch((err) => {
+      this.submitNewWorkoutsToSupabase(workouts).catch((err) => {
         console.warn('[HealthKit] Supabase auto-submit error (silent):', err);
       });
     } catch (error) {
@@ -1011,8 +999,7 @@ export class HealthKitService {
    * Submit newly discovered cardio workouts to Supabase for leaderboard tracking.
    */
   private async submitNewWorkoutsToSupabase(
-    workouts: HealthKitWorkout[],
-    previousIds: Set<string>
+    workouts: HealthKitWorkout[]
   ): Promise<void> {
     const CARDIO_TYPES = ['running', 'walking', 'cycling', 'hiking'];
     const npub = await AsyncStorage.getItem('@runstr:npub');
@@ -1024,7 +1011,11 @@ export class HealthKitService {
 
     const newCardio = workouts.filter((w) => {
       const id = w.UUID || w.id || '';
-      if (!id || previousIds.has(id) || submittedIds.has(id)) return false;
+
+      // Only suppress workouts that are already confirmed submitted.
+      // Do NOT suppress by previous cache presence: if a prior submit failed,
+      // the workout can exist in cache but still needs retry.
+      if (!id || submittedIds.has(id)) return false;
       if (!w.activityType || !CARDIO_TYPES.includes(w.activityType)) return false;
       if (!w.totalDistance || w.totalDistance <= 0) return false;
       return true;


### PR DESCRIPTION
## Summary
Fixes a data-integrity bug in HealthKit/Health Connect auto-submit flow where failed Supabase submissions were silently dropped forever.

## Root cause
Both services filtered candidate workouts by `previousIds` (workouts already present in local cache) **and** `submittedIds` (workouts confirmed in Supabase).

Because cache write happens before async submit completes, a transient submit failure leaves a workout in cache but not in `submittedIds`. On the next sync it was excluded by `previousIds`, so it was never retried.

## Changes
- `src/services/fitness/healthKitService.ts`
- `src/services/fitness/healthConnectService.ts`

In both services:
- remove `previousIds`-based suppression logic
- only suppress workouts already present in `submittedIds`
- simplify `submitNewWorkoutsToSupabase(...)` signature accordingly

This preserves dedup (via `submittedIds`) while allowing retry of previously failed submissions.

## Validation
- Static repro evidence on `origin/main`:
  - `healthKitService.ts` filtered out `previousIds` at line ~1027
  - `healthConnectService.ts` filtered out `previousIds` at line ~809
- Post-fix behavior: failed-but-cached workouts remain eligible until confirmed submitted and written to `submittedIds`.
- `npx eslint src/services/fitness/healthKitService.ts src/services/fitness/healthConnectService.ts` passes with warnings only (no errors).

## Risk
Low: targeted filter logic change in two services; existing dedup key (`submittedIds`) remains unchanged.
