### PR TITLE
fix(health): serialize HealthKit auto-submit to prevent duplicate runs

### DIFF
--- a/src/services/fitness/healthKitService.ts
+++ b/src/services/fitness/healthKitService.ts
@@ -186,6 +186,7 @@ export class HealthKitService {
   private readonly PERMISSION_TIMEOUT = 30000; // 30 seconds for permissions (increased for careful users)
   private abortController: AbortController | null = null;
   private isModuleAvailable: boolean = false;
+  private autoSubmitInProgress = false;
 
   private constructor() {
     this.initializeModule();
@@ -1014,52 +1015,63 @@ export class HealthKitService {
     workouts: HealthKitWorkout[],
     previousIds: Set<string>
   ): Promise<void> {
-    const CARDIO_TYPES = ['running', 'walking', 'cycling', 'hiking'];
-    const npub = await AsyncStorage.getItem('@runstr:npub');
-    if (!npub) return;
-
-    // Include Lightning address in tags so Supabase trigger can auto-reward
-    const lightningAddress = await AsyncStorage.getItem('@runstr:lightning_address');
-    const submittedIds = await this.getSubmittedIds();
-
-    const newCardio = workouts.filter((w) => {
-      const id = w.UUID || w.id || '';
-      if (!id || previousIds.has(id) || submittedIds.has(id)) return false;
-      if (!w.activityType || !CARDIO_TYPES.includes(w.activityType)) return false;
-      if (!w.totalDistance || w.totalDistance <= 0) return false;
-      return true;
-    });
-
-    for (const w of newCardio) {
-      try {
-        const workoutId = w.UUID || w.id || '';
-        const eventId = `hk_${workoutId}`;
-        const tags: string[][] = [];
-        if (lightningAddress) {
-          tags.push(['lightning', lightningAddress]);
-        }
-
-        await SupabaseCompetitionService.submitWorkoutSimple({
-          eventId,
-          npub,
-          type: w.activityType || 'running',
-          distance: w.totalDistance,
-          duration: w.duration,
-          calories: w.totalEnergyBurned,
-          startTime: w.startDate,
-          tags,
-        });
-
-        if (workoutId) {
-          submittedIds.add(workoutId);
-        }
-        debugLog(`[HealthKit] Auto-submitted ${w.activityType} workout to Supabase: ${eventId}`);
-      } catch (err) {
-        console.warn(`[HealthKit] Failed to submit workout ${w.UUID}:`, err);
-      }
+    if (this.autoSubmitInProgress) {
+      debugLog('[HealthKit] Auto-submit already in progress, skipping duplicate run');
+      return;
     }
 
-    await this.saveSubmittedIds(submittedIds);
+    this.autoSubmitInProgress = true;
+
+    try {
+      const CARDIO_TYPES = ['running', 'walking', 'cycling', 'hiking'];
+      const npub = await AsyncStorage.getItem('@runstr:npub');
+      if (!npub) return;
+
+      // Include Lightning address in tags so Supabase trigger can auto-reward
+      const lightningAddress = await AsyncStorage.getItem('@runstr:lightning_address');
+      const submittedIds = await this.getSubmittedIds();
+
+      const newCardio = workouts.filter((w) => {
+        const id = w.UUID || w.id || '';
+        if (!id || previousIds.has(id) || submittedIds.has(id)) return false;
+        if (!w.activityType || !CARDIO_TYPES.includes(w.activityType)) return false;
+        if (!w.totalDistance || w.totalDistance <= 0) return false;
+        return true;
+      });
+
+      for (const w of newCardio) {
+        try {
+          const workoutId = w.UUID || w.id || '';
+          const eventId = `hk_${workoutId}`;
+          const tags: string[][] = [];
+          if (lightningAddress) {
+            tags.push(['lightning', lightningAddress]);
+          }
+
+          await SupabaseCompetitionService.submitWorkoutSimple({
+            eventId,
+            npub,
+            type: w.activityType || 'running',
+            distance: w.totalDistance,
+            duration: w.duration,
+            calories: w.totalEnergyBurned,
+            startTime: w.startDate,
+            tags,
+          });
+
+          if (workoutId) {
+            submittedIds.add(workoutId);
+          }
+          debugLog(`[HealthKit] Auto-submitted ${w.activityType} workout to Supabase: ${eventId}`);
+        } catch (err) {
+          console.warn(`[HealthKit] Failed to submit workout ${w.UUID}:`, err);
+        }
+      }
+
+      await this.saveSubmittedIds(submittedIds);
+    } finally {
+      this.autoSubmitInProgress = false;
+    }
   }
 
   private async getSubmittedIds(): Promise<Set<string>> {


### PR DESCRIPTION
## Summary
Fixes a concurrency hole in HealthKit auto-submit that could trigger duplicate submission runs when sync/caching paths overlap in time.

## Audit linkage
- Lane: H09 (/health)
- Finding ID: **H09-NEW-001**
- Source: 2026-03-07 health diff/new critical signal (duplicate HealthKit submissions)

## What changed
- Added `autoSubmitInProgress` guard in `HealthKitService`.
- Early-return if a submit pass is already running.
- Wrapped submit pipeline in `try/finally` to always release the lock.

## Required metadata
- Agent Owner: **Pulse**
- Confidence Tier: **Quick review**
- Handoffs Consumed: **None**

## Gates
- LIVE_CODE: ✅ Single live-code change in `src/services/fitness/healthKitService.ts`
- REPRO: ✅ Duplicate-run scenario addressed by explicit in-process lock around auto-submit pipeline
- STALE_BASE: ✅ Branched from latest `origin/main` before change
- IMPACT: ✅ Reduces risk of duplicate HealthKit submissions and leaderboard double-counting
- PROOF: ✅ Diff + commit + branch + this PR + proof JSON artifact
- REGRESSION (7-day merged overlap): ✅ No merged PR in last 7 days touched `src/services/fitness/healthKitService.ts`
- DEPENDENCY-AWARENESS (same-day branch/file overlap): ✅ Checked today’s open PRs (#72–#75), no overlap on target file

## Validation
- `npm run -s typecheck` ❌ fails due to broad pre-existing repo-wide TypeScript errors unrelated to this file.
- No dependency changes.
- No file deletions.
- `src/config/canary.ts` untouched.

## Risk
Low-to-moderate: lock is scoped to one service instance and only wraps existing submit flow.
