### PR TITLE
fix(team): use supported UnifiedSigningService pubkey API in EventsCard

### DIFF
--- a/src/components/team/EventsCard.tsx
+++ b/src/components/team/EventsCard.tsx
@@ -81,7 +81,7 @@ export const EventsCard: React.FC<EventsCardProps> = ({
     const loadCurrentUser = async () => {
       try {
         const hexPubkey =
-          await UnifiedSigningService.getInstance().getHexPubkey();
+          await UnifiedSigningService.getInstance().getUserPubkey();
         if (hexPubkey) {
           setCurrentUserHex(hexPubkey);
           // Note: We only need hex pubkey for event status checking
@@ -374,7 +374,7 @@ export const EventsCard: React.FC<EventsCardProps> = ({
 
       // Get user's hex pubkey
       const userHexPubkey =
-        await UnifiedSigningService.getInstance().getHexPubkey();
+        await UnifiedSigningService.getInstance().getUserPubkey();
       if (!userHexPubkey) {
         CustomAlert.alert('Error', 'Could not determine user public key', [
           { text: 'OK' },


### PR DESCRIPTION
## Summary
- replace `UnifiedSigningService.getHexPubkey()` calls in `EventsCard` with the supported `getUserPubkey()` API
- keep existing event status/join request behavior unchanged while removing calls to a non-existent service method

## Why
`UnifiedSigningService` does not expose `getHexPubkey()`. Calling it can break event card flows (status lookup + join request path) at runtime/typecheck time.

## Risk
Low — two callsite substitutions in one component, no schema or payload changes.

## Validation
- static callsite review confirms both `getHexPubkey()` usages in `EventsCard` were replaced
- local `npm run -s typecheck` could not run in this environment (`tsc: command not found`)
