### PR TITLE
fix: propagate selected team tag in Health auto-submit paths

### DIFF
--- a/src/services/fitness/HealthKitBackgroundService.ts
+++ b/src/services/fitness/HealthKitBackgroundService.ts
@@ -124,8 +124,9 @@ export class HealthKitBackgroundService {
         return;
       }
 
-      // Get Lightning address for auto-reward trigger
+      // Get reward + team context tags for Supabase trigger parsing
       const lightningAddress = await AsyncStorage.getItem('@runstr:lightning_address');
+      const selectedTeamId = await AsyncStorage.getItem('@runstr:selected_team_id');
 
       const { SupabaseCompetitionService } = await import(
         '../backend/SupabaseCompetitionService'
@@ -137,6 +138,9 @@ export class HealthKitBackgroundService {
           const tags: string[][] = [];
           if (lightningAddress) {
             tags.push(['lightning', lightningAddress]);
+          }
+          if (selectedTeamId) {
+            tags.push(['team', selectedTeamId]);
           }
 
           await SupabaseCompetitionService.submitWorkoutSimple({

--- a/src/services/fitness/healthConnectService.ts
+++ b/src/services/fitness/healthConnectService.ts
@@ -803,6 +803,7 @@ export class HealthConnectService {
     const npub = await AsyncStorage.getItem('@runstr:npub');
     if (!npub) return;
 
+    const selectedTeamId = await AsyncStorage.getItem('@runstr:selected_team_id');
     const submittedIds = await this.getSubmittedIds();
 
     const newCardio = workouts.filter((w) => {
@@ -815,6 +816,11 @@ export class HealthConnectService {
     for (const w of newCardio) {
       try {
         const eventId = `hc_${w.id}`;
+        const tags: string[][] = [];
+        if (selectedTeamId) {
+          tags.push(['team', selectedTeamId]);
+        }
+
         await SupabaseCompetitionService.submitWorkoutSimple({
           eventId,
           npub,
@@ -823,6 +829,7 @@ export class HealthConnectService {
           duration: w.duration,
           calories: w.totalEnergyBurned,
           startTime: w.startTime,
+          tags,
         });
 
         submittedIds.add(w.id);

--- a/src/services/fitness/healthKitService.ts
+++ b/src/services/fitness/healthKitService.ts
@@ -1018,8 +1018,9 @@ export class HealthKitService {
     const npub = await AsyncStorage.getItem('@runstr:npub');
     if (!npub) return;
 
-    // Include Lightning address in tags so Supabase trigger can auto-reward
+    // Include reward + team context tags so Supabase can route rewards/charity attribution
     const lightningAddress = await AsyncStorage.getItem('@runstr:lightning_address');
+    const selectedTeamId = await AsyncStorage.getItem('@runstr:selected_team_id');
     const submittedIds = await this.getSubmittedIds();
 
     const newCardio = workouts.filter((w) => {
@@ -1037,6 +1038,9 @@ export class HealthKitService {
         const tags: string[][] = [];
         if (lightningAddress) {
           tags.push(['lightning', lightningAddress]);
+        }
+        if (selectedTeamId) {
+          tags.push(['team', selectedTeamId]);
         }
 
         await SupabaseCompetitionService.submitWorkoutSimple({


### PR DESCRIPTION
## Summary
- add `['team', selectedTeamId]` tag propagation to HealthKit background auto-submit path
- add team tag propagation to HealthKit foreground cache auto-submit path
- add team tag propagation to Health Connect auto-submit path so Supabase leaderboard charity extraction can resolve team attribution

## Why
Nostr intake checkpoint re-validated a legacy signal: health auto-submit paths were not consistently including charity/team tags, so leaderboard charity attribution could be skipped for auto-submitted workouts.

## Test evidence
- ⚠️ `npm run typecheck` in cron worktree (no `node_modules`) -> `tsc: command not found`
- No runtime behavior changes outside tag payload enrichment.

## Risk
Low: payload-only additive change (`tags` enrichment) on existing submit calls.
