### PR TITLE
fix(cache): prevent cross-cache AsyncStorage deletion collisions

### DIFF
--- a/src/services/cache/UnifiedNostrCache.ts
+++ b/src/services/cache/UnifiedNostrCache.ts
@@ -50,7 +50,7 @@ interface CacheOptions {
 // Subscriber callback type
 type SubscriberCallback<T = any> = (data: T) => void;
 
-const STORAGE_PREFIX = '@runstr:unified_cache:';
+const STORAGE_PREFIX = '@runstr:unified_nostr_cache:';
 
 /**
  * UnifiedNostrCache - Centralized cache for all Nostr data


### PR DESCRIPTION
## Summary
- change `UnifiedNostrCache` AsyncStorage prefix from `@runstr:unified_cache:` to `@runstr:unified_nostr_cache:`
- prevent `UnifiedNostrCache.clear()` and `UnifiedCacheService.clearAll()` from deleting each other's persisted entries

## Why
Both cache systems previously shared the same prefix, so a clear operation in one subsystem could wipe data owned by the other.

## Evidence
- `src/services/cache/UnifiedCacheService.ts:44` uses `@runstr:unified_cache:`
- `src/services/cache/UnifiedNostrCache.ts:53` previously used the same prefix
- both systems enumerate/remove all AsyncStorage keys by prefix in their clear paths

## Risk
Low. Scoped to storage namespace separation in one cache service.
