### PR TITLE
feat(tracker): add reward routing audit tags on autosubmit

### DIFF
--- a/scripts/verify/verify-autosubmit-tags.ts
+++ b/scripts/verify/verify-autosubmit-tags.ts
@@ -26,6 +26,12 @@ interface MockWorkout {
   steps?: number;
 }
 
+interface MockRewardDestination {
+  isPPQ: boolean;
+  isCharity: boolean;
+  charityId: string;
+}
+
 function buildWorkoutTags(workout: MockWorkout): string[][] {
   const tags: string[][] = [];
   tags.push(['exercise', workout.type]);
@@ -47,6 +53,25 @@ function buildWorkoutTags(workout: MockWorkout): string[][] {
   if (workout.steps) {
     tags.push(['steps', workout.steps.toString()]);
     tags.push(['source', 'auto_steps']);
+  }
+
+  return tags;
+}
+
+function appendRewardDestinationTags(
+  tags: string[][],
+  destination: MockRewardDestination
+): string[][] {
+  if (destination.isPPQ) {
+    tags.push(['reward_destination', 'ppq']);
+  } else if (destination.isCharity) {
+    tags.push(['reward_destination', 'charity']);
+  } else {
+    tags.push(['reward_destination', 'user']);
+  }
+
+  if (destination.charityId) {
+    tags.push(['reward_charity_id', destination.charityId]);
   }
 
   return tags;
@@ -122,6 +147,32 @@ const stepWorkout: MockWorkout = {
 const stepTags = buildWorkoutTags(stepWorkout);
 assert('has steps tag', stepTags.some(t => t[0] === 'steps' && t[1] === '5000'));
 assert('has source auto_steps tag', stepTags.some(t => t[0] === 'source' && t[1] === 'auto_steps'));
+
+console.log('\n=== reward destination tag tests ===');
+const baseTags: string[][] = [['exercise', 'running']];
+
+const userDest = appendRewardDestinationTags([...baseTags], {
+  isPPQ: false,
+  isCharity: false,
+  charityId: 'runstr',
+});
+assert('user destination tag present', userDest.some(t => t[0] === 'reward_destination' && t[1] === 'user'));
+assert('charity id tag present for user fallback context', userDest.some(t => t[0] === 'reward_charity_id' && t[1] === 'runstr'));
+
+const charityDest = appendRewardDestinationTags([...baseTags], {
+  isPPQ: false,
+  isCharity: true,
+  charityId: 'hrf',
+});
+assert('charity destination tag present', charityDest.some(t => t[0] === 'reward_destination' && t[1] === 'charity'));
+assert('charity id tag present', charityDest.some(t => t[0] === 'reward_charity_id' && t[1] === 'hrf'));
+
+const ppqDest = appendRewardDestinationTags([...baseTags], {
+  isPPQ: true,
+  isCharity: false,
+  charityId: 'ppq_ai',
+});
+assert('ppq destination tag present', ppqDest.some(t => t[0] === 'reward_destination' && t[1] === 'ppq'));
 
 console.log(`\n=== Results: ${passed} passed, ${failed} failed ===\n`);
 process.exit(failed > 0 ? 1 : 0);

--- a/src/services/fitness/LocalWorkoutStorageService.ts
+++ b/src/services/fitness/LocalWorkoutStorageService.ts
@@ -8,6 +8,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { WorkoutType } from '../../types/workout';
 import type { Split } from '../activity/SplitTrackingService';
 import { DailyRewardService } from '../rewards/DailyRewardService';
+import { RewardDestinationService } from '../rewards/RewardDestinationService';
 import { SupabaseCompetitionService } from '../backend/SupabaseCompetitionService';
 import Toast from 'react-native-toast-message';
 
@@ -592,6 +593,29 @@ export class LocalWorkoutStorageService {
   }
 
   /**
+   * Add reward-routing audit tags without leaking user Lightning addresses.
+   */
+  private async appendRewardDestinationTags(tags: string[][]): Promise<void> {
+    try {
+      const destination = await RewardDestinationService.getDestinationAddress();
+
+      if (destination.isPPQ) {
+        tags.push(['reward_destination', 'ppq']);
+      } else if (destination.isCharity) {
+        tags.push(['reward_destination', 'charity']);
+      } else {
+        tags.push(['reward_destination', 'user']);
+      }
+
+      if (destination.charityId) {
+        tags.push(['reward_charity_id', destination.charityId]);
+      }
+    } catch (error) {
+      console.warn('[LocalWorkoutStorage] Failed to add reward destination tags:', error);
+    }
+  }
+
+  /**
    * Auto-submit cardio workouts to Supabase for leaderboard tracking.
    * Fire-and-forget — errors are logged, never block the save path.
    */
@@ -614,6 +638,9 @@ export class LocalWorkoutStorageService {
       if (selectedTeamId) {
         tags.push(['team', selectedTeamId]);
       }
+
+      // Include reward routing audit tags (user/charity/ppq)
+      await this.appendRewardDestinationTags(tags);
 
       // Get profile for leaderboard display
       const profile = await this.getCachedProfile();
@@ -708,6 +735,8 @@ export class LocalWorkoutStorageService {
       if (selectedTeamId) {
         tags.push(['team', selectedTeamId]);
       }
+
+      await this.appendRewardDestinationTags(tags);
 
       const profile = await this.getCachedProfile();
 


### PR DESCRIPTION
## Summary
- add reward-routing audit tags to workout autosubmit payloads
- include `reward_destination` (`user|charity|ppq`) and `reward_charity_id`
- apply tags in both normal autosubmit and retry submission paths
- extend `scripts/verify/verify-autosubmit-tags.ts` with reward-tag test cases

## Why
Core workflow requires confidence that rewards are routed to the intended destination. This PR adds non-sensitive metadata to submitted workout events so backend analysis/audits can verify reward routing decisions without exposing user Lightning addresses.

## Validation
- `npx tsx scripts/verify/verify-autosubmit-tags.ts`
  - Result: 23 passed, 0 failed
