### PR TITLE
docs: align route services README with implemented files

### DIFF
--- a/src/services/routes/README.md
+++ b/src/services/routes/README.md
@@ -1,8 +1,8 @@
 # Route Services
 
-Services for managing GPS routes and course comparison functionality.
+Services for managing saved GPS routes and related route tooling.
 
-## Files
+## Active Files
 
 ### `RouteStorageService.ts`
 Persistent storage service for saved GPS routes. Allows users to:
@@ -51,54 +51,22 @@ await routeStorage.updateRouteStats(routeId, {
 });
 ```
 
-### `RouteMatchingService.ts`
-GPS-based route comparison and matching service. Provides:
-- **Automatic Route Detection**: Matches current workout GPS track against saved routes
-- **Fuzzy GPS Matching**: Handles GPS drift with 50m distance threshold
-- **Confidence Scoring**: 0-1 score based on match percentage and points matched
-- **PR Comparison**: Real-time progress tracking vs personal record
-- **Progress Messages**: User-friendly "ahead/behind PR" feedback
-- **Target Pace Calculation**: Recommended pace to match PR time
-
-**Key Features:**
-- Haversine formula for accurate GPS distance calculation
-- Sequential point matching with expected index optimization
-- Minimum 70% match threshold to prevent false positives
-- Requires 10+ GPS points before attempting match
-- Activity-type filtering (only matches same activity)
-
-**Usage:**
-```typescript
-import routeMatchingService from '../services/routes/RouteMatchingService';
-
-// During workout: Check if we're on a saved route
-const match = await routeMatchingService.findMatchingRoute(
-  gpsPoints,
-  'running'
-);
-
-if (match && match.confidence > 0.8) {
-  console.log(`On route: ${match.routeName} (${match.matchPercentage}% match)`);
-
-  // Compare with PR
-  const comparison = await routeMatchingService.compareWithPR(
-    match.routeId,
-    currentDistance,
-    currentTime
-  );
-
-  if (comparison) {
-    const message = routeMatchingService.formatProgressMessage(comparison);
-    // Show: "🔥 1:30 ahead of PR!" or "💪 0:45 behind PR - push harder!"
-  }
-}
-```
-
 ## Planned Files
 
+### `RouteMatchingService.ts` (Future)
+GPS-based route comparison and matching service (not currently in this directory):
+- Automatic route detection against saved routes
+- Fuzzy GPS matching with drift tolerance
+- Confidence scoring and PR progress comparison
+- User-facing pace/progress feedback
+
 ### `RouteSimplificationService.ts` (Future)
-GPS track optimization. Will reduce storage size by:
-- Douglas-Peucker algorithm for coordinate simplification
-- Removes redundant GPS points while preserving route shape
-- Configurable precision levels (high/medium/low)
-- Reduces storage usage by 60-80% without visual quality loss
+GPS track optimization service (not currently in this directory):
+- Douglas-Peucker coordinate simplification
+- Redundant point removal while preserving route shape
+- Configurable precision levels
+- Storage reduction without major visual quality loss
+
+## Maintenance Note
+
+Keep this README aligned with files that actually exist in `src/services/routes/` to prevent audit/onboarding drift.


### PR DESCRIPTION
## Summary
- move `RouteMatchingService.ts` from active files to planned services
- clarify that route matching/simplification services are future work and not currently in `src/services/routes/`
- add a maintenance note to keep the README file index aligned with real directory contents

## Why
`src/services/routes/README.md` described `RouteMatchingService.ts` as an active file even though only `RouteStorageService.ts` currently exists, which caused onboarding and audit drift.

## Validation
- `test -f src/services/routes/RouteStorageService.ts`
- `! test -f src/services/routes/RouteMatchingService.ts`
- `! test -f src/services/routes/RouteSimplificationService.ts`
