### PR TITLE
refactor(health): centralize submitted ID persistence helpers (H11)

### DIFF
--- a/src/services/fitness/HealthKitBackgroundService.ts
+++ b/src/services/fitness/HealthKitBackgroundService.ts
@@ -9,6 +9,7 @@
 import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { EventSubscription } from 'expo-modules-core';
+import { SubmittedIdStore } from '../../utils/SubmittedIdStore';
 
 // Only import HealthKit APIs on iOS
 let enableBackgroundDelivery: any;
@@ -32,8 +33,10 @@ if (Platform.OS === 'ios') {
   }
 }
 
-const SUBMITTED_IDS_KEY = '@healthkit_bg:submitted_ids';
-const MAX_STORED_IDS = 500;
+const submittedIdStore = new SubmittedIdStore({
+  storageKey: '@healthkit_bg:submitted_ids',
+  maxIds: 500,
+});
 
 export class HealthKitBackgroundService {
   private static instance: HealthKitBackgroundService;
@@ -109,7 +112,7 @@ export class HealthKitBackgroundService {
       }
 
       // Load previously submitted IDs for dedup
-      const submittedIds = await this.getSubmittedIds();
+      const submittedIds = await submittedIdStore.get();
       const CARDIO_TYPES = ['running', 'walking', 'cycling', 'hiking'];
 
       const newWorkouts = recentWorkouts.filter((w) => {
@@ -158,32 +161,13 @@ export class HealthKitBackgroundService {
       }
 
       // Persist updated submitted IDs
-      await this.saveSubmittedIds(submittedIds);
+      try {
+        await submittedIdStore.save(submittedIds);
+      } catch (error) {
+        console.warn('[HKBackground] Failed to save submitted IDs:', error);
+      }
     } catch (error) {
       console.error('[HKBackground] handleWorkoutUpdate error:', error);
-    }
-  }
-
-  /** Load previously submitted workout IDs from AsyncStorage */
-  private async getSubmittedIds(): Promise<Set<string>> {
-    try {
-      const raw = await AsyncStorage.getItem(SUBMITTED_IDS_KEY);
-      if (!raw) return new Set();
-      return new Set(JSON.parse(raw));
-    } catch {
-      return new Set();
-    }
-  }
-
-  /** Persist submitted workout IDs, capping at MAX_STORED_IDS */
-  private async saveSubmittedIds(ids: Set<string>): Promise<void> {
-    try {
-      const arr = Array.from(ids);
-      // Keep only the most recent IDs to avoid unbounded storage growth
-      const trimmed = arr.slice(-MAX_STORED_IDS);
-      await AsyncStorage.setItem(SUBMITTED_IDS_KEY, JSON.stringify(trimmed));
-    } catch (error) {
-      console.warn('[HKBackground] Failed to save submitted IDs:', error);
     }
   }
 

--- a/src/services/fitness/healthConnectService.ts
+++ b/src/services/fitness/healthConnectService.ts
@@ -8,6 +8,7 @@ import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { WorkoutData, WorkoutType } from '../../types/workout';
 import { inferActivityTypeSimple } from '../../utils/activityInference';
+import { SubmittedIdStore } from '../../utils/SubmittedIdStore';
 import { SupabaseCompetitionService } from '../backend/SupabaseCompetitionService';
 
 // Environment-based logging utility
@@ -21,8 +22,10 @@ const errorLog = (message: string, ...args: any[]) => {
   console.error(message, ...args);
 };
 
-const SUBMITTED_IDS_KEY = '@healthconnect:submitted_workout_ids';
-const MAX_SUBMITTED_IDS = 500;
+const submittedIdStore = new SubmittedIdStore({
+  storageKey: '@healthconnect:submitted_workout_ids',
+  maxIds: 500,
+});
 
 // Import react-native-health-connect for Android only
 let HealthConnect: any = null;
@@ -803,7 +806,7 @@ export class HealthConnectService {
     const npub = await AsyncStorage.getItem('@runstr:npub');
     if (!npub) return;
 
-    const submittedIds = await this.getSubmittedIds();
+    const submittedIds = await submittedIdStore.get();
 
     const newCardio = workouts.filter((w) => {
       if (!w.id || previousIds.has(w.id) || submittedIds.has(w.id)) return false;
@@ -832,23 +835,8 @@ export class HealthConnectService {
       }
     }
 
-    await this.saveSubmittedIds(submittedIds);
-  }
-
-  private async getSubmittedIds(): Promise<Set<string>> {
     try {
-      const raw = await AsyncStorage.getItem(SUBMITTED_IDS_KEY);
-      if (!raw) return new Set();
-      return new Set(JSON.parse(raw));
-    } catch {
-      return new Set();
-    }
-  }
-
-  private async saveSubmittedIds(ids: Set<string>): Promise<void> {
-    try {
-      const trimmed = Array.from(ids).slice(-MAX_SUBMITTED_IDS);
-      await AsyncStorage.setItem(SUBMITTED_IDS_KEY, JSON.stringify(trimmed));
+      await submittedIdStore.save(submittedIds);
     } catch (error) {
       console.warn('[HealthConnect] Failed to save submitted workout IDs:', error);
     }

--- a/src/utils/SubmittedIdStore.ts
+++ b/src/utils/SubmittedIdStore.ts
@@ -1,0 +1,32 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+interface SubmittedIdStoreConfig {
+  storageKey: string;
+  maxIds?: number;
+}
+
+const DEFAULT_MAX_IDS = 500;
+
+export class SubmittedIdStore {
+  private readonly storageKey: string;
+  private readonly maxIds: number;
+
+  constructor(config: SubmittedIdStoreConfig) {
+    this.storageKey = config.storageKey;
+    this.maxIds = config.maxIds ?? DEFAULT_MAX_IDS;
+  }
+
+  async get(): Promise<Set<string>> {
+    try {
+      const raw = await AsyncStorage.getItem(this.storageKey);
+      return raw ? new Set(JSON.parse(raw)) : new Set();
+    } catch {
+      return new Set();
+    }
+  }
+
+  async save(ids: Set<string>): Promise<void> {
+    const trimmed = Array.from(ids).slice(-this.maxIds);
+    await AsyncStorage.setItem(this.storageKey, JSON.stringify(trimmed));
+  }
+}


### PR DESCRIPTION
## Summary
Introduce a shared `SubmittedIdStore` helper and migrate two fitness auto-submit paths (`healthConnectService` + `HealthKitBackgroundService`) off duplicated AsyncStorage read/write helpers.

This is a focused simplification from the H11 `/simplify` lane finding on submitted-ID duplication.

## Required Metadata
- **Agent Owner:** Razor
- **Lane + Finding ID:** H11 / SIMPLIFY-NEW-01
- **Confidence Tier:** Quick review
- **Handoffs Consumed:**
  - `2026-03-07-pixel-to-razor.json` (reviewed; no direct overlap with this scope)
  - `2026-03-07-scout-to-razor.json` (reviewed; no direct overlap with this scope)
- **Regression Context:** None suspected (no merged PR overlap in touched files over last 7 days)

## Gates
- **LIVE_CODE:** PASS (real code-path refactor in production services)
- **REPRO:** PASS (`rg` confirms touched services now use `SubmittedIdStore` and no longer define local `getSubmittedIds/saveSubmittedIds` helpers)
- **STALE_BASE:** PASS (`origin/main` at `404d726` at branch cut)
- **IMPACT:** PASS (dedup persistence logic centralized for two auto-submit services; less drift risk)
- **PROOF:** PASS with baseline caveat (`npm run typecheck` fails on existing repo-wide errors unrelated to touched files)
- **REGRESSION (7-day merged overlap):** PASS (no overlap on touched files)
- **DEPENDENCY-AWARENESS (same-day branch/file overlap):** PASS (no overlap with same-day open PR touched files)

## Constraints Check
- No dependency changes
- No file deletions
- 3 files changed, 96 changed lines (<100)
- `src/config/canary.ts` untouched
