### PR TITLE
fix: prevent leaderboard charity zap crash when no charity selected

### DIFF
--- a/src/components/team/LeaderboardCard.tsx
+++ b/src/components/team/LeaderboardCard.tsx
@@ -27,6 +27,14 @@ export const LeaderboardCard: React.FC<LeaderboardCardProps> = ({
   const handleCharityZap = async () => {
     try {
       const charity = await CharitySelectionService.getSelectedCharity();
+
+      if (!charity?.lightningAddress) {
+        console.warn(
+          '[LeaderboardCard] Charity zap requested without a selected charity'
+        );
+        return;
+      }
+
       setSelectedCharity({
         name: charity.name,
         address: charity.lightningAddress,


### PR DESCRIPTION
## Summary
- guard `LeaderboardCard.handleCharityZap` when no charity has been selected
- avoid dereferencing `charity.name` / `charity.lightningAddress` when `getSelectedCharity()` returns `null`
- log a warning and exit early instead of opening the zap modal with invalid recipient data

## Why
`CharitySelectionService.getSelectedCharity()` is documented to return `null` when the user has not selected a charity. The previous code unconditionally read properties from `charity`, which can throw at runtime and crash this leaderboard flow.

## Risk
Low — single guarded early return in one component; no API/schema/state-shape changes.

## Validation
- `npx eslint src/components/team/LeaderboardCard.tsx`
