### PR TITLE
docs: correct team README testing reference

### DIFF
--- a/src/services/team/README.md
+++ b/src/services/team/README.md
@@ -51,4 +51,9 @@ const teams = await ndkService.discoverAllTeams();
 
 ## Testing
 
-Use `test-ndk-team-discovery.js` in the project root to verify performance and coverage.
+Use `__tests__/teamDiscovery.test.tsx` to verify team discovery coverage and behavior.
+
+Example:
+```bash
+npm test -- teamDiscovery.test.tsx
+```


### PR DESCRIPTION
## Summary
Fixes an outdated testing reference in `src/services/team/README.md` so contributors can run an existing team discovery test file.

## Changes
- Replaced stale `test-ndk-team-discovery.js` mention with `__tests__/teamDiscovery.test.tsx`
- Added an example Jest command: `npm test -- teamDiscovery.test.tsx`

## Why
The previous README pointed to a non-existent script, which causes confusion during onboarding and audit runs.

## Risk
Low (documentation-only change).

## Validation
- `test -f __tests__/teamDiscovery.test.tsx`
- `grep -q '__tests__/teamDiscovery.test.tsx' src/services/team/README.md`
- Confirmed removed stale `test-ndk-team-discovery.js` reference
