### PR TITLE
fix(wallet): restore Alert import for ReceiveBitcoinForm

### DIFF
--- a/src/components/wallet/ReceiveBitcoinForm.tsx
+++ b/src/components/wallet/ReceiveBitcoinForm.tsx
@@ -10,6 +10,7 @@ import {
   TextInput,
   TouchableOpacity,
   StyleSheet,
+  Alert,
 } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { theme } from '../../styles/theme';


### PR DESCRIPTION
## Summary
- import `Alert` from `react-native` in `ReceiveBitcoinForm`
- restore runtime safety for validation and share handlers that call `Alert.alert(...)`

## Why
`ReceiveBitcoinForm` calls `Alert.alert(...)` in input validation and QR share flows, but `Alert` was not imported. That can trigger a runtime `ReferenceError: Can't find variable: Alert` when those paths are used.

## Risk
- low: single-file import fix, no behavior or API changes

## Validation
- attempted: `npm run -s typecheck` *(blocked in cron environment: `tsc: command not found`)*
- attempted: `npm run -s lint -- src/components/wallet/ReceiveBitcoinForm.tsx` *(blocked in cron environment: `expo: command not found`)*
- manual: verified all `Alert.alert(...)` call sites in the component now resolve to a defined import
