### PR TITLE
fix: enforce runtime analytics metadata and user initialization for telemetry events

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -208,6 +208,7 @@ import { WelcomePermissionModal } from './components/onboarding/WelcomePermissio
 import AppInitializationService from './services/core/AppInitializationService';
 import { StepPollingService } from './services/rewards/StepPollingService';
 import { StepCompetitionService } from './services/competition/StepCompetitionService';
+import { analytics } from './utils/analytics';
 import {
   CustomAlertProvider,
   CustomAlertManager,
@@ -330,6 +331,21 @@ const AppContent: React.FC<AppContentProps> = ({ onPermissionComplete }) => {
         }
       });
     }
+  }, [isAuthenticated, currentUser]);
+
+  // Initialize analytics context for authenticated sessions
+  React.useEffect(() => {
+    if (!isAuthenticated || !currentUser) {
+      return;
+    }
+
+    const analyticsUserId = currentUser.npub || currentUser.id;
+    if (!analyticsUserId) {
+      console.warn('[App] Analytics init skipped: missing user identifier');
+      return;
+    }
+
+    analytics.initialize(analyticsUserId);
   }, [isAuthenticated, currentUser]);
 
   // Initialize app after authentication

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -3,6 +3,8 @@
  * Tracks user behavior, team selection, and key conversion events
  */
 
+import Constants from 'expo-constants';
+import { Platform } from 'react-native';
 import { DiscoveryTeam, Team } from '../types';
 
 // Analytics event types
@@ -82,6 +84,12 @@ class Analytics {
   private isEnabled: boolean = true;
   private userId?: string;
   private sessionId: string;
+  private readonly anonymousAllowedEvents = new Set<AnalyticsEvent>([
+    'onboarding_started',
+    'onboarding_step_completed',
+    'onboarding_abandoned',
+    'onboarding_skipped',
+  ]);
 
   constructor() {
     this.sessionId = this.generateSessionId();
@@ -90,6 +98,15 @@ class Analytics {
 
   // Initialize analytics with user context
   initialize(userId: string) {
+    if (!userId) {
+      console.warn('[Analytics] initialize called without userId');
+      return;
+    }
+
+    if (this.userId === userId) {
+      return;
+    }
+
     this.userId = userId;
     console.log('Analytics initialized for user:', userId);
   }
@@ -110,14 +127,21 @@ class Analytics {
       userId: this.userId,
       timestamp: new Date().toISOString(),
       sessionId: this.sessionId,
-      platform: 'ios', // TODO: Get from Platform.OS
-      appVersion: '1.0.0', // TODO: Get from package.json or config
+      platform: Platform.OS === 'android' ? 'android' : 'ios',
+      appVersion: Constants.expoConfig?.version || 'unknown',
     };
   }
 
   // Track generic event
   track(event: AnalyticsEvent, properties?: Record<string, any>) {
     if (!this.isEnabled) return;
+
+    if (!this.userId && !this.anonymousAllowedEvents.has(event)) {
+      console.warn(
+        `[Analytics] Skipping ${event}: analytics.initialize(userId) has not been called yet`
+      );
+      return;
+    }
 
     const eventData = {
       event,


### PR DESCRIPTION
## Summary
Enforce runtime telemetry metadata and require analytics user initialization before user-scoped events emit.

## Changes
- replace hardcoded analytics `platform` and `appVersion` with runtime values (`Platform.OS`, `Constants.expoConfig?.version`)
- add guard to skip user-scoped events when `analytics.initialize(userId)` has not run yet
- bootstrap `analytics.initialize(...)` in `App.tsx` once authentication has a valid user identifier

## Why
Hardcoded telemetry metadata and missing user bootstrap caused inaccurate event attribution and untrustworthy trend counters.

## Risk
Low-medium: user-scoped analytics events are now intentionally dropped until user context is initialized; anonymous onboarding events remain allowed.

## Validation
- ⚠️ `npx eslint src/utils/analytics.ts src/App.tsx` failed because repository uses legacy Expo lint wiring and no local ESLint package in this worktree
- ⚠️ `npx expo lint --max-warnings=0` failed (`Cannot find module 'eslint'`)
- ⚠️ `npx tsc --noEmit` failed (TypeScript compiler not installed in this worktree)

## Rollback
Revert commit `2585a6d` or close this PR and delete branch `bugfix/nostr-h10-runtime-analytics-metadata`.
