### PR TITLE
fix(activity): prevent run-session data loss on pause/stop failures

### DIFF
--- a/src/screens/activity/RunningTrackerScreen.tsx
+++ b/src/screens/activity/RunningTrackerScreen.tsx
@@ -619,15 +619,35 @@ export const RunningTrackerScreen: React.FC<RunningTrackerScreenProps> = ({
 
   const pauseTracking = async () => {
     if (!isPaused) {
-      await simpleRunTracker.pauseTracking();
-      setIsPaused(true);
+      try {
+        await simpleRunTracker.pauseTracking();
+        setIsPaused(true);
+      } catch (error) {
+        console.error('[RunningTrackerScreen] Failed to pause tracking:', error);
+        setAlertConfig({
+          title: 'Pause Failed',
+          message: 'Could not pause tracking. Please try again.',
+          buttons: [{ text: 'OK', style: 'default' }],
+        });
+        setAlertVisible(true);
+      }
     }
   };
 
   const resumeTracking = async () => {
     if (isPaused) {
-      await simpleRunTracker.resumeTracking();
-      setIsPaused(false);
+      try {
+        await simpleRunTracker.resumeTracking();
+        setIsPaused(false);
+      } catch (error) {
+        console.error('[RunningTrackerScreen] Failed to resume tracking:', error);
+        setAlertConfig({
+          title: 'Resume Failed',
+          message: 'Could not resume tracking. Please try again.',
+          buttons: [{ text: 'OK', style: 'default' }],
+        });
+        setAlertVisible(true);
+      }
     }
   };
 
@@ -638,27 +658,39 @@ export const RunningTrackerScreen: React.FC<RunningTrackerScreenProps> = ({
       metricsUpdateRef.current = null;
     }
 
-    const session = await simpleRunTracker.stopTracking();
-    setIsTracking(false);
-    setIsPaused(false);
+    try {
+      const session = await simpleRunTracker.stopTracking();
+      setIsTracking(false);
+      setIsPaused(false);
 
-    if (
-      session &&
-      session.distance !== undefined &&
-      session.distance > MIN_WORKOUT_DISTANCE_METERS
-    ) {
-      // Only show summary if moved at least 10 meters
-      showWorkoutSummary(session as RunSession);
-    } else {
-      // Reset metrics
-      setMetrics({
-        distance: '0.00 km',
-        duration: '0:00',
-        pace: '--:--',
-        elevation: '0 m',
+      if (
+        session &&
+        session.distance !== undefined &&
+        session.distance > MIN_WORKOUT_DISTANCE_METERS
+      ) {
+        // Only show summary if moved at least 10 meters
+        showWorkoutSummary(session as RunSession);
+      } else {
+        // Reset metrics
+        setMetrics({
+          distance: '0.00 km',
+          duration: '0:00',
+          pace: '--:--',
+          elevation: '0 m',
+        });
+        setElapsedTime(0);
+        setSelectedRoute(null); // Clear selected route
+      }
+    } catch (error) {
+      console.error('[RunningTrackerScreen] Failed to stop tracking:', error);
+      setAlertConfig({
+        title: 'Stop Failed',
+        message: 'Could not stop tracking safely. Your run is still active.',
+        buttons: [{ text: 'OK', style: 'default' }],
       });
-      setElapsedTime(0);
-      setSelectedRoute(null); // Clear selected route
+      setAlertVisible(true);
+      // Ensure UI remains in active state when stop fails
+      setIsTracking(true);
     }
   };
 


### PR DESCRIPTION
## Summary
- add try/catch around pause, resume, and stop actions in `RunningTrackerScreen`
- show user-facing alerts when tracker operations fail
- keep run UI in active state if stop fails to avoid false-complete/data-loss flow

## Why
Latest health analysis flagged missing error handling in running pause/stop paths. If tracker operations throw, users can be left with inconsistent state and may lose confidence in workout persistence.

## Validation
- static evidence (latest main): `src/screens/activity/RunningTrackerScreen.tsx` pause/resume/stop handlers had direct awaits without try/catch
- live code path evidence:
  - `src/navigation/AppNavigator.tsx` routes `Exercise` to `ActivityTrackerScreen`
  - `src/screens/activity/ActivityTrackerScreen.tsx` renders `RunningTrackerScreen` for running mode
- `npm run typecheck` run: fails due large pre-existing repo-wide TS issues unrelated to this focused change

## Risk
Low. Single-file, error-path-only handling in an actively used tracking screen.
