### PR TITLE
fix: use runtime analytics metadata and require user init for user-scoped events

### DIFF
--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -3,6 +3,9 @@
  * Tracks user behavior, team selection, and key conversion events
  */
 
+import Constants from 'expo-constants';
+import { Platform } from 'react-native';
+
 import { DiscoveryTeam, Team } from '../types';
 
 // Analytics event types
@@ -90,8 +93,17 @@ class Analytics {
 
   // Initialize analytics with user context
   initialize(userId: string) {
-    this.userId = userId;
-    console.log('Analytics initialized for user:', userId);
+    const normalizedUserId = userId?.trim();
+
+    if (!normalizedUserId) {
+      console.warn(
+        '⚠️ Analytics initialize skipped: userId is required for user-scoped events.'
+      );
+      return;
+    }
+
+    this.userId = normalizedUserId;
+    console.log('Analytics initialized for user:', normalizedUserId);
   }
 
   // Enable/disable analytics
@@ -104,20 +116,44 @@ class Analytics {
     return `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
   }
 
+  private getRuntimePlatform(): BaseAnalyticsProperties['platform'] {
+    return Platform.OS === 'android' ? 'android' : 'ios';
+  }
+
+  private getRuntimeAppVersion(): string | undefined {
+    return Constants.expoConfig?.version;
+  }
+
+  private requiresInitializedUser(event: AnalyticsEvent): boolean {
+    return (
+      event.startsWith('team_') ||
+      event.startsWith('user_') ||
+      event.startsWith('profile_') ||
+      event.startsWith('notification_')
+    );
+  }
+
   // Get base properties for all events
   private getBaseProperties(): BaseAnalyticsProperties {
     return {
       userId: this.userId,
       timestamp: new Date().toISOString(),
       sessionId: this.sessionId,
-      platform: 'ios', // TODO: Get from Platform.OS
-      appVersion: '1.0.0', // TODO: Get from package.json or config
+      platform: this.getRuntimePlatform(),
+      appVersion: this.getRuntimeAppVersion(),
     };
   }
 
   // Track generic event
   track(event: AnalyticsEvent, properties?: Record<string, any>) {
     if (!this.isEnabled) return;
+
+    if (this.requiresInitializedUser(event) && !this.userId) {
+      console.warn(
+        `⚠️ Analytics skipped for "${event}": call analytics.initialize(userId) before user-scoped tracking.`
+      );
+      return;
+    }
 
     const eventData = {
       event,


### PR DESCRIPTION
## Summary
Use runtime analytics metadata and prevent user-scoped analytics events from emitting before analytics.initialize(userId) is called.

## Changes
- derive platform from Platform.OS instead of hardcoded iOS
- derive appVersion from Constants.expoConfig.version instead of hardcoded 1.0.0
- normalize initialize(userId) input and skip empty values
- block user-scoped event emission (team/user/profile/notification) until user context is initialized

## Validation
- npx eslint src/utils/analytics.ts (fails in this isolated worktree because ESLint v10 expects eslint.config.* while repo still uses legacy .eslintrc config)
- git diff --check

## Risk
Low — analytics-only guardrails and metadata source changes; no workout or persistence logic changed.

## Rollback
Revert commit 10db181 or close PR without merge.
