### PR TITLE
fix: clear stale Amber timeout handles after activity launch race

### DIFF
--- a/src/services/auth/amber/AmberNDKSigner.ts
+++ b/src/services/auth/amber/AmberNDKSigner.ts
@@ -35,22 +35,26 @@ export class AmberNDKSigner implements NDKSigner {
     options: any,
     timeoutMs: number = this.AMBER_TIMEOUT_MS
   ): Promise<any> {
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
     try {
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(
+          () =>
+            reject(
+              new Error(
+                `Amber request timed out after ${
+                  timeoutMs / 1000
+                } seconds. Please respond in Amber app.`
+              )
+            ),
+          timeoutMs
+        );
+      });
+
       return await Promise.race([
         IntentLauncher.startActivityAsync(action, options),
-        new Promise((_, reject) =>
-          setTimeout(
-            () =>
-              reject(
-                new Error(
-                  `Amber request timed out after ${
-                    timeoutMs / 1000
-                  } seconds. Please respond in Amber app.`
-                )
-              ),
-            timeoutMs
-          )
-        ),
+        timeoutPromise,
       ]);
     } catch (error) {
       const errorMessage = String(error);
@@ -69,6 +73,10 @@ export class AmberNDKSigner implements NDKSigner {
 
       // Re-throw other errors
       throw error;
+    } finally {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- clear `setTimeout` handles created by `startActivityWithTimeout` once the activity promise settles
- keep existing timeout/error mapping behavior unchanged
- prevent leaked timers that trigger Jest open-handle warnings and keep extra event-loop work queued unnecessarily

## Testing
- `npm run test:amber -- --runInBand` on branch from `main` *(expected red from pre-existing baseline issues tracked by open PRs #87/#92/#94; this change does not add new assertion failures)*
- stack replay validation (`main` + PRs #86-#94 + this commit):
  - `npm test -- --runInBand --detectOpenHandles --passWithNoTests` ✅ 8 suites / 92 tests passing with no open-handle warning

## Risk
- low: localized to timeout cleanup path in Amber signer
- no behavior change to successful/rejected intent responses besides timer disposal

## Release Readiness Note
- this removes the lingering Amber timeout-handle class from stacked replay and improves release confidence once the existing amber baseline PR stack lands
