### PR TITLE
Fix WorkoutHistory navigation lookup in nested navigator tree

### DIFF
--- a/src/components/profile/YourCompetitionsBox.tsx
+++ b/src/components/profile/YourCompetitionsBox.tsx
@@ -16,13 +16,26 @@ export const FitnessHistoryBox: React.FC = () => {
 
   const handlePress = () => {
     // Navigate to WorkoutHistory screen (workout history/stats)
-    // Use parent navigator since WorkoutHistory is in the stack, not the tab navigator
-    const parentNav = navigation.getParent();
-    if (parentNav) {
-      parentNav.navigate('WorkoutHistory');
-    } else {
-      navigation.navigate('WorkoutHistory');
+    // Walk up the full navigator chain and navigate from the first navigator
+    // that actually owns the WorkoutHistory route.
+    let currentNav: any = navigation;
+
+    while (currentNav) {
+      const routeNames = currentNav.getState?.()?.routeNames;
+      if (
+        Array.isArray(routeNames) &&
+        routeNames.includes('WorkoutHistory')
+      ) {
+        currentNav.navigate('WorkoutHistory');
+        return;
+      }
+
+      currentNav = currentNav.getParent?.();
     }
+
+    console.warn(
+      '[FitnessHistoryBox] WorkoutHistory route not found in navigator chain'
+    );
   };
 
   return (


### PR DESCRIPTION
## Summary\n- update FitnessHistoryBox to walk up the navigator chain before dispatching WorkoutHistory navigation\n- navigate from the first navigator that actually owns the WorkoutHistory route\n- emit a warning instead of dispatching to the wrong navigator when route lookup fails\n\n## Why\nIssue #66 reports failure when tapping **View History** on iOS. The old logic assumed one-level parent ownership, which can fail in deeper nesting and trigger unhandled navigation actions.\n\n## Validation\n- git diff --check\n- npm run typecheck *(fails in automation workspace: )*\n\n## Risk\nLow — change is isolated to one button handler and only affects route resolution path for WorkoutHistory navigation.\n\nRefs #66