### PR TITLE
fix: repair broken testing guide link in scripts README

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -237,7 +237,7 @@ When adding a new script:
 ## Related Documentation
 
 - [Pre-Launch Review Guide](../docs/PRE_LAUNCH_REVIEW_GUIDE.md)
-- [Testing Guide](../docs/PHASE_1_2_TESTING_GUIDE.md)
+- [Testing Guide](../docs/archive/PHASE_1_2_TESTING_GUIDE.md)
 - [Amber Integration](../docs/AMBER_INTEGRATION.md)
 
 ---


### PR DESCRIPTION
## Summary
Fixes a broken internal markdown link in `scripts/README.md` so the Testing Guide reference resolves correctly.

## Changes
- Updated `Testing Guide` link from `../docs/PHASE_1_2_TESTING_GUIDE.md` to `../docs/archive/PHASE_1_2_TESTING_GUIDE.md`.

## Validation
- Ran a targeted markdown relative-link check for `scripts/README.md`.
  - Before: 1 broken relative link
  - After: 0 broken relative links

## Risk
Low — documentation-only change, no runtime behavior modified.
