### PR TITLE
fix: stabilize StepDebugOverlay hook flow and snapshot defaults

### DIFF
--- a/src/components/debug/StepDebugOverlay.tsx
+++ b/src/components/debug/StepDebugOverlay.tsx
@@ -35,6 +35,7 @@ import {
 import { nativeStepCounterService } from '../../services/activity/NativeStepCounterService';
 
 const POLL_INTERVAL_MS = 2000;
+const STEP_DEBUG_OVERLAY_ENABLED = false;
 
 const STATUS_COLORS = {
   good: theme.colors.success,
@@ -82,19 +83,33 @@ interface DiagSnapshot extends StepDiagnosticStatus {
   lastPollTime: Date;
 }
 
+const createInitialSnapshot = (): DiagSnapshot => ({
+  activeSource: 'none',
+  nativeSensorRunning: false,
+  backgroundTrackingEnabled: false,
+  healthConnectSdkAvailable: false,
+  healthConnectSdkStatus: 1,
+  stepsPermissionGranted: false,
+  romType: 'stock',
+  isPrivacyROM: false,
+  sensorNotes: null,
+  androidVersion: 0,
+  isLoading: false,
+  todaySteps: 0,
+  trackingStartTime: null,
+  lastPollTime: new Date(0),
+});
+
 export const StepDebugOverlay: React.FC = () => {
-  // Disabled for production - uncomment below for debug builds
-  return null;
-
-  // Android-only component
-  if (Platform.OS !== 'android') return null;
-
+  const isEnabled = STEP_DEBUG_OVERLAY_ENABLED && Platform.OS === 'android';
   const [isExpanded, setIsExpanded] = useState(false);
-  const [snapshot, setSnapshot] = useState<DiagSnapshot | null>(null);
+  const [snapshot, setSnapshot] = useState<DiagSnapshot>(() => createInitialSnapshot());
   const [copyFeedback, setCopyFeedback] = useState(false);
 
   // Poll diagnostics
   useEffect(() => {
+    if (!isEnabled) return;
+
     let mounted = true;
 
     const poll = async () => {
@@ -128,11 +143,9 @@ export const StepDebugOverlay: React.FC = () => {
       mounted = false;
       clearInterval(interval);
     };
-  }, []);
+  }, [isEnabled]);
 
   const copyToClipboard = useCallback(async () => {
-    if (!snapshot) return;
-
     const text = `
 RUNSTR Step Debug - ${new Date().toISOString()}
 
@@ -180,6 +193,8 @@ Last Poll: ${snapshot.lastPollTime.toISOString()}
   const boolColor = (val: boolean): string =>
     val ? STATUS_COLORS.good : STATUS_COLORS.bad;
 
+  if (!isEnabled) return null;
+
   return (
     <View style={styles.container}>
       {/* Floating bug icon */}
@@ -196,7 +211,7 @@ Last Poll: ${snapshot.lastPollTime.toISOString()}
       </TouchableOpacity>
 
       {/* Expanded panel */}
-      {isExpanded && snapshot && (
+      {isExpanded && (
         <View style={styles.panel}>
           {/* Header */}
           <View style={styles.panelHeader}>


### PR DESCRIPTION
## Summary
- remove the unconditional early `return null` that made StepDebugOverlay hooks unreachable and violated hooks ordering
- gate overlay behavior with a single `STEP_DEBUG_OVERLAY_ENABLED` toggle while keeping hooks order stable
- initialize diagnostic snapshot with safe defaults so render/copy paths do not rely on nullable state

## Why
- current overlay file has conditional/unreachable hook flow and nullable snapshot references that add avoidable type/lint debt
- this keeps the overlay disabled by default in production while making the component safe when toggled on for Android diagnostics

## Validation
- `./node_modules/.bin/eslint src/components/debug/StepDebugOverlay.tsx`
- `npm run -s typecheck 2>&1 | rg "StepDebugOverlay"` (no remaining StepDebugOverlay type errors)

## Risk
- low: single debug-only component, feature remains disabled by default
