### PR TITLE
cleanup: remove unused Circle import in SpeedGauge

### DIFF
--- a/src/components/activity/SpeedGauge.tsx
+++ b/src/components/activity/SpeedGauge.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import Svg, { Circle, Path, Text as SvgText } from 'react-native-svg';
+import Svg, { Path, Text as SvgText } from 'react-native-svg';
 import { theme } from '../../styles/theme';
 
 interface SpeedGaugeProps {


### PR DESCRIPTION
## Summary
Remove an unused `Circle` import from `SpeedGauge` to reduce lint noise in activity UI code.

## Why
`@typescript-eslint/no-unused-vars` flagged `Circle` as unused in a user-facing component, adding avoidable warning noise.

## Validation
- `npx eslint src/components/activity/SpeedGauge.tsx -f unix` (0 problems)
- `npx jest --findRelatedTests src/components/activity/SpeedGauge.tsx --runInBand --passWithNoTests` (no related tests found, exits 0)

## Risk
Low — import-only cleanup, no runtime logic changes.
