### PR TITLE
test: unblock stale test-floor assertions for NIP-55 + distance suite

### DIFF
--- a/src/services/activity/__tests__/DistanceFreezeTest.test.ts
+++ b/src/services/activity/__tests__/DistanceFreezeTest.test.ts
@@ -37,14 +37,6 @@ jest.mock('expo-keep-awake', () => ({
   deactivateKeepAwake: jest.fn(),
 }));
 
-jest.mock('../BackgroundLocationTask', () => ({
-  startBackgroundLocationTracking: jest.fn(() => Promise.resolve()),
-  stopBackgroundLocationTracking: jest.fn(() => Promise.resolve()),
-  pauseBackgroundTracking: jest.fn(() => Promise.resolve()),
-  resumeBackgroundTracking: jest.fn(() => Promise.resolve()),
-  getAndClearBackgroundLocations: jest.fn(() => Promise.resolve([])),
-}));
-
 // Type definitions
 type DistanceUpdate = {
   timestamp: number;

--- a/src/services/auth/amber/__tests__/AmberNDKSigner.test.ts
+++ b/src/services/auth/amber/__tests__/AmberNDKSigner.test.ts
@@ -188,9 +188,9 @@ describe('AmberNDKSigner', () => {
 
       await signer.sign(event);
 
-      // Verify event is URI-encoded in data field
+      // Verify NIP-55 raw JSON payload (no URL-encoding) in data field
       expect(capturedIntent.data).toContain('nostrsigner:');
-      expect(capturedIntent.data).toContain('%7B'); // URL-encoded JSON
+      expect(capturedIntent.data).toContain('{"pubkey"');
     });
 
     test('unsigned event does NOT include id or sig fields', async () => {


### PR DESCRIPTION
## Summary
- align Amber NIP-55 compliance test with current raw `nostrsigner:` payload behavior
- remove stale `BackgroundLocationTask` mock from `DistanceFreezeTest` (module no longer exists and is not used by these simulations)

## Why
H11 attempt targets a highest-priority remaining test-floor finding from today’s audit lane: stale test fixtures/expectations causing avoidable red suites.

## Validation
- `npm test -- src/services/activity/__tests__/DistanceFreezeTest.test.ts src/services/auth/amber/__tests__/AmberNDKSigner.test.ts --runInBand` ✅
- `npm test -- --runInBand --passWithNoTests` ⚠️ still failing on other known suites (env placeholder config, Jest asset/ESM transforms, legacy navigation/teamDiscovery tests), but this PR reduces failures from 8 suites/6 tests to 6 suites/5 tests.

## Risk
Low — test-only changes, no runtime app behavior modified.