### PR TITLE
fix: install global JS exception handler at app bootstrap

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,45 @@ LogBox.ignoreLogs([
   // Normal Nostr relay responses during connection/query - not errors
   'Error from relay',
 ]);
+
+let globalJsExceptionHandlerInstalled = false;
+
+function installGlobalJsExceptionHandler(): void {
+  if (globalJsExceptionHandlerInstalled) {
+    return;
+  }
+
+  const errorUtils = (globalThis as any)?.ErrorUtils;
+  if (
+    !errorUtils ||
+    typeof errorUtils.getGlobalHandler !== 'function' ||
+    typeof errorUtils.setGlobalHandler !== 'function'
+  ) {
+    console.warn('[App] ErrorUtils global handler unavailable; skipping install');
+    return;
+  }
+
+  const defaultHandler = errorUtils.getGlobalHandler();
+  errorUtils.setGlobalHandler((error: Error, isFatal?: boolean) => {
+    console.error('🚨 Global JS exception captured:', {
+      message: error?.message,
+      isFatal: Boolean(isFatal),
+      stack: error?.stack,
+    });
+
+    if (typeof defaultHandler === 'function') {
+      try {
+        defaultHandler(error, isFatal);
+      } catch (handlerError) {
+        console.error('🚨 Default global error handler failed:', handlerError);
+      }
+    }
+  });
+
+  globalJsExceptionHandlerInstalled = true;
+  console.log('[App] ✅ Installed global JS exception handler');
+}
+
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import * as Linking from 'expo-linking';
 
@@ -1270,6 +1309,8 @@ export default function App() {
   React.useEffect(() => {
     async function prepare() {
       try {
+        installGlobalJsExceptionHandler();
+
         // SENIOR DEVELOPER FIX: Initialize WebSocket polyfill immediately with error handling
         try {
           initializeWebSocketPolyfill();


### PR DESCRIPTION
## Summary
Adds a global JS exception handler during app startup to improve crash visibility for white-screen failures.

## Changes
- install a one-time `ErrorUtils` global handler in `src/App.tsx`
- log fatal/non-fatal metadata and stack when uncaught JS exceptions occur
- forward exceptions to the default React Native global handler to preserve current behavior

## Risk
Low — additive handler wiring and logging only; no business logic or navigation behavior changes.

## Validation
- `git diff --check`
- `rg -n "installGlobalJsExceptionHandler|setGlobalHandler|Global JS exception captured" src/App.tsx`
- `npm run typecheck` *(blocked in run workspace: `tsc` binary not available)*
