### PR TITLE
security: mitigate lodash prototype pollution exposure (H07)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14991,7 +14991,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -20990,12 +20989,6 @@
         "lodash": "4.17.3",
         "serialize-error": "2.1.0"
       }
-    },
-    "node_modules/webview-crypto/node_modules/lodash": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.3.tgz",
-      "integrity": "sha512-H+sg4+uBLOBrw9833P6gCURJjV+puWPbxM8S3H4ORlhVCmQpF5yCE50bc4Exaqm9U5Nhjw83Okq1azyb1U7mxw==",
-      "license": "MIT"
     },
     "node_modules/whatwg-encoding": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -134,5 +134,8 @@
     "typescript": "~5.8.3",
     "ws": "^8.18.3"
   },
-  "private": true
+  "private": true,
+  "overrides": {
+    "lodash": "4.17.21"
+  }
 }


### PR DESCRIPTION
## Summary
Patch the H07 security-lane lodash finding by forcing lodash@4.17.21 across the dependency tree so webview-crypto no longer installs lodash@4.17.3.

## Required Metadata
- Agent Owner: Vault
- Lane + Finding ID: H07 / SEC-NEW-002 (lodash prototype pollution exposure)
- Confidence Tier: Quick review
- Handoffs Consumed: none
- Regression Context: No merged PR overlap on package.json / package-lock.json in last 7 days detected from origin/main merge history.

## Gates
- LIVE_CODE: ✅ real dependency graph changed in repo lockfile + manifest
- REPRO: ✅ npm audit --omit=dev showed critical lodash via webview-crypto before; now critical count is 0
- STALE_BASE: ✅ branch cut from origin/main (2026-03-07)
- IMPACT: ✅ removes known critical lodash line from installed tree (webview-crypto now resolves to 4.17.21)
- PROOF: ✅ proof JSON written by lane runner
- REGRESSION (7d merged overlap): ✅ none found for touched files
- DEPENDENCY-AWARENESS (same-day overlap): ✅ checked open same-day PRs (#72, #73, #74), no file overlap

## Validation Evidence
- npm ls lodash --depth=4
  - before: webview-crypto -> lodash@4.17.3
  - after: webview-crypto -> lodash@4.17.21
- npm audit --json --omit=dev
  - before: critical: 1
  - after: critical: 0
- npm run typecheck
  - fails due to large pre-existing baseline type errors unrelated to this PR (no new TS files touched).

## Risk
Low-to-moderate: dependency resolution override only (2 files), no runtime app code edited.
