### PR TITLE
fix: enforce HTTPS-only custom Blossom server endpoints

### DIFF
--- a/src/components/music/BlossomServerManager.tsx
+++ b/src/components/music/BlossomServerManager.tsx
@@ -107,12 +107,23 @@ export const BlossomServerManager: React.FC<BlossomServerManagerProps> = ({
       url = 'https://' + url;
     }
 
+    let parsedUrl: URL;
     try {
-      new URL(url); // Validate URL
+      parsedUrl = new URL(url);
     } catch {
       Alert.alert('Error', 'Please enter a valid URL');
       return;
     }
+
+    if (parsedUrl.protocol !== 'https:') {
+      Alert.alert(
+        'HTTPS Required',
+        'For security, custom Blossom servers must use https:// endpoints.'
+      );
+      return;
+    }
+
+    url = parsedUrl.toString().replace(/\/$/, '');
 
     setIsAddingServer(true);
 

--- a/src/services/music/BlossomService.ts
+++ b/src/services/music/BlossomService.ts
@@ -96,13 +96,23 @@ class BlossomServiceClass {
    */
   async addServer(url: string, name?: string): Promise<boolean> {
     try {
+      // Security hardening: custom Blossom endpoints must use HTTPS
+      const parsedUrl = new URL(url);
+      if (parsedUrl.protocol !== 'https:') {
+        console.warn(
+          '[BlossomService] Rejected non-HTTPS server URL:',
+          parsedUrl.protocol
+        );
+        return false;
+      }
+
       // Normalize URL (remove trailing slash)
-      const normalizedUrl = url.replace(/\/$/, '');
+      const normalizedUrl = parsedUrl.toString().replace(/\/$/, '');
 
       // Check if already exists
       const servers = await this.getServers();
-      const exists = servers.some(s =>
-        s.url.replace(/\/$/, '') === normalizedUrl
+      const exists = servers.some(
+        (s) => s.url.replace(/\/$/, '') === normalizedUrl
       );
 
       if (exists) {
@@ -113,7 +123,10 @@ class BlossomServiceClass {
       // Test connection before adding
       const isValid = await this.testConnection(normalizedUrl);
       if (!isValid) {
-        console.warn('[BlossomService] Failed to connect to server:', normalizedUrl);
+        console.warn(
+          '[BlossomService] Failed to connect to server:',
+          normalizedUrl
+        );
         return false;
       }
 
@@ -123,7 +136,7 @@ class BlossomServiceClass {
 
       customServers.push({
         url: normalizedUrl,
-        name: name || new URL(normalizedUrl).hostname,
+        name: name || parsedUrl.hostname,
         isDefault: false,
       });
 


### PR DESCRIPTION
## Summary
- enforce `https://` requirement when users add custom Blossom servers in `BlossomServerManager`
- reject non-HTTPS protocols in `BlossomService.addServer()` as a service-layer guardrail
- normalize stored URLs after validation to keep duplicate checks stable

## Why
Security triage flagged that custom Blossom endpoints could be added over plaintext HTTP, which risks media/auth metadata interception on hostile networks.

## Risk
Low: scoped to custom server add flow only. Existing default servers are unchanged.

## Validation
- `npx eslint src/components/music/BlossomServerManager.tsx src/services/music/BlossomService.ts` (passes; existing hook warning only)
