### PR TITLE
test: remove stale BackgroundLocationTask mock from distance freeze suite

### DIFF
--- a/src/services/activity/__tests__/DistanceFreezeTest.test.ts
+++ b/src/services/activity/__tests__/DistanceFreezeTest.test.ts
@@ -37,14 +37,6 @@ jest.mock('expo-keep-awake', () => ({
   deactivateKeepAwake: jest.fn(),
 }));
 
-jest.mock('../BackgroundLocationTask', () => ({
-  startBackgroundLocationTracking: jest.fn(() => Promise.resolve()),
-  stopBackgroundLocationTracking: jest.fn(() => Promise.resolve()),
-  pauseBackgroundTracking: jest.fn(() => Promise.resolve()),
-  resumeBackgroundTracking: jest.fn(() => Promise.resolve()),
-  getAndClearBackgroundLocations: jest.fn(() => Promise.resolve([])),
-}));
-
 // Type definitions
 type DistanceUpdate = {
   timestamp: number;


### PR DESCRIPTION
## Summary
- remove stale mock of deleted BackgroundLocationTask module from DistanceFreezeTest
- unblock suite startup so freeze-regression assertions execute again

## Validation
- npx jest src/services/activity/__tests__/DistanceFreezeTest.test.ts --runInBand
- npx eslint src/services/activity/__tests__/DistanceFreezeTest.test.ts