### PR TITLE
Fix stale internal doc links across RUNSTR docs

### DIFF
--- a/docs/ANDROID_BUILD.md
+++ b/docs/ANDROID_BUILD.md
@@ -338,5 +338,5 @@ jobs:
 ## Related Documentation
 
 - 📖 **For iOS builds**: See main CLAUDE.md Development Workflow section
-- 📖 **For app distribution**: [ZAPSTORE_PUBLISHING.md](./ZAPSTORE_PUBLISHING.md)
+- 📖 **For app distribution**: [ZAPSTORE_PUBLISHING.md](./archive/ZAPSTORE_PUBLISHING.md)
 - 📖 **For version management**: See CHANGELOG.md

--- a/docs/KIND_1301_SPEC.md
+++ b/docs/KIND_1301_SPEC.md
@@ -527,6 +527,6 @@ const runningWorkouts = await ndk.fetchEvents(filter);
 
 ## Related Documentation
 
-- 📖 **For competition architecture**: [nostr-native-fitness-competitions.md](./nostr-native-fitness-competitions.md)
+- 📖 **For competition architecture**: [nostr-native-fitness-competitions.md](./events-and-leagues.md)
 - 📖 **For HealthKit integration**: [HEALTHKIT_IMPLEMENTATION_GUIDE.md](./HEALTHKIT_IMPLEMENTATION_GUIDE.md)
 - 📖 **For workout publishing**: See main CLAUDE.md App Flow Architecture section

--- a/docs/PERFORMANCE_GUIDE.md
+++ b/docs/PERFORMANCE_GUIDE.md
@@ -397,4 +397,4 @@ console.log(`Cache fetch took ${duration}ms`);
 
 - 📖 **For caching implementation**: See `src/utils/cache/UnifiedNostrCache.ts`
 - 📖 **For data architecture**: [DATA_ARCHITECTURE_AND_CACHING_STRATEGY.md](./DATA_ARCHITECTURE_AND_CACHING_STRATEGY.md)
-- 📖 **For Nostr optimization**: [nostr-native-fitness-competitions.md](./nostr-native-fitness-competitions.md)
+- 📖 **For Nostr optimization**: [nostr-native-fitness-competitions.md](./events-and-leagues.md)

--- a/docs/TEAM_MANAGEMENT_SYSTEM.md
+++ b/docs/TEAM_MANAGEMENT_SYSTEM.md
@@ -277,6 +277,6 @@ All member displays throughout the app now use the `ZappableUserRow` component w
 - League Rankings: `src/components/team/LeagueRankingsSection.tsx:388-400`
 
 ## Related Documentation
-- [App User Flow Documentation](./APP_USER_FLOW_AND_CAPTAIN_EXPERIENCE.md)
-- [Competition System Documentation](./COMPETITION_SYSTEM.md)
-- [Nostr Protocol Integration](./NOSTR_PROTOCOL.md)
+- [App User Flow Documentation](./internal/PROJECT_OVERVIEW.md)
+- [Competition System Documentation](./events-and-leagues.md)
+- [Nostr Protocol Integration](./KIND_1301_SPEC.md)

--- a/docs/archive/EVENT_WIZARD_SUCCESS.md
+++ b/docs/archive/EVENT_WIZARD_SUCCESS.md
@@ -326,5 +326,5 @@ As of January 2025:
   - `src/services/nostr/NostrListService.ts`
   - `src/services/nostr/eventAnnouncementCardGenerator.ts`
 - **Docs:**
-  - [Nostr Competition Events](../docs/nostr-native-fitness-competitions.md)
-  - [Performance Guide](../docs/PERFORMANCE_GUIDE.md)
+  - [Nostr Competition Events](../events-and-leagues.md)
+  - [Performance Guide](../PERFORMANCE_GUIDE.md)

--- a/docs/internal/PROJECT_OVERVIEW.md
+++ b/docs/internal/PROJECT_OVERVIEW.md
@@ -142,4 +142,4 @@ RUNSTR represents a paradigm shift in fitness app design—combining decentraliz
 - **Bitcoin-native**: Lightning payments integrated throughout for instant global transactions
 - **Open ecosystem**: Workouts published as Nostr events, interoperable with any Nostr client
 
-For technical implementation details, architecture patterns, and development guidelines, see [CLAUDE.md](./CLAUDE.md).
+For technical implementation details, architecture patterns, and development guidelines, see [CLAUDE.md](../../CLAUDE.md).


### PR DESCRIPTION
## Summary
Fixes stale/broken relative markdown links found in the docs fallback integrity scan.

## Changes
- Update Android build guide link to archived Zapstore publishing doc
- Replace missing `nostr-native-fitness-competitions.md` links with `events-and-leagues.md`
- Update team-management related links to existing docs
- Fix archive link paths in `EVENT_WIZARD_SUCCESS.md`
- Fix `PROJECT_OVERVIEW.md` link to repo-root `CLAUDE.md`

## Validation
- Ran local docs link validation script over `docs/**/*.md`
- Result: `broken 0` (down from 9)

## Risk
Low — documentation-only relative link updates, no runtime code changes.

## Rollback
Revert commit `746475e` on `bugfix/nostr-h10-fix-doc-internal-links`.
