### PR TITLE
fix(design): correct PrimaryButton tokening comment

### DIFF
--- a/src/components/ui/PrimaryButton.tsx
+++ b/src/components/ui/PrimaryButton.tsx
@@ -1,5 +1,5 @@
 /**
- * PrimaryButton - Reusable orange button with white text
+ * PrimaryButton - Reusable orange button using theme-tokenized accent text
  * Consistent styling across the app for primary actions
  */
 


### PR DESCRIPTION
## Summary
Align the `PrimaryButton` header comment with current token usage (`theme.colors.accentText`) so the documented contract matches implementation.

## Why
Design lane H03 flagged a stale contract comment in `src/components/ui/PrimaryButton.tsx` claiming white button text, while the component uses `accentText`.

## Scope
- 1 file changed
- 1 line changed
- Documentation-only (no runtime behavior changes)

## PR Lane Metadata
- Agent Owner: Pixel
- Lane + Finding ID: H03 / H03-DESIGN-F003
- Confidence Tier: Quick review
- Handoffs Consumed: None
- Regression Context: No merged commits in last 7 days touching `src/components/ui/PrimaryButton.tsx`

## Gates
- LIVE_CODE: PASS
- REPRO: PASS
- STALE_BASE: PASS (branched from `origin/main` @ `404d726`)
- IMPACT: PASS (removes misleading design guidance)
- PROOF: PASS (proof JSON written)
- REGRESSION: PASS (no 7-day overlap on same file)
- DEPENDENCY-AWARENESS: PASS (no package/lockfile changes)

## Validation
- Manual diff verification passed (comment-only change).
- `npm run typecheck` executed in repo and currently fails due pre-existing baseline TypeScript errors unrelated to this PR.
