### PR TITLE
fix(wallet): prevent Receive modal runtime errors and stale pollers

### DIFF
--- a/src/components/wallet/ReceiveModal.tsx
+++ b/src/components/wallet/ReceiveModal.tsx
@@ -13,6 +13,7 @@ import {
   Modal,
   ScrollView,
   ActivityIndicator,
+  Alert,
 } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { theme } from '../../styles/theme';
@@ -43,6 +44,7 @@ export const ReceiveModal: React.FC<ReceiveModalProps> = ({
   const [hasNWC, setHasNWC] = useState(false);
   const [isReady, setIsReady] = useState(false);
   const checkIntervalRef = React.useRef<NodeJS.Timeout>();
+  const stopCheckingTimeoutRef = React.useRef<NodeJS.Timeout>();
 
   // Check NWC availability when modal opens
   useEffect(() => {
@@ -52,6 +54,11 @@ export const ReceiveModal: React.FC<ReceiveModalProps> = ({
     return () => {
       if (checkIntervalRef.current) {
         clearInterval(checkIntervalRef.current);
+        checkIntervalRef.current = undefined;
+      }
+      if (stopCheckingTimeoutRef.current) {
+        clearTimeout(stopCheckingTimeoutRef.current);
+        stopCheckingTimeoutRef.current = undefined;
       }
     };
   }, [visible]);
@@ -90,11 +97,27 @@ export const ReceiveModal: React.FC<ReceiveModalProps> = ({
 
       // Start polling for payment using NWC lookupInvoice
       setIsCheckingPayment(true);
+
+      if (checkIntervalRef.current) {
+        clearInterval(checkIntervalRef.current);
+      }
+      if (stopCheckingTimeoutRef.current) {
+        clearTimeout(stopCheckingTimeoutRef.current);
+      }
+
       checkIntervalRef.current = setInterval(async () => {
         try {
           const lookupResult = await NWCWalletService.lookupInvoice(result.invoice!);
           if (lookupResult.success && lookupResult.paid) {
-            clearInterval(checkIntervalRef.current!);
+            if (checkIntervalRef.current) {
+              clearInterval(checkIntervalRef.current);
+              checkIntervalRef.current = undefined;
+            }
+            if (stopCheckingTimeoutRef.current) {
+              clearTimeout(stopCheckingTimeoutRef.current);
+              stopCheckingTimeoutRef.current = undefined;
+            }
+
             setIsCheckingPayment(false);
             Alert.alert(
               'Payment Received!',
@@ -108,11 +131,13 @@ export const ReceiveModal: React.FC<ReceiveModalProps> = ({
       }, 3000);
 
       // Stop checking after 10 minutes
-      setTimeout(() => {
+      stopCheckingTimeoutRef.current = setTimeout(() => {
         if (checkIntervalRef.current) {
           clearInterval(checkIntervalRef.current);
-          setIsCheckingPayment(false);
+          checkIntervalRef.current = undefined;
         }
+        setIsCheckingPayment(false);
+        stopCheckingTimeoutRef.current = undefined;
       }, 600000);
     } catch (error) {
       console.error('Generate invoice error:', error);
@@ -156,9 +181,16 @@ export const ReceiveModal: React.FC<ReceiveModalProps> = ({
     setInvoice('');
     setPaymentHash('');
     setIsCheckingPayment(false);
+
     if (checkIntervalRef.current) {
       clearInterval(checkIntervalRef.current);
+      checkIntervalRef.current = undefined;
     }
+    if (stopCheckingTimeoutRef.current) {
+      clearTimeout(stopCheckingTimeoutRef.current);
+      stopCheckingTimeoutRef.current = undefined;
+    }
+
     onClose();
   };
 
@@ -280,6 +312,11 @@ export const ReceiveModal: React.FC<ReceiveModalProps> = ({
                   setAmount('');
                   if (checkIntervalRef.current) {
                     clearInterval(checkIntervalRef.current);
+                    checkIntervalRef.current = undefined;
+                  }
+                  if (stopCheckingTimeoutRef.current) {
+                    clearTimeout(stopCheckingTimeoutRef.current);
+                    stopCheckingTimeoutRef.current = undefined;
                   }
                   setIsCheckingPayment(false);
                 }}


### PR DESCRIPTION
## Summary
- add missing `Alert` import in `ReceiveModal` so validation and success/error dialogs are callable at runtime
- track the 10-minute polling timeout with a ref and clear it on modal close/reset/unmount
- clear existing interval/timeout handles before starting a new invoice polling cycle

## Why
Opening and using the receive flow can trigger runtime failures when `Alert` is referenced without import, and repeated invoice attempts can leave stale timers running after close/reset. This patch hardens both paths.

## Testing
- `npm run -s typecheck` *(fails in this environment: `tsc: command not found`)*
- logic review of receive flow cleanup paths (close, regenerate invoice, unmount, settled payment)