### PR TITLE
cleanup: remove unused AppNavigator vars to reduce lint noise

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -49,7 +49,6 @@ import { ActivityTrackerScreen } from '../screens/activity/ActivityTrackerScreen
 import { Season2Screen } from '../screens/season2/Season2Screen';
 import { CompeteScreen } from '../screens/CompeteScreen';
 import { LeaderboardsScreen } from '../screens/LeaderboardsScreen';
-import type { DiscoveredNostrUser } from '../services/user/UserDiscoveryService';
 
 // Navigation Configuration
 import {
@@ -120,7 +119,6 @@ export const AppNavigator: React.FC<AppNavigatorProps> = ({
   // Fetch real data instead of using mock data
   const {
     user,
-    teamData,
     profileData,
     walletData,
     captainDashboardData,
@@ -376,7 +374,7 @@ export const AppNavigator: React.FC<AppNavigatorProps> = ({
       >
         {({ navigation, route }) => {
           // Get team and captain data from route params if passed
-          const { teamId, teamName, isCaptain } = route.params || {};
+          const { teamId, teamName } = route.params || {};
 
           // Use captain dashboard data or create a minimal version
           const dashboardData = captainDashboardData || {


### PR DESCRIPTION
## Summary
Removes unused symbols in `AppNavigator` that were generating avoidable lint warnings.

## Changes
- removed unused `DiscoveredNostrUser` type import
- removed unused `teamData` from `useNavigationData` destructure
- removed unused `isCaptain` route param destructure in CaptainDashboard route

## Validation
- `/Users/larry/RUNSTR/node_modules/.bin/eslint -c .eslintrc.js src/navigation/AppNavigator.tsx` (before: 3 warnings, after: 0 warnings)

## Risk
Low — no runtime logic/path changes; cleanup only.

## Rollback
Revert commit `37552e4` from this branch.
