### PR TITLE
chore: remove unused import in navigation handlers

### DIFF
--- a/src/navigation/navigationHandlers.ts
+++ b/src/navigation/navigationHandlers.ts
@@ -9,7 +9,6 @@ import { AuthService } from '../services/auth/authService';
 import { getNostrTeamService } from '../services/nostr/NostrTeamService';
 import { CaptainDetectionService } from '../services/team/captainDetectionService';
 import { isTeamMember, isTeamCaptain } from '../utils/teamUtils';
-import { DirectNostrProfileService } from '../services/user/directNostrProfileService';
 import { CaptainCache } from '../utils/captainCache';
 import { CustomAlertManager } from '../components/ui/CustomAlert';
 


### PR DESCRIPTION
## Summary\n- remove unused `DirectNostrProfileService` import from `navigationHandlers.ts`\n- keep runtime behavior unchanged (lint-only cleanup)\n\n## Validation\n- `/Users/larry/RUNSTR/node_modules/.bin/eslint -c .eslintrc.js src/navigation/navigationHandlers.ts --format unix`\n  - before: 1 no-unused-vars warning\n  - after: 0 warnings\n\n## Risk\n- low (single-line cleanup, no logic changes)