### PR TITLE
refactor: remove RewardsScreen error color fallback literal

### DIFF
--- a/src/screens/RewardsScreen.tsx
+++ b/src/screens/RewardsScreen.tsx
@@ -709,7 +709,7 @@ const styles = StyleSheet.create({
     color: theme.colors.text,
   },
   lightningAddressInputError: {
-    borderColor: theme.colors.error || '#ff4444',
+    borderColor: theme.colors.error,
   },
   lightningAddressSaveButton: {
     backgroundColor: theme.colors.accent,
@@ -725,7 +725,7 @@ const styles = StyleSheet.create({
     opacity: 0.6,
   },
   lightningAddressError: {
-    color: theme.colors.error || '#ff4444',
+    color: theme.colors.error,
     fontSize: 12,
     marginTop: 6,
   },


### PR DESCRIPTION
## Summary
Remove hardcoded  fallback usage from RewardsScreen error styles and rely on semantic theme token only.

## Changes
- replace  with  for lightning address input error border
- replace  with  for lightning address error text

## Validation
-  (no matches)
- 
/Users/larry/RUNSTR/src/screens/RewardsScreen.tsx
   16:10  warning  'SafeAreaView' is defined but never used                     @typescript-eslint/no-unused-vars
   58:10  warning  'hasNWC' is assigned a value but never used                  @typescript-eslint/no-unused-vars
  105:22  warning  'setAlertTitle' is assigned a value but never used           @typescript-eslint/no-unused-vars
  106:24  warning  'setAlertMessage' is assigned a value but never used         @typescript-eslint/no-unused-vars
  107:24  warning  'setAlertButtons' is assigned a value but never used         @typescript-eslint/no-unused-vars
  108:5   warning  Array type using 'Array<T>' is forbidden. Use 'T[]' instead  @typescript-eslint/array-type

✖ 6 problems (0 errors, 6 warnings)
  0 errors and 1 warning potentially fixable with the `--fix` option. (0 errors; pre-existing warnings only)

## Risk
Low — style-token alignment only in one screen.
