### PR TITLE
fix: add missing useEffect cleanup to App subscription to prevent memory leak

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -307,6 +307,11 @@ const AppContent: React.FC<AppContentProps> = ({ onPermissionComplete }) => {
       '[App] 🎯 Initializing AppStateManager - Single source of truth'
     );
     AppStateManager.initialize();
+
+    return () => {
+      console.log('[App] 🧹 Cleaning up AppStateManager listener');
+      AppStateManager.cleanup();
+    };
   }, []);
 
   const [showWelcomeModal, setShowWelcomeModal] = React.useState(false);


### PR DESCRIPTION
## Summary
- add cleanup return to the root AppStateManager initialization effect in \
- call \ on unmount/fast-refresh teardown to prevent stacked AppState listeners
- keep initialization behavior unchanged while ensuring listener lifecycle is bounded

## Why
Without effect cleanup, repeated mounts (including fast refresh/dev reload paths) can accumulate stale AppState listeners and callbacks, risking duplicate foreground handlers and memory growth.

## Risk
Low: isolated lifecycle change in root effect; cleanup method already exists in AppStateManager.

## Validation
- \