### PR TITLE
feat(tracker): honor default activity on tracker entry

### DIFF
--- a/__tests__/ActivityGridService.test.ts
+++ b/__tests__/ActivityGridService.test.ts
@@ -1,0 +1,27 @@
+import { activityGridService } from '../src/services/activity/ActivityGridService';
+
+describe('ActivityGridService helpers', () => {
+  it('maps cardio activity keys to grid positions', () => {
+    expect(activityGridService.getPositionForActivity('run')).toEqual({ row: 0, column: 0 });
+    expect(activityGridService.getPositionForActivity('walk')).toEqual({ row: 0, column: 1 });
+    expect(activityGridService.getPositionForActivity('cycle')).toEqual({ row: 0, column: 2 });
+    expect(activityGridService.getPositionForActivity('hiking')).toEqual({ row: 0, column: 3 });
+  });
+
+  it('returns null for unknown activity keys', () => {
+    expect(activityGridService.getPositionForActivity('unknown')).toBeNull();
+  });
+
+  it('validates in-bounds positions', () => {
+    expect(activityGridService.isPositionValid({ row: 1, column: 2 })).toBe(true);
+    expect(activityGridService.isPositionValid({ row: 3, column: 1 })).toBe(true);
+  });
+
+  it('invalidates malformed or out-of-bounds positions', () => {
+    expect(activityGridService.isPositionValid(null)).toBe(false);
+    expect(activityGridService.isPositionValid({ row: -1, column: 0 })).toBe(false);
+    expect(activityGridService.isPositionValid({ row: 0, column: 6 })).toBe(false);
+    expect(activityGridService.isPositionValid({ row: 0.5, column: 0 })).toBe(false);
+    expect(activityGridService.isPositionValid({ row: 0, column: '1' as unknown as number })).toBe(false);
+  });
+});

--- a/src/screens/activity/ActivityTrackerScreen.tsx
+++ b/src/screens/activity/ActivityTrackerScreen.tsx
@@ -23,6 +23,7 @@ import {
   activityGridService,
   type GridPosition,
 } from '../../services/activity/ActivityGridService';
+import { defaultActivityService } from '../../services/activity/DefaultActivityService';
 import { RunningTrackerScreen } from './RunningTrackerScreen';
 import { WalkingTrackerScreen } from './WalkingTrackerScreen';
 import { CyclingTrackerScreen } from './CyclingTrackerScreen';
@@ -80,9 +81,20 @@ export const ActivityTrackerScreen: React.FC = () => {
   useEffect(() => {
     const loadPosition = async () => {
       const saved = await activityGridService.loadPosition();
-      setGridPosition(saved);
+      let initialPosition = saved;
+
+      // Apply saved default activity for cardio trackers on entry.
+      const defaultActivity = await defaultActivityService.getSavedDefault();
+      if (defaultActivity) {
+        const defaultPosition = activityGridService.getPositionForActivity(defaultActivity);
+        if (defaultPosition && defaultPosition.row === 0) {
+          initialPosition = defaultPosition;
+        }
+      }
+
+      setGridPosition(initialPosition);
       setPositionLoaded(true);
-      console.log('[ActivityTracker] Loaded grid position:', saved);
+      console.log('[ActivityTracker] Loaded grid position:', initialPosition);
     };
     loadPosition();
   }, []);

--- a/src/services/activity/ActivityGridService.ts
+++ b/src/services/activity/ActivityGridService.ts
@@ -99,13 +99,57 @@ export class ActivityGridService {
    * Get current category and activity from grid position
    */
   getActivityAt(position: GridPosition): { category: CategoryRow; activity: string } {
-    const row = Math.max(0, Math.min(position.row, ACTIVITY_GRID.length - 1));
+    const safePosition = this.isPositionValid(position)
+      ? position
+      : { row: 0, column: 0 };
+    const row = Math.max(0, Math.min(safePosition.row, ACTIVITY_GRID.length - 1));
     const category = ACTIVITY_GRID[row];
-    const column = Math.max(0, Math.min(position.column, category.activities.length - 1));
+    const column = Math.max(0, Math.min(safePosition.column, category.activities.length - 1));
     return {
       category,
       activity: category.activities[column],
     };
+  }
+
+  /**
+   * Resolve an activity key to its grid coordinates
+   */
+  getPositionForActivity(activity: string): GridPosition | null {
+    if (typeof activity !== 'string') {
+      return null;
+    }
+    for (let row = 0; row < ACTIVITY_GRID.length; row++) {
+      const column = ACTIVITY_GRID[row].activities.indexOf(activity);
+      if (column !== -1) {
+        return { row, column };
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Validate whether a grid position exists within the current activity matrix
+   */
+  isPositionValid(position: unknown): position is GridPosition {
+    if (!position || typeof position !== 'object') {
+      return false;
+    }
+    const candidate = position as Partial<GridPosition>;
+    if (
+      typeof candidate.row !== 'number' ||
+      typeof candidate.column !== 'number' ||
+      !Number.isInteger(candidate.row) ||
+      !Number.isInteger(candidate.column)
+    ) {
+      return false;
+    }
+
+    const inRowBounds = candidate.row >= 0 && candidate.row < ACTIVITY_GRID.length;
+    if (!inRowBounds) {
+      return false;
+    }
+    const rowActivities = ACTIVITY_GRID[candidate.row].activities;
+    return candidate.column >= 0 && candidate.column < rowActivities.length;
   }
 
   /**
@@ -119,18 +163,27 @@ export class ActivityGridService {
    * Navigate left (next activity in row, with wrap)
    */
   navigateLeft(position: GridPosition): GridPosition {
-    const category = ACTIVITY_GRID[position.row];
-    const newColumn = (position.column + 1) % category.activities.length;
-    return { row: position.row, column: newColumn };
+    const safePosition = this.isPositionValid(position)
+      ? position
+      : { row: 0, column: 0 };
+    const { row, column } = safePosition;
+    const category = ACTIVITY_GRID[row];
+    const newColumn = (column + 1) % category.activities.length;
+    return { row, column: newColumn };
   }
 
   /**
    * Navigate right (previous activity in row, with wrap)
    */
   navigateRight(position: GridPosition): GridPosition {
-    const category = ACTIVITY_GRID[position.row];
-    const newColumn = (position.column - 1 + category.activities.length) % category.activities.length;
-    return { row: position.row, column: newColumn };
+    const safePosition = this.isPositionValid(position)
+      ? position
+      : { row: 0, column: 0 };
+    const { row, column } = safePosition;
+    const category = ACTIVITY_GRID[row];
+    const newColumn =
+      (column - 1 + category.activities.length) % category.activities.length;
+    return { row, column: newColumn };
   }
 
   /**
@@ -138,6 +191,9 @@ export class ActivityGridService {
    * Returns null if already at bottom category
    */
   navigateUp(position: GridPosition): GridPosition | null {
+    if (!this.isPositionValid(position)) {
+      return { row: 0, column: 0 };
+    }
     if (position.row >= ACTIVITY_GRID.length - 1) {
       return null; // Already at bottom category (Wellness)
     }
@@ -149,6 +205,9 @@ export class ActivityGridService {
    * Returns null if already at top category
    */
   navigateDown(position: GridPosition): GridPosition | null {
+    if (!this.isPositionValid(position)) {
+      return { row: 0, column: 0 };
+    }
     if (position.row <= 0) {
       return null; // Already at top category (Cardio)
     }
@@ -176,18 +235,9 @@ export class ActivityGridService {
       const stored = await AsyncStorage.getItem(STORAGE_KEY);
       if (stored) {
         const position = JSON.parse(stored) as GridPosition;
-        // Validate position is within bounds
-        if (
-          typeof position.row === 'number' &&
-          typeof position.column === 'number' &&
-          position.row >= 0 &&
-          position.row < ACTIVITY_GRID.length
-        ) {
-          const category = ACTIVITY_GRID[position.row];
-          if (position.column >= 0 && position.column < category.activities.length) {
-            console.log('[ActivityGridService] Loaded position:', position);
-            return position;
-          }
+        if (this.isPositionValid(position)) {
+          console.log('[ActivityGridService] Loaded position:', position);
+          return position;
         }
       }
     } catch (error) {

--- a/src/services/activity/DefaultActivityService.ts
+++ b/src/services/activity/DefaultActivityService.ts
@@ -35,16 +35,25 @@ export class DefaultActivityService {
    * Returns 'run' if no preference is saved
    */
   async getDefault(): Promise<DefaultActivity> {
+    const savedDefault = await this.getSavedDefault();
+    return savedDefault ?? 'run';
+  }
+
+  /**
+   * Get the user's saved default preference without fallback.
+   * Returns null if missing or invalid.
+   */
+  async getSavedDefault(): Promise<DefaultActivity | null> {
     try {
       const stored = await AsyncStorage.getItem(STORAGE_KEY);
       if (stored && this.isValidActivity(stored)) {
         console.log('[DefaultActivityService] Loaded default activity:', stored);
         return stored as DefaultActivity;
       }
-      return 'run';
+      return null;
     } catch (error) {
       console.error('[DefaultActivityService] Error loading default activity:', error);
-      return 'run';
+      return null;
     }
   }
 


### PR DESCRIPTION
## Summary
- apply saved default activity (run/walk/cycle/hiking) on Activity Tracker entry
- add `ActivityGridService` helpers to map activity keys to grid positions and validate positions
- harden grid navigation/restore paths with shared position validation
- add focused unit tests for new grid helper behavior

## Why
The tracker settings already let users choose a default activity, but entry flow did not reliably honor it. This PR wires that preference into the tracker entry flow while preserving saved-position fallback behavior.

## Testing
- Added `__tests__/ActivityGridService.test.ts` for mapping and position validation helpers
- Could not run Jest locally in this worktree because required Babel preset deps are not available in this isolated checkout (`Cannot find module '@babel/preset-env'`)
