### PR TITLE
cleanup: remove RewardsScreen error-color fallback literals

### DIFF
--- a/src/screens/RewardsScreen.tsx
+++ b/src/screens/RewardsScreen.tsx
@@ -709,7 +709,7 @@ const styles = StyleSheet.create({
     color: theme.colors.text,
   },
   lightningAddressInputError: {
-    borderColor: theme.colors.error || '#ff4444',
+    borderColor: theme.colors.error,
   },
   lightningAddressSaveButton: {
     backgroundColor: theme.colors.accent,
@@ -725,7 +725,7 @@ const styles = StyleSheet.create({
     opacity: 0.6,
   },
   lightningAddressError: {
-    color: theme.colors.error || '#ff4444',
+    color: theme.colors.error,
     fontSize: 12,
     marginTop: 6,
   },


### PR DESCRIPTION
## Summary
Removes two hardcoded `'#ff4444'` fallback literals in `RewardsScreen` so error styles consistently use semantic theme tokens.

## Changes
- `lightningAddressInputError.borderColor`: `theme.colors.error || '#ff4444'` → `theme.colors.error`
- `lightningAddressError.color`: `theme.colors.error || '#ff4444'` → `theme.colors.error`

## Validation
- `rg -n "theme\.colors\.error\s*\|\|\s*'#ff4444'" src/screens/RewardsScreen.tsx` → no matches
- `./node_modules/.bin/eslint src/screens/RewardsScreen.tsx` → 0 errors (pre-existing warnings only)

## Risk
Low — style-token alignment only; no behavioral logic changes.

## Rollback
Revert commit `36bf975`.
