### PR TITLE
Fix Fitness Test 'View Test History' button navigation

### DIFF
--- a/src/screens/FitnessTestResultsScreen.tsx
+++ b/src/screens/FitnessTestResultsScreen.tsx
@@ -124,8 +124,9 @@ export const FitnessTestResultsScreen: React.FC = () => {
   };
 
   const handleViewHistory = () => {
-    // TODO: Navigate to test history screen
-    console.log('View test history');
+    // Fitness test history is surfaced within WorkoutHistory for now.
+    // Use root stack route instead of a no-op so users can actually access history.
+    (navigation as any).navigate('WorkoutHistory');
   };
 
   const formatTime = (seconds: number): string => {


### PR DESCRIPTION
## Summary
Wire the **View Test History** button in `FitnessTestResultsScreen` to navigate to `WorkoutHistory` instead of logging a TODO no-op.

## Why
Users currently tap the button and nothing happens, which blocks access to history from the test results flow.

## Changes
- Replace TODO console log in `handleViewHistory` with stack navigation to `WorkoutHistory`
- Keep patch single-file and low-risk

## Validation
- `git diff --check` ✅
- `rg -n "handleViewHistory|navigate\('WorkoutHistory'\)|View test history" src/screens/FitnessTestResultsScreen.tsx` ✅
- `npm run typecheck` ⚠️ blocked in run workspace (`tsc: command not found`)
