### PR TITLE
cleanup: remove unused SafeAreaView import in TeamsScreen

### DIFF
--- a/src/screens/TeamsScreen.tsx
+++ b/src/screens/TeamsScreen.tsx
@@ -16,7 +16,6 @@ import {
   RefreshControl,
   Animated,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { useFocusEffect } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';


### PR DESCRIPTION
## Summary
Removes an unused `SafeAreaView` import from `TeamsScreen` to eliminate avoidable lint noise in an active user-facing screen.

## Why
`@typescript-eslint/no-unused-vars` flagged this import, and keeping lint noise low improves signal quality for real defects.

## Changes
- removed `SafeAreaView` import from `src/screens/TeamsScreen.tsx`

## Validation
- `npx eslint src/screens/TeamsScreen.tsx -f unix` (clean)

## Risk
Low — one-line dead import removal, no runtime behavior changes.
