### PR TITLE
Fix event creation modal alert API + signer pubkey lookup

### DIFF
--- a/src/components/competition/EventCreationModal.tsx
+++ b/src/components/competition/EventCreationModal.tsx
@@ -21,7 +21,7 @@ import { NostrListService } from '../../services/nostr/NostrListService';
 import { GlobalNDKService } from '../../services/nostr/GlobalNDKService';
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import UnifiedSigningService from '../../services/auth/UnifiedSigningService';
-import { CustomAlert } from '../ui/CustomAlert';
+import { CustomAlertManager as CustomAlert } from '../ui/CustomAlert';
 import type { NostrTeam } from '../../services/nostr/NostrTeamService';
 
 interface EventCreationModalProps {
@@ -206,7 +206,7 @@ export const EventCreationModal: React.FC<EventCreationModalProps> = ({
           const listService = NostrListService.getInstance();
 
           // Get captain's hex pubkey
-          const captainHexPubkey = await signingService.getHexPubkey();
+          const captainHexPubkey = await signingService.getUserPubkey();
           if (!captainHexPubkey) {
             throw new Error('Could not determine captain public key');
           }

--- a/src/services/nostr/NostrCompetitionService.ts
+++ b/src/services/nostr/NostrCompetitionService.ts
@@ -199,7 +199,7 @@ export class NostrCompetitionService {
   static async createEvent(
     eventData: Omit<
       NostrEventDefinition,
-      'captainPubkey' | 'createdAt' | 'updatedAt' | 'status'
+      'id' | 'captainPubkey' | 'createdAt' | 'updatedAt' | 'status'
     > & { id?: string }, // ✅ FIX: Allow optional id from wizard
     captainPrivateKeyOrSigner: string | NDKSigner
   ): Promise<CompetitionPublishResult> {


### PR DESCRIPTION
## Summary
- swap `EventCreationModal` from `CustomAlert` component import to `CustomAlertManager` so `CustomAlert.alert(...)` calls resolve at runtime
- replace invalid `UnifiedSigningService.getHexPubkey()` call with supported `getUserPubkey()` when creating participant lists
- align `NostrCompetitionService.createEvent` input type with runtime behavior by making `id` optional in the Omit contract

## Why
Event creation modal currently references APIs that do not exist (`CustomAlert.alert` on the component export and `getHexPubkey` on `UnifiedSigningService`). In failure/validation flows this can break alerting and in participant-list creation it can fail pubkey retrieval.

## Validation
- `npm run -s typecheck 2>&1 | rg "EventCreationModal|NostrCompetitionService.ts|testCompetitions.ts"` returns no matches for those paths after this change
