### PR TITLE
perf: bound reward payment history queries (H05)

### DIFF
--- a/src/services/rewards/SupabaseRewardService.ts
+++ b/src/services/rewards/SupabaseRewardService.ts
@@ -19,6 +19,9 @@ import { getCharityByLightningAddress } from '../../constants/charities';
 // Geyser Fund charity IDs (payments to these may be pending)
 const GEYSER_CHARITY_IDS = ['ashigaru', 'bitcoin-yucatan', 'buho-go', 'wesatoshi'];
 
+// Bound history queries to avoid unbounded payloads on high-activity accounts
+const MAX_PAYMENT_HISTORY_ROWS = 200;
+
 export interface PaymentRecord {
   id: string;
   npub: string;
@@ -68,7 +71,8 @@ class SupabaseRewardServiceClass {
         .from('reward_payments')
         .select('*')
         .eq('npub', npub)
-        .order('paid_at', { ascending: false });
+        .order('paid_at', { ascending: false })
+        .limit(MAX_PAYMENT_HISTORY_ROWS);
 
       if (error) {
         console.error('[SupabaseRewardService] Error fetching payment history:', error);
@@ -247,7 +251,8 @@ class SupabaseRewardServiceClass {
         .eq('npub', npub)
         .eq('status', 'success')
         .gt('paid_at', sinceTimestamp)
-        .order('paid_at', { ascending: false });
+        .order('paid_at', { ascending: false })
+        .limit(MAX_PAYMENT_HISTORY_ROWS);
 
       if (error) {
         console.error('[SupabaseRewardService] Error fetching new payments:', error);


### PR DESCRIPTION
## Summary
Bound high-traffic reward payment history queries to a fixed row cap to prevent unbounded Supabase payloads for high-activity users.

## Why this fix
From perf lane H05 findings (query/network inefficiencies persistent), `SupabaseRewardService` had two user-history queries ordered by `paid_at` with no upper bound. This can increase response size and render latency over time for active accounts.

## Change
- Added `MAX_PAYMENT_HISTORY_ROWS = 200`
- Applied `.limit(MAX_PAYMENT_HISTORY_ROWS)` to:
  - `getPaymentHistory`
  - `getNewPaymentsSince`

## Gates
- LIVE_CODE: ✅ `src/services/rewards/SupabaseRewardService.ts` (production service)
- REPRO: ✅ Unbounded `.select('*').order(...)` detected in both methods before fix
- STALE_BASE: ✅ branched from `origin/main` after fresh fetch on 2026-03-07
- IMPACT: ✅ caps per-request row volume; lowers network payload + client processing cost
- PROOF: ✅ diff + branch + PR + run proof JSON
- REGRESSION (7d merged overlap): ✅ none found touching this file
- DEPENDENCY-AWARENESS (same-day overlap): ✅ no same-day open PR overlap on this file

## Validation
- `npm run typecheck` ❌ fails on existing unrelated baseline TypeScript errors across many files (not introduced by this change)

## Required Metadata
- Agent Owner: Turbo
- Lane + Finding ID: H05 / H05-PERF-QUERY-BOUNDS-01
- Confidence Tier: Quick review
- Handoffs Consumed: none
- Regression Context: none suspected
