### PR TITLE
fix: stabilize WorkoutHistory user-data loading effect dependencies

### DIFF
--- a/src/screens/WorkoutHistoryScreen.tsx
+++ b/src/screens/WorkoutHistoryScreen.tsx
@@ -7,7 +7,7 @@
  * Tabs are displayed in the header row next to the back button.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
@@ -51,12 +51,7 @@ export const WorkoutHistoryScreen: React.FC<WorkoutHistoryScreenProps> = ({
   const [selectedWorkout, setSelectedWorkout] = useState<any>(null);
   const [userProfile, setUserProfile] = useState<NostrProfile | null>(null);
 
-  // Load user credentials on mount
-  useEffect(() => {
-    loadUserData();
-  }, []);
-
-  const loadUserData = async () => {
+  const loadUserData = useCallback(async () => {
     try {
       console.log('[WorkoutHistory] Loading user data...');
 
@@ -92,7 +87,12 @@ export const WorkoutHistoryScreen: React.FC<WorkoutHistoryScreenProps> = ({
     } finally {
       setIsInitializing(false);
     }
-  };
+  }, [route?.params?.pubkey, route?.params?.userId]);
+
+  // Load user credentials on mount and when route params change
+  useEffect(() => {
+    loadUserData();
+  }, [loadUserData]);
 
   // Load user profile in background (non-blocking, for social cards only)
   useEffect(() => {


### PR DESCRIPTION
## Summary
Stabilize `WorkoutHistoryScreen` user-data loading by fixing hook dependency wiring so lint no longer flags stale effect deps and route param updates are handled cleanly.

## Changes
- wrapped `loadUserData` in `useCallback` with route param dependencies
- updated mount effect to depend on `loadUserData` instead of an empty array
- kept behavior and fallback loading logic unchanged

## Validation
- `npx eslint src/screens/WorkoutHistoryScreen.tsx` ✅
- `npx jest --findRelatedTests src/screens/WorkoutHistoryScreen.tsx --runInBand` ⚠️ no related tests discovered in current Jest config

## Risk
Low — single-screen hook dependency fix, no API or state schema changes.

## Rollback
Revert commit `5c8cf54`.
