### PR TITLE
test: unblock Jest Expo/static-asset imports in CI

### DIFF
--- a/__mocks__/expo-constants.ts
+++ b/__mocks__/expo-constants.ts
@@ -1,0 +1,6 @@
+const Constants = {
+  expoConfig: {},
+  manifest: {},
+};
+
+export default Constants;

--- a/__mocks__/expo-secure-store.ts
+++ b/__mocks__/expo-secure-store.ts
@@ -1,0 +1,27 @@
+type SecureValue = string | null;
+
+const store = new Map<string, string>();
+
+export const setItemAsync = async (key: string, value: string): Promise<void> => {
+  store.set(key, value);
+};
+
+export const getItemAsync = async (key: string): Promise<SecureValue> => {
+  return store.has(key) ? (store.get(key) as string) : null;
+};
+
+export const deleteItemAsync = async (key: string): Promise<void> => {
+  store.delete(key);
+};
+
+export const isAvailableAsync = async (): Promise<boolean> => true;
+
+export const canUseBiometricAuthentication = async (): Promise<boolean> => false;
+
+export default {
+  setItemAsync,
+  getItemAsync,
+  deleteItemAsync,
+  isAvailableAsync,
+  canUseBiometricAuthentication,
+};

--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/__mocks__/react-native-toast-message.ts
+++ b/__mocks__/react-native-toast-message.ts
@@ -1,0 +1,6 @@
+const Toast = {
+  show: () => undefined,
+  hide: () => undefined,
+};
+
+export default Toast;

--- a/__mocks__/react-native-url-polyfill-auto.js
+++ b/__mocks__/react-native-url-polyfill-auto.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
   ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   testEnvironment: 'node',
+  setupFiles: ['<rootDir>/jest.setup.js'],
   testMatch: ['**/__tests__/**/*.test.ts', '**/__tests__/**/*.test.tsx'],
   collectCoverageFrom: [
     'src/**/*.{ts,tsx}',
@@ -25,6 +26,11 @@ module.exports = {
     '^react-native$': '<rootDir>/__mocks__/react-native.ts',
     'expo-intent-launcher': '<rootDir>/__mocks__/expo-intent-launcher.ts',
     'expo-linking': '<rootDir>/__mocks__/expo-linking.ts',
+    '^expo-secure-store$': '<rootDir>/__mocks__/expo-secure-store.ts',
+    '^react-native-toast-message$': '<rootDir>/__mocks__/react-native-toast-message.ts',
+    '^expo-constants$': '<rootDir>/__mocks__/expo-constants.ts',
+    '^react-native-url-polyfill/auto$': '<rootDir>/__mocks__/react-native-url-polyfill-auto.js',
     '^@react-native-async-storage/async-storage$': '<rootDir>/__mocks__/@react-native-async-storage/async-storage.ts',
+    '\\.(png|jpe?g|gif|webp|svg)$': '<rootDir>/__mocks__/fileMock.js',
   },
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+global.__DEV__ = false;


### PR DESCRIPTION
## Summary
- add Jest module mappings for Expo/runtime dependencies that currently fail in Node test env
- add static asset stub mapping so PNG-based reward tests run under Jest
- add lightweight setup file to define `__DEV__` for shared logger imports

## Files
- `jest.config.js`
- `jest.setup.js`
- `__mocks__/expo-secure-store.ts`
- `__mocks__/expo-constants.ts`
- `__mocks__/react-native-toast-message.ts`
- `__mocks__/react-native-url-polyfill-auto.js`
- `__mocks__/fileMock.js`

## Validation
- `npm test -- __tests__/rewards/dailyRewardEligibility.test.ts --runInBand` ✅ (15/15)
- `npm test -- --runInBand --passWithNoTests` ⚠️ still red overall, but suite failures improved from 8 to 7 and parse-time infra blockers for `expo-secure-store` and PNG assets are removed.

## Risk
- Low: test infrastructure only (Jest config + mocks), no runtime app logic changes.
