### PR TITLE
fix: align CompetitionEvent type with parsed Nostr fields

### DIFF
--- a/src/services/competition/SimpleCompetitionService.ts
+++ b/src/services/competition/SimpleCompetitionService.ts
@@ -27,9 +27,11 @@ export interface CompetitionEvent {
   id: string; // d tag
   teamId: string;
   captainPubkey: string;
+  pubkey?: string; // Raw Nostr event pubkey (backwards-compat lookups)
   name: string;
   description?: string;
   activityType: string;
+  location?: string;
   scoringType?: string; // NEW: 'completion' | 'fastest_time'
   metric: string; // Deprecated: Use scoringType instead
   eventDate: string; // ISO date


### PR DESCRIPTION
## Summary
SimpleCompetitionService parses and returns `pubkey` and `location` on competition events, but `CompetitionEvent` did not declare those fields. This triggered an avoidable TypeScript object-shape error in targeted checks.

## Changes
- Added optional `pubkey?: string` to `CompetitionEvent`
- Added optional `location?: string` to `CompetitionEvent`

## Validation
- `npx tsc --noEmit --pretty false src/services/competition/SimpleCompetitionService.ts 2>&1 | rg -n "CompetitionEvent|location|pubkey"`
- Result: no `CompetitionEvent` object-literal field errors remain for `pubkey`/`location` (repo still has unrelated baseline type errors).

## Risk
Low — type-only interface alignment, no runtime behavior changes.

## Rollback
Revert commit `92534e7`.
