### PR TITLE
cleanup: remove unused BottomTabNavigator navigation variables

### DIFF
--- a/src/navigation/BottomTabNavigator.tsx
+++ b/src/navigation/BottomTabNavigator.tsx
@@ -9,12 +9,10 @@ import {
   View,
   StyleSheet,
   TouchableOpacity,
-  InteractionManager,
   ActivityIndicator,
 } from 'react-native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { Ionicons } from '@expo/vector-icons';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { theme } from '../styles/theme';
 import { PerformanceLogger } from '../utils/PerformanceLogger';
@@ -79,14 +77,10 @@ export const BottomTabNavigator: React.FC<BottomTabNavigatorProps> = ({
   const {
     user,
     profileData,
-    availableTeams,
     isLoading,
     isLoadingTeam,
     error,
     refresh,
-    loadTeams,
-    loadWallet,
-    prefetchLeaguesInBackground,
   } = useNavigationData();
 
   // Create navigation handlers


### PR DESCRIPTION
## Summary
Remove unused imports and unused values destructured from useNavigationData in BottomTabNavigator to reduce lint noise in a core navigation surface.

## Changes
- removed unused InteractionManager and SafeAreaView imports
- removed unused availableTeams, loadTeams, loadWallet, and prefetchLeaguesInBackground destructuring

## Validation
- npx eslint src/navigation/BottomTabNavigator.tsx -f unix
  - before: 8 warnings (6 no-unused-vars + 2 import/first)
  - after: 2 warnings (remaining import/first items outside this run scope)
