### PR TITLE
docs: align relay/runtime truth in architecture guides

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,7 +42,7 @@ AsyncStorage: nsec/npub present?
   v                     v
 LoginScreen         AppInitialization
   |                     |
-  v                     +---> GlobalNDKService.initialize()  (4 relay connections)
+  v                     +---> GlobalNDKService.initialize()  (3 active default relay connections)
 Enter nsec              +---> Load profile from cache/Nostr  (kind 0)
   |                     +---> Prefetch charity list, competitions
   v                     +---> Start step counter
@@ -178,11 +178,10 @@ Services are organized by domain under `src/services/`. Each service is a single
 ```
 GlobalNDKService (SINGLETON - one NDK instance for entire app)
   |
-  |  4 WebSocket connections to relays:
+  |  3 WebSocket connections to default relays:
   |    wss://relay.damus.io
   |    wss://nos.lol
   |    wss://relay.primal.net
-  |    wss://relay.nostr.band
   |
   +---> NostrProfileService        (fetch/publish kind 0 profiles)
   +---> NostrProfilePublisher      (update profile metadata)
@@ -761,7 +760,7 @@ runstr.project/
 |   |   +-- nostr/                 GlobalNDKService, profiles, publishing
 |   |   +-- fitness/               Workout storage, health integrations
 |   |   +-- activity/              GPS tracking, step counting, metrics
-|   |   +-- rewards/               Daily rewards, step rewards, Lightning
+|   |   +-- rewards/               Daily rewards, paused step-reward pipeline, Lightning
 |   |   +-- competition/           Leaderboards, Supabase competition ops
 |   |   +-- backend/               Supabase operations
 |   |   +-- backup/                Encrypted backup (kind 30078, NIP-44)
@@ -829,14 +828,14 @@ runstr.project/
 ## Architectural Principles
 
 1. **File size limit: 500 lines** -- Split anything larger into focused modules
-2. **Global NDK singleton** -- One NDK instance, 4 relay connections, used everywhere
+2. **Global NDK singleton** -- One NDK instance, 3 active default relay connections, used everywhere
 3. **Local-first** -- Save to AsyncStorage immediately, sync to backend in background
 4. **Cache-first rendering** -- Show cached data instantly, refresh in background
 5. **Silent reward failures** -- Rewards never block workout saving or user flow
 6. **Cardio focus** -- Running, walking, cycling are core; strength/diet/meditation are experimental
 7. **Teams = Charities** -- Not social groups; selecting a team means supporting a charity. Charities are hardcoded in `constants/charities.ts`
 8. **Supabase for competitions** -- Nostr for identity/social/backup, Supabase for leaderboards/payments
-9. **NDK only** -- Never use nostr-tools; NDK handles all Nostr operations
+9. **NDK-first runtime** -- Global NDK is the required relay/query backbone; `nostr-tools` still exists in helper/legacy paths, but avoid adding new non-NDK runtime relay flows
 10. **Optimistic updates** -- Update local state before backend confirms, for instant UX
 
 ## Supported Charities

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,9 +66,9 @@ RUNSTR is an anonymous fitness tracker that rewards cardio workouts with Bitcoin
 - **Event Participation**: Supabase database for joining events and leaderboards
 - **Authentication**: Nostr (nsec) - direct authentication only
 - **Rewards**: Lightning address via LNURL protocol
-- **Nostr Library**: NDK (@nostr-dev-kit/ndk) EXCLUSIVELY - NEVER use nostr-tools
+- **Nostr Library**: NDK (`@nostr-dev-kit/ndk`) is the runtime relay/publish backbone; `nostr-tools` is still used in legacy/helper paths during migration
 - **Global NDK Instance**: Single shared NDK instance via `GlobalNDKService`
-- **Nostr Relays**: Damus, Primal, nos.lol, Nostr.band (4 relays)
+- **Nostr Relays**: Damus, nos.lol, Primal (3 active default relays in `GlobalNDKService`)
 
 ## Nostr Event Kinds
 
@@ -157,7 +157,7 @@ Workouts include tags for:
 **CRITICAL: The app uses a single global NDK instance for all Nostr operations**
 
 **Why Global NDK?**
-- **Prevents Connection Explosion**: Before global NDK, 9 services × 4 relays = 36 WebSocket connections. After: 1 NDK × 4 relays = 4 connections (90% reduction)
+- **Prevents Connection Explosion**: Before global NDK, 9 services × 3 relays = 27 WebSocket connections. After: 1 NDK × 3 relays = 3 connections (89% reduction)
 - **Eliminates Timing Issues**: New relay managers need 2-3 seconds to connect, causing "No connected relays available" errors
 - **Better Performance**: Reusing one connection pool instead of creating/destroying connections per query
 - **Connection Stability**: Single instance maintains persistent relay connections throughout app lifetime
@@ -179,7 +179,7 @@ const events = await ndk.fetchEvents(filter);
 - ✅ **USE** `ndk.subscribe()` for real-time subscriptions (returns subscription object)
 
 **Global NDK Configuration:**
-- **Default Relays**: `wss://relay.damus.io`, `wss://relay.primal.net`, `wss://nos.lol`, `wss://relay.nostr.band`
+- **Default Relays**: `wss://relay.damus.io`, `wss://nos.lol`, `wss://relay.primal.net`
 - **Initialized**: On app startup by `GlobalNDKService`
 - **Connection Timeout**: 2 seconds
 - **Auto-reconnect**: Built into NDK
@@ -611,7 +611,7 @@ All work happens on a **version branch** (e.g., `v1.6.8`). This is the next rele
 ✅ Kind 1301 workout publishing
 ✅ Kind 1 social posts with achievement cards
 ✅ Daily rewards (50 sats/workout)
-✅ Step rewards (5 sats/1k steps)
+⚠️ Step rewards pipeline exists but UI/runtime exposure is currently paused in Settings
 ✅ Lightning address reward delivery via LNURL
 ✅ Teams = Charities with donation splitting
 ✅ Impact Level XP system


### PR DESCRIPTION
## Summary
Align architecture guidance with current runtime reality so docs stop contradicting code.

## Changes
- Update `CLAUDE.md` to reflect 3 active default relays in `GlobalNDKService`
- Replace absolute "NDK-only everywhere" wording with accurate NDK-first runtime guidance during migration
- Mark step-reward status as currently paused in settings/runtime-facing UI docs
- Mirror same truth updates in `ARCHITECTURE.md`

## Validation
- `rg -n "DEFAULT_RELAYS" src/services/nostr/GlobalNDKService.ts` confirms 3 default relays
- `rg -n "const STEP_REWARDS_ENABLED = false" src/screens/SettingsScreen.tsx` confirms paused UI exposure
- `rg -n "from 'nostr-tools'" src | wc -l` confirms active legacy/helper usage remains

## Risk
Low (docs-only; no runtime code changes).

## Rollback
Revert commit `2c9b0d4` on this branch.
