### PR TITLE
Fix View History navigation when WorkoutHistory route is unavailable

### DIFF
--- a/__tests__/navigation/findNavigatorWithRoute.test.ts
+++ b/__tests__/navigation/findNavigatorWithRoute.test.ts
@@ -1,0 +1,40 @@
+import { findNavigatorWithRoute } from '../../src/navigation/findNavigatorWithRoute';
+
+describe('findNavigatorWithRoute', () => {
+  it('returns the current navigator when route exists locally', () => {
+    const nav = {
+      getState: () => ({ routeNames: ['Home', 'WorkoutHistory'] }),
+      getParent: () => null,
+    };
+
+    expect(findNavigatorWithRoute(nav, 'WorkoutHistory')).toBe(nav);
+  });
+
+  it('walks up parent navigators until route is found', () => {
+    const parent = {
+      getState: () => ({ routeNames: ['MainTabs', 'WorkoutHistory'] }),
+      getParent: () => null,
+    };
+
+    const child = {
+      getState: () => ({ routeNames: ['Profile', 'Settings'] }),
+      getParent: () => parent,
+    };
+
+    expect(findNavigatorWithRoute(child, 'WorkoutHistory')).toBe(parent);
+  });
+
+  it('returns null when route does not exist in navigator chain', () => {
+    const root = {
+      getState: () => ({ routeNames: ['Home', 'Feed'] }),
+      getParent: () => null,
+    };
+
+    const child = {
+      getState: () => ({ routeNames: ['Profile'] }),
+      getParent: () => root,
+    };
+
+    expect(findNavigatorWithRoute(child, 'WorkoutHistory')).toBeNull();
+  });
+});

--- a/src/components/profile/YourCompetitionsBox.tsx
+++ b/src/components/profile/YourCompetitionsBox.tsx
@@ -5,24 +5,29 @@
  */
 
 import React from 'react';
-import { Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { Text, TouchableOpacity, StyleSheet, Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
 import { theme } from '../../styles/theme';
+import { findNavigatorWithRoute } from '../../navigation/findNavigatorWithRoute';
 
 export const FitnessHistoryBox: React.FC = () => {
   const navigation = useNavigation<any>();
   const { t } = useTranslation('profile');
 
   const handlePress = () => {
-    // Navigate to WorkoutHistory screen (workout history/stats)
-    // Use parent navigator since WorkoutHistory is in the stack, not the tab navigator
-    const parentNav = navigation.getParent();
-    if (parentNav) {
-      parentNav.navigate('WorkoutHistory');
-    } else {
-      navigation.navigate('WorkoutHistory');
+    const navigatorWithHistory = findNavigatorWithRoute(
+      navigation,
+      'WorkoutHistory'
+    );
+
+    if (navigatorWithHistory) {
+      navigatorWithHistory.navigate('WorkoutHistory');
+      return;
     }
+
+    console.warn('[FitnessHistoryBox] WorkoutHistory route not available');
+    Alert.alert('History unavailable', 'Please sign in to view workout history.');
   };
 
   return (

--- a/src/navigation/findNavigatorWithRoute.ts
+++ b/src/navigation/findNavigatorWithRoute.ts
@@ -1,0 +1,13 @@
+export const findNavigatorWithRoute = (nav: any, routeName: string) => {
+  let currentNav = nav;
+
+  while (currentNav) {
+    const state = currentNav.getState?.();
+    if (state?.routeNames?.includes(routeName)) {
+      return currentNav;
+    }
+    currentNav = currentNav.getParent?.();
+  }
+
+  return null;
+};


### PR DESCRIPTION
## Summary
Fixes a navigation crash path from Profile > View History by guarding route lookup before navigation.

## Changes
- Added `findNavigatorWithRoute` helper to walk up parent navigator chain safely
- Updated `FitnessHistoryBox` to navigate only when `WorkoutHistory` exists
- Added user-facing fallback alert when route is unavailable (e.g. signed-out state)
- Added unit tests for route lookup helper

## Validation
- `npx eslint src/components/profile/YourCompetitionsBox.tsx src/navigation/findNavigatorWithRoute.ts __tests__/navigation/findNavigatorWithRoute.test.ts`
- `npx jest __tests__/navigation/findNavigatorWithRoute.test.ts --runInBand`

## Risk
Low: behavior changes only in View History button handler and adds guard/fallback for missing route.

## Related
- Fixes #66
