### PR TITLE
test: align Amber URI assertion with raw NIP-55 payload

### DIFF
--- a/src/services/auth/amber/__tests__/AmberNDKSigner.test.ts
+++ b/src/services/auth/amber/__tests__/AmberNDKSigner.test.ts
@@ -188,9 +188,10 @@ describe('AmberNDKSigner', () => {
 
       await signer.sign(event);
 
-      // Verify event is URI-encoded in data field
+      // Verify event is passed as RAW JSON in URI per NIP-55 (not percent-encoded)
       expect(capturedIntent.data).toContain('nostrsigner:');
-      expect(capturedIntent.data).toContain('%7B'); // URL-encoded JSON
+      expect(capturedIntent.data).toContain('{"pubkey"');
+      expect(capturedIntent.data).not.toContain('%7B');
     });
 
     test('unsigned event does NOT include id or sig fields', async () => {


### PR DESCRIPTION
## Summary\n- update Amber signer NIP-55 URI test to assert raw JSON payload (not percent-encoded)\n- keep  prefix check and guard against  encoded payload drift\n\n## Why\nThe signer implementation intentionally sends raw JSON in the URI per current Amber/NIP-55 contract. The prior expectation for  encoded JSON produced deterministic false failures.\n\n## Validation\n-   console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.log
    [Amber DEBUG] Activity result received: {
      resultCode: -1,
      hasData: false,
      hasExtra: true,
      dataType: 'undefined',
      extraKeys: [ 'result' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:163:15)

  console.log
    [Amber DEBUG] Extracted pubkey from: extra.result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:180:17)

  console.log
    [Amber DEBUG] Pubkey value: 1234567890abcdef1234...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:190:17)

  console.log
    [Amber] Signing event kind 1 via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:226:13)

  console.log
    [Amber DEBUG] Event prepared for signing (NO id/sig fields): {
      kind: 1,
      pubkey: '1234567890abcdef...',
      tagsCount: 0,
      hasId: false,
      hasSig: false
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:244:13)

  console.log
    [Amber DEBUG] Sign event URI (NIP-55 raw JSON format): {
      type: 'sign_event',
      eventKind: 1,
      uriLength: 154,
      eventJsonLength: 142,
      rawJsonSample: '{"pubkey":"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef","created_at":1773000333...'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:262:15)

  console.log
    [Amber DEBUG] Sign result received: {
      resultCode: -1,
      resultCodeValue: 'Success',
      hasData: false,
      hasExtra: true,
      extraKeys: [ 'signature' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:284:15)

  console.log
    [Amber DEBUG] Extracted signature from: extra.signature

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:327:17)

  console.log
    [Amber DEBUG] Signature value: abcdef1234567890abcd...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:339:17)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.log
    [Amber DEBUG] Activity result received: {
      resultCode: -1,
      hasData: false,
      hasExtra: true,
      dataType: 'undefined',
      extraKeys: [ 'result' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:163:15)

  console.log
    [Amber DEBUG] Extracted pubkey from: extra.result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:180:17)

  console.log
    [Amber DEBUG] Pubkey value: 1234567890abcdef1234...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:190:17)

  console.log
    [Amber] Signing event kind 1301 via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:226:13)

  console.log
    [Amber DEBUG] Event prepared for signing (NO id/sig fields): {
      kind: 1301,
      pubkey: '1234567890abcdef...',
      tagsCount: 0,
      hasId: false,
      hasSig: false
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:244:13)

  console.log
    [Amber DEBUG] Sign event URI (NIP-55 raw JSON format): {
      type: 'sign_event',
      eventKind: 1301,
      uriLength: 160,
      eventJsonLength: 148,
      rawJsonSample: '{"pubkey":"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef","created_at":1773000334...'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:262:15)

  console.log
    [Amber DEBUG] Sign result received: {
      resultCode: -1,
      resultCodeValue: 'Success',
      hasData: false,
      hasExtra: true,
      extraKeys: [ 'signature' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:284:15)

  console.log
    [Amber DEBUG] Extracted signature from: extra.signature

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:327:17)

  console.log
    [Amber DEBUG] Signature value: abcdef1234567890abcd...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:339:17)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.log
    [Amber DEBUG] Activity result received: {
      resultCode: -1,
      hasData: false,
      hasExtra: true,
      dataType: 'undefined',
      extraKeys: [ 'result' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:163:15)

  console.log
    [Amber DEBUG] Extracted pubkey from: extra.result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:180:17)

  console.log
    [Amber DEBUG] Pubkey value: 1234567890abcdef1234...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:190:17)

  console.log
    [Amber] Signing event kind 1 via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:226:13)

  console.log
    [Amber DEBUG] Event prepared for signing (NO id/sig fields): {
      kind: 1,
      pubkey: '1234567890abcdef...',
      tagsCount: 0,
      hasId: false,
      hasSig: false
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:244:13)

  console.log
    [Amber DEBUG] Sign event URI (NIP-55 raw JSON format): {
      type: 'sign_event',
      eventKind: 1,
      uriLength: 149,
      eventJsonLength: 137,
      rawJsonSample: '{"pubkey":"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef","created_at":1773000334...'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:262:15)

  console.log
    [Amber DEBUG] Sign result received: {
      resultCode: -1,
      resultCodeValue: 'Success',
      hasData: false,
      hasExtra: true,
      extraKeys: [ 'signature' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:284:15)

  console.log
    [Amber DEBUG] Extracted signature from: extra.signature

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:327:17)

  console.log
    [Amber DEBUG] Signature value: abcdef1234567890abcd...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:339:17)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.log
    [Amber DEBUG] Activity result received: {
      resultCode: -1,
      hasData: false,
      hasExtra: true,
      dataType: 'undefined',
      extraKeys: [ 'result' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:163:15)

  console.log
    [Amber DEBUG] Extracted pubkey from: extra.result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:180:17)

  console.log
    [Amber DEBUG] Pubkey value: 1234567890abcdef1234...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:190:17)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.log
    [Amber DEBUG] Activity result received: {
      resultCode: -1,
      hasData: false,
      hasExtra: true,
      dataType: 'undefined',
      extraKeys: [ 'result' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:163:15)

  console.log
    [Amber DEBUG] Extracted pubkey from: extra.result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:180:17)

  console.log
    [Amber DEBUG] Pubkey value: 1234567890abcdef1234...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:190:17)

  console.log
    [Amber] Signing event kind 1 via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:226:13)

  console.log
    [Amber DEBUG] Event prepared for signing (NO id/sig fields): {
      kind: 1,
      pubkey: '1234567890abcdef...',
      tagsCount: 0,
      hasId: false,
      hasSig: false
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:244:13)

  console.log
    [Amber DEBUG] Sign event URI (NIP-55 raw JSON format): {
      type: 'sign_event',
      eventKind: 1,
      uriLength: 149,
      eventJsonLength: 137,
      rawJsonSample: '{"pubkey":"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef","created_at":1773000334...'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:262:15)

  console.log
    [Amber DEBUG] Sign result received: {
      resultCode: -1,
      resultCodeValue: 'Success',
      hasData: false,
      hasExtra: true,
      extraKeys: [ 'signature' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:284:15)

  console.log
    [Amber DEBUG] Extracted signature from: extra.signature

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:327:17)

  console.log
    [Amber DEBUG] Signature value: abcdef1234567890abcd...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:339:17)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.log
    [Amber DEBUG] Activity result received: {
      resultCode: -1,
      hasData: false,
      hasExtra: true,
      dataType: 'undefined',
      extraKeys: [ 'result' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:163:15)

  console.log
    [Amber DEBUG] Extracted pubkey from: extra.result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:180:17)

  console.log
    [Amber DEBUG] Pubkey value: 1234567890abcdef1234...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:190:17)

  console.log
    [Amber] Signing event kind 1 via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:226:13)

  console.log
    [Amber DEBUG] Event prepared for signing (NO id/sig fields): {
      kind: 1,
      pubkey: '1234567890abcdef...',
      tagsCount: 0,
      hasId: false,
      hasSig: false
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:244:13)

  console.log
    [Amber DEBUG] Sign event URI (NIP-55 raw JSON format): {
      type: 'sign_event',
      eventKind: 1,
      uriLength: 149,
      eventJsonLength: 137,
      rawJsonSample: '{"pubkey":"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef","created_at":1773000334...'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:262:15)

  console.log
    [Amber DEBUG] Sign result received: {
      resultCode: -1,
      resultCodeValue: 'Success',
      hasData: false,
      hasExtra: true,
      extraKeys: [ 'signature' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:284:15)

  console.log
    [Amber DEBUG] Extracted signature from: extra.signature

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:327:17)

  console.log
    [Amber DEBUG] Signature value: abcdef1234567890abcd...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:339:17)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.error
    [Amber] Failed to get public key: Error: Amber request timed out after 60 seconds. Please respond in Amber app.
        at /private/tmp/runstr-h16-pr7/src/services/auth/amber/AmberNDKSigner.ts:45:17
        at callTimer (/Users/larry/RUNSTR/node_modules/@sinonjs/fake-timers/src/fake-timers-src.js:744:24)
        at doTickInner (/Users/larry/RUNSTR/node_modules/@sinonjs/fake-timers/src/fake-timers-src.js:1312:29)
        at doTick (/Users/larry/RUNSTR/node_modules/@sinonjs/fake-timers/src/fake-timers-src.js:1393:20)
        at Object.tick (/Users/larry/RUNSTR/node_modules/@sinonjs/fake-timers/src/fake-timers-src.js:1401:20)
        at FakeTimers.advanceTimersByTime (/Users/larry/RUNSTR/node_modules/@jest/fake-timers/build/modernFakeTimers.js:94:19)
        at Object.advanceTimersByTime (/Users/larry/RUNSTR/node_modules/jest-runtime/build/index.js:2027:26)
        at Object.advanceTimersByTime (/private/tmp/runstr-h16-pr7/src/services/auth/amber/__tests__/AmberNDKSigner.test.ts:249:12)
        at Generator.next (<anonymous>)
        at asyncGeneratorStep (/Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:17)
        at _next (/Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:17:9)
        at /Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:22:7
        at new Promise (<anonymous>)
        at Object.<anonymous> (/Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:14:12)
        at Promise.then.completed (/Users/larry/RUNSTR/node_modules/jest-circus/build/utils.js:298:28)
        at new Promise (<anonymous>)
        at callAsyncCircusFn (/Users/larry/RUNSTR/node_modules/jest-circus/build/utils.js:231:10)
        at _callCircusTest (/Users/larry/RUNSTR/node_modules/jest-circus/build/run.js:316:40)
        at _runTest (/Users/larry/RUNSTR/node_modules/jest-circus/build/run.js:252:3)
        at _runTestsForDescribeBlock (/Users/larry/RUNSTR/node_modules/jest-circus/build/run.js:126:9)
        at _runTestsForDescribeBlock (/Users/larry/RUNSTR/node_modules/jest-circus/build/run.js:121:9)
        at _runTestsForDescribeBlock (/Users/larry/RUNSTR/node_modules/jest-circus/build/run.js:121:9)
        at run (/Users/larry/RUNSTR/node_modules/jest-circus/build/run.js:71:3)
        at runAndTransformResultsToJestFormat (/Users/larry/RUNSTR/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
        at jestAdapter (/Users/larry/RUNSTR/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
        at runTestInternal (/Users/larry/RUNSTR/node_modules/jest-runner/build/runTest.js:367:16)
        at runTest (/Users/larry/RUNSTR/node_modules/jest-runner/build/runTest.js:444:34)

      209 |       }
      210 |     } catch (error) {
    > 211 |       console.error('[Amber] Failed to get public key:', error);
          |               ^
      212 |       throw new Error(
      213 |         'Could not get public key from Amber: ' +
      214 |           (error instanceof Error ? error.message : String(error))

      at AmberNDKSigner.error (src/services/auth/amber/AmberNDKSigner.ts:211:15)
          at Generator.throw (<anonymous>)
      at asyncGeneratorStep (../../../Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:17)
      at _throw (../../../Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:20:9)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.log
    [Amber DEBUG] Activity result received: {
      resultCode: -1,
      hasData: false,
      hasExtra: true,
      dataType: 'undefined',
      extraKeys: [ 'result' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:163:15)

  console.log
    [Amber DEBUG] Extracted pubkey from: extra.result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:180:17)

  console.log
    [Amber DEBUG] Pubkey value: 1234567890abcdef1234...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:190:17)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.error
    [Amber] Failed to get public key: Error: Amber app not found. Please install Amber from Google Play Store:
    https://play.google.com/store/apps/details?id=com.greenart7c3.nostrsigner
        at AmberNDKSigner.<anonymous> (/private/tmp/runstr-h16-pr7/src/services/auth/amber/AmberNDKSigner.ts:64:15)
        at Generator.throw (<anonymous>)
        at asyncGeneratorStep (/Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:17)
        at _throw (/Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:20:9)

      209 |       }
      210 |     } catch (error) {
    > 211 |       console.error('[Amber] Failed to get public key:', error);
          |               ^
      212 |       throw new Error(
      213 |         'Could not get public key from Amber: ' +
      214 |           (error instanceof Error ? error.message : String(error))

      at AmberNDKSigner.error (src/services/auth/amber/AmberNDKSigner.ts:211:15)
          at Generator.throw (<anonymous>)
      at asyncGeneratorStep (../../../Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:17)
      at _throw (../../../Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:20:9)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.error
    [Amber] Failed to get public key: Error: Amber app not found. Please install Amber from Google Play Store:
    https://play.google.com/store/apps/details?id=com.greenart7c3.nostrsigner
        at AmberNDKSigner.<anonymous> (/private/tmp/runstr-h16-pr7/src/services/auth/amber/AmberNDKSigner.ts:64:15)
        at Generator.throw (<anonymous>)
        at asyncGeneratorStep (/Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:17)
        at _throw (/Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:20:9)

      209 |       }
      210 |     } catch (error) {
    > 211 |       console.error('[Amber] Failed to get public key:', error);
          |               ^
      212 |       throw new Error(
      213 |         'Could not get public key from Amber: ' +
      214 |           (error instanceof Error ? error.message : String(error))

      at AmberNDKSigner.error (src/services/auth/amber/AmberNDKSigner.ts:211:15)
          at Generator.throw (<anonymous>)
      at asyncGeneratorStep (../../../Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:17)
      at _throw (../../../Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:20:9)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.error
    [Amber] Failed to get public key: Error: Amber app not found. Please install Amber from Google Play Store:
    https://play.google.com/store/apps/details?id=com.greenart7c3.nostrsigner
        at AmberNDKSigner.<anonymous> (/private/tmp/runstr-h16-pr7/src/services/auth/amber/AmberNDKSigner.ts:64:15)
        at Generator.throw (<anonymous>)
        at asyncGeneratorStep (/Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:17)
        at _throw (/Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:20:9)

      209 |       }
      210 |     } catch (error) {
    > 211 |       console.error('[Amber] Failed to get public key:', error);
          |               ^
      212 |       throw new Error(
      213 |         'Could not get public key from Amber: ' +
      214 |           (error instanceof Error ? error.message : String(error))

      at AmberNDKSigner.error (src/services/auth/amber/AmberNDKSigner.ts:211:15)
          at Generator.throw (<anonymous>)
      at asyncGeneratorStep (../../../Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:17)
      at _throw (../../../Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:20:9)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.log
    [Amber DEBUG] Activity result received: {
      resultCode: -1,
      hasData: false,
      hasExtra: true,
      dataType: 'undefined',
      extraKeys: [ 'result' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:163:15)

  console.log
    [Amber DEBUG] Extracted pubkey from: extra.result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:180:17)

  console.log
    [Amber DEBUG] Pubkey value: 1234567890abcdef1234...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:190:17)

  console.log
    [Amber] Signing event kind 1 via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:226:13)

  console.log
    [Amber DEBUG] Event prepared for signing (NO id/sig fields): {
      kind: 1,
      pubkey: '1234567890abcdef...',
      tagsCount: 0,
      hasId: false,
      hasSig: false
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:244:13)

  console.log
    [Amber DEBUG] Sign event URI (NIP-55 raw JSON format): {
      type: 'sign_event',
      eventKind: 1,
      uriLength: 149,
      eventJsonLength: 137,
      rawJsonSample: '{"pubkey":"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef","created_at":1773000334...'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:262:15)

  console.log
    [Amber DEBUG] Sign result received: {
      resultCode: 0,
      resultCodeValue: 'Canceled',
      hasData: false,
      hasExtra: false,
      extraKeys: []
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:284:15)

  console.error
    [Amber] Failed to sign event: Error: User canceled signing request in Amber
        at AmberNDKSigner.<anonymous> (/private/tmp/runstr-h16-pr7/src/services/auth/amber/AmberNDKSigner.ts:364:15)
        at Generator.next (<anonymous>)
        at asyncGeneratorStep (/Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:17)
        at _next (/Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:17:9)

      369 |       }
      370 |     } catch (error) {
    > 371 |       console.error('[Amber] Failed to sign event:', error);
          |               ^
      372 |       const errorMessage =
      373 |         error instanceof Error ? error.message : String(error);
      374 |

      at AmberNDKSigner.error (src/services/auth/amber/AmberNDKSigner.ts:371:15)
      at asyncGeneratorStep (../../../Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:17)
      at _next (../../../Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:17:9)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.log
    [Amber DEBUG] Activity result received: {
      resultCode: -1,
      hasData: false,
      hasExtra: true,
      dataType: 'undefined',
      extraKeys: [ 'result' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:163:15)

  console.log
    [Amber DEBUG] Extracted pubkey from: extra.result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:180:17)

  console.log
    [Amber DEBUG] Pubkey value: 1234567890abcdef1234...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:190:17)

  console.log
    [Amber] Signing event kind 1 via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:226:13)

  console.log
    [Amber DEBUG] Event prepared for signing (NO id/sig fields): {
      kind: 1,
      pubkey: '1234567890abcdef...',
      tagsCount: 0,
      hasId: false,
      hasSig: false
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:244:13)

  console.log
    [Amber DEBUG] Sign event URI (NIP-55 raw JSON format): {
      type: 'sign_event',
      eventKind: 1,
      uriLength: 149,
      eventJsonLength: 137,
      rawJsonSample: '{"pubkey":"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef","created_at":1773000334...'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:262:15)

  console.log
    [Amber DEBUG] Sign result received: {
      resultCode: -1,
      resultCodeValue: 'Success',
      hasData: false,
      hasExtra: true,
      extraKeys: []
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:284:15)

  console.log
    [Amber DEBUG] Extracted signature from: NONE

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:327:17)

  console.log
    [Amber DEBUG] Signature value: NONE

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:339:17)

  console.error
    [Amber] Failed to sign event: Error: No signature in Amber response
        at AmberNDKSigner.<anonymous> (/private/tmp/runstr-h16-pr7/src/services/auth/amber/AmberNDKSigner.ts:361:17)
        at Generator.next (<anonymous>)
        at asyncGeneratorStep (/Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:17)
        at _next (/Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:17:9)

      369 |       }
      370 |     } catch (error) {
    > 371 |       console.error('[Amber] Failed to sign event:', error);
          |               ^
      372 |       const errorMessage =
      373 |         error instanceof Error ? error.message : String(error);
      374 |

      at AmberNDKSigner.error (src/services/auth/amber/AmberNDKSigner.ts:371:15)
      at asyncGeneratorStep (../../../Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:17)
      at _next (../../../Users/larry/RUNSTR/node_modules/@babel/runtime/helpers/asyncToGenerator.js:17:9)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.log
    [Amber DEBUG] Activity result received: {
      resultCode: -1,
      hasData: false,
      hasExtra: true,
      dataType: 'undefined',
      extraKeys: [ 'result' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:163:15)

  console.log
    [Amber DEBUG] Extracted pubkey from: extra.result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:180:17)

  console.log
    [Amber DEBUG] Pubkey value: 1234567890abcdef1234...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:190:17)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.log
    [Amber DEBUG] Activity result received: {
      resultCode: -1,
      hasData: false,
      hasExtra: true,
      dataType: 'undefined',
      extraKeys: [ 'pubkey' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:163:15)

  console.log
    [Amber DEBUG] Extracted pubkey from: extra.pubkey

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:180:17)

  console.log
    [Amber DEBUG] Pubkey value: 1234567890abcdef1234...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:190:17)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.log
    [Amber DEBUG] Activity result received: {
      resultCode: -1,
      hasData: false,
      hasExtra: true,
      dataType: 'undefined',
      extraKeys: [ 'result' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:163:15)

  console.log
    [Amber DEBUG] Extracted pubkey from: extra.result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:180:17)

  console.log
    [Amber DEBUG] Pubkey value: 1234567890abcdef1234...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:190:17)

  console.log
    [Amber] Signing event kind 1 via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:226:13)

  console.log
    [Amber DEBUG] Event prepared for signing (NO id/sig fields): {
      kind: 1,
      pubkey: '1234567890abcdef...',
      tagsCount: 0,
      hasId: false,
      hasSig: false
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:244:13)

  console.log
    [Amber DEBUG] Sign event URI (NIP-55 raw JSON format): {
      type: 'sign_event',
      eventKind: 1,
      uriLength: 149,
      eventJsonLength: 137,
      rawJsonSample: '{"pubkey":"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef","created_at":1773000334...'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:262:15)

  console.log
    [Amber DEBUG] Sign result received: {
      resultCode: -1,
      resultCodeValue: 'Success',
      hasData: false,
      hasExtra: true,
      extraKeys: [ 'signature' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:284:15)

  console.log
    [Amber DEBUG] Extracted signature from: extra.signature

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:327:17)

  console.log
    [Amber DEBUG] Signature value: abcdef1234567890abcd...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:339:17)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.log
    [Amber DEBUG] Activity result received: {
      resultCode: -1,
      hasData: false,
      hasExtra: true,
      dataType: 'undefined',
      extraKeys: [ 'result' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:163:15)

  console.log
    [Amber DEBUG] Extracted pubkey from: extra.result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:180:17)

  console.log
    [Amber DEBUG] Pubkey value: 1234567890abcdef1234...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:190:17)

  console.log
    [Amber] Signing event kind 1 via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:226:13)

  console.log
    [Amber DEBUG] Event prepared for signing (NO id/sig fields): {
      kind: 1,
      pubkey: '1234567890abcdef...',
      tagsCount: 0,
      hasId: false,
      hasSig: false
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:244:13)

  console.log
    [Amber DEBUG] Sign event URI (NIP-55 raw JSON format): {
      type: 'sign_event',
      eventKind: 1,
      uriLength: 149,
      eventJsonLength: 137,
      rawJsonSample: '{"pubkey":"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef","created_at":1773000334...'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:262:15)

  console.log
    [Amber DEBUG] Sign result received: {
      resultCode: -1,
      resultCodeValue: 'Success',
      hasData: false,
      hasExtra: true,
      extraKeys: [ 'event' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:284:15)

  console.log
    [Amber DEBUG] Extracted signature from: extra.event.sig

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:327:17)

  console.log
    [Amber DEBUG] Signature value: abcdef1234567890abcd...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:339:17)

  console.log
    [Amber DEBUG] Cached event ID from Amber: event123...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:351:21)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.log
    [Amber DEBUG] Activity result received: {
      resultCode: -1,
      hasData: false,
      hasExtra: true,
      dataType: 'undefined',
      extraKeys: [ 'result' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:163:15)

  console.log
    [Amber DEBUG] Extracted pubkey from: extra.result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:180:17)

  console.log
    [Amber DEBUG] Pubkey value: 1234567890abcdef1234...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:190:17)

  console.log
    [Amber] Signing event kind 1 via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:226:13)

  console.log
    [Amber DEBUG] Event prepared for signing (NO id/sig fields): {
      kind: 1,
      pubkey: '1234567890abcdef...',
      tagsCount: 0,
      hasId: false,
      hasSig: false
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:244:13)

  console.log
    [Amber DEBUG] Sign event URI (NIP-55 raw JSON format): {
      type: 'sign_event',
      eventKind: 1,
      uriLength: 149,
      eventJsonLength: 137,
      rawJsonSample: '{"pubkey":"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef","created_at":1773000334...'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:262:15)

  console.log
    [Amber DEBUG] Sign result received: {
      resultCode: -1,
      resultCodeValue: 'Success',
      hasData: false,
      hasExtra: true,
      extraKeys: [ 'event' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:284:15)

  console.log
    [Amber DEBUG] Extracted signature from: extra.event.sig

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:327:17)

  console.log
    [Amber DEBUG] Signature value: abcdef1234567890abcd...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:339:17)

  console.log
    [Amber DEBUG] Cached event ID from Amber: cached-event-id-...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:351:21)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.log
    [Amber DEBUG] Activity result received: {
      resultCode: -1,
      hasData: false,
      hasExtra: true,
      dataType: 'undefined',
      extraKeys: [ 'result' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:163:15)

  console.log
    [Amber DEBUG] Extracted pubkey from: extra.result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:180:17)

  console.log
    [Amber DEBUG] Pubkey value: 234567890abcdef12345...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:190:17)

  console.log
    [Amber] Padded hex pubkey from 63 to 64 characters

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:576:15)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.log
    [Amber DEBUG] Activity result received: {
      resultCode: -1,
      hasData: false,
      hasExtra: true,
      dataType: 'undefined',
      extraKeys: [ 'result' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:163:15)

  console.log
    [Amber DEBUG] Extracted pubkey from: extra.result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:180:17)

  console.log
    [Amber DEBUG] Pubkey value: 1234567890abcdef1234...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:190:17)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.log
    [Amber DEBUG] Activity result received: {
      resultCode: -1,
      hasData: false,
      hasExtra: true,
      dataType: 'undefined',
      extraKeys: [ 'result' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:163:15)

  console.log
    [Amber DEBUG] Extracted pubkey from: extra.result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:180:17)

  console.log
    [Amber DEBUG] Pubkey value: 1234567890abcdef1234...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:190:17)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Requesting public key via Activity Result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:129:13)

  console.log
    [Amber DEBUG] Launching Intent with extras: {
      type: 'get_public_key',
      permissions: '[{"type":"sign_event","kind":0},{"type":"sign_event","kind":1},{"type":"sign_event","kind":1301},{"type":"sign_event","kind":30000},{"type":"sign_event","kind":30001},{"type":"sign_event","kind":30078},{"type":"sign_event","kind":33404},{"type":"nip04_encrypt"},{"type":"nip04_decrypt"},{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]'
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:152:15)

  console.log
    [Amber DEBUG] Activity result received: {
      resultCode: -1,
      hasData: false,
      hasExtra: true,
      dataType: 'undefined',
      extraKeys: [ 'result' ]
    }

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:163:15)

  console.log
    [Amber DEBUG] Extracted pubkey from: extra.result

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:180:17)

  console.log
    [Amber DEBUG] Pubkey value: 1234567890abcdef1234...

      at AmberNDKSigner.log (src/services/auth/amber/AmberNDKSigner.ts:190:17)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)

  console.log
    [Amber] Initializing NDK Signer for Activity Result communication

      at new log (src/services/auth/amber/AmberNDKSigner.ts:20:13)\n