### PR TITLE
docs(auth): align Amber signer paths in auth README

### DIFF
--- a/src/services/auth/README.md
+++ b/src/services/auth/README.md
@@ -16,8 +16,8 @@ Authentication services, secure key storage, and signing providers for RUNSTR us
 
 ### amber/
 
-- **AmberNDKSigner.ts** - NDK Signer implementation that delegates all signing to the Amber app on Android. Private keys never leave Amber.
-- **__tests__/AmberNDKSigner.test.ts** - Unit tests for the AmberNDKSigner.
+- **amber/AmberNDKSigner.ts** - NDK Signer implementation that delegates all signing to the Amber app on Android. Private keys never leave Amber.
+- **amber/__tests__/AmberNDKSigner.test.ts** - Unit tests for the AmberNDKSigner.
 
 ### providers/
 


### PR DESCRIPTION
## Summary\nFixes stale file references in \ so the Amber signer paths match the actual directory structure.\n\n## Changes\n- Update \ reference to \\n- Update unit-test reference to \\n\n## Validation\n- Verified both referenced files exist under \\n\n## Risk\nLow (docs-only change).\n