### PR TITLE
fix: remove hardcoded test nsec literals from auth flow utility

### DIFF
--- a/docs/archive/PHASE1_TESTING_GUIDE.md
+++ b/docs/archive/PHASE1_TESTING_GUIDE.md
@@ -131,12 +131,10 @@ await tester.testNostrUtilities();
 
 ### Sample Test Keys
 ```typescript
-// Valid test nsec (use for testing only)
-const testNsec = 'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5f';
-const expectedNpub = 'npub1yx5cw0xrx6mc8vjpdnvl3lnvvkr2ce9g98x9w2l2qdtdgstz3tkqxyxk5l';
-
-// Generate fresh keys for testing
+// Generate fresh keys for testing (preferred)
 const keyPair = generateNostrKeyPair();
+const testNsec = keyPair.nsec;
+const expectedNpub = keyPair.npub;
 ```
 
 ### Mock Responses

--- a/src/utils/testAuthFlow.ts
+++ b/src/utils/testAuthFlow.ts
@@ -25,6 +25,10 @@ export interface TestResult {
 export class AuthFlowTester {
   private results: TestResult[] = [];
 
+  private createValidTestNsec(): string {
+    return generateNostrKeyPair().nsec;
+  }
+
   private logResult(
     step: string,
     success: boolean,
@@ -85,7 +89,7 @@ export class AuthFlowTester {
       // Test nsec validation
       const testCases = [
         {
-          nsec: 'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5f',
+          nsec: this.createValidTestNsec(),
           expected: true,
         },
         { nsec: 'invalid-nsec', expected: false },
@@ -117,8 +121,7 @@ export class AuthFlowTester {
 
     try {
       // Test nsec to npub conversion
-      const testNsec =
-        'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5f';
+      const testNsec = this.createValidTestNsec();
       const npub = nsecToNpub(testNsec);
 
       this.logResult(
@@ -208,9 +211,6 @@ export class AuthFlowTester {
   async testAuthenticationService(): Promise<void> {
     console.log('\n🔐 Testing Authentication Service...');
 
-    const testNsec =
-      'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5f';
-
     try {
       // Test invalid nsec handling
       const invalidResult = await AuthService.signInWithNostr('invalid-nsec');
@@ -258,8 +258,7 @@ export class AuthFlowTester {
     console.log('\n💾 Testing Local Storage...');
 
     const testUserId = 'test-user-' + Date.now();
-    const testNsec =
-      'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5f';
+    const testNsec = this.createValidTestNsec();
 
     try {
       // Clear any existing storage
@@ -309,7 +308,7 @@ export class AuthFlowTester {
           if (!testCase.expectedToFail) {
             errorHandlingPassed++;
           }
-        } catch (error) {
+        } catch {
           if (testCase.expectedToFail) {
             errorHandlingPassed++;
           }


### PR DESCRIPTION
## Summary
- remove hardcoded `nsec1...` literals from `src/utils/testAuthFlow.ts`
- generate fresh valid test nsec values at runtime for utility checks
- update archived phase testing guide to show generated key usage instead of embedding a fixed nsec/npub pair

## Why
Security audit called out bundled hardcoded test nsec material in source/docs. This keeps test coverage behavior while eliminating fixed secret-like literals in the auth flow utility path.

## Validation
- `npx eslint src/utils/testAuthFlow.ts`
