### PR TITLE
cleanup: remove hardcoded error color fallback in ProfileEditScreen

### DIFF
--- a/src/screens/ProfileEditScreen.tsx
+++ b/src/screens/ProfileEditScreen.tsx
@@ -483,7 +483,7 @@ const styles = StyleSheet.create({
     textAlignVertical: 'top',
   },
   error: {
-    color: theme.colors.error || '#ff4444',
+    color: theme.colors.error,
     fontSize: 12,
     marginTop: 4,
   },


### PR DESCRIPTION
## Summary
Remove the hardcoded `'#ff4444'` fallback from `ProfileEditScreen` error text styling so the screen consistently uses the semantic `theme.colors.error` token.

## Why
Keeping semantic theme token usage consistent reduces design-token drift and keeps error UI aligned with app theming.

## Validation
- `rg -n "theme\.colors\.error\s*\|\|\s*'#ff4444'" src/screens/ProfileEditScreen.tsx` (no matches)
- `./node_modules/.bin/eslint src/screens/ProfileEditScreen.tsx` (0 errors, 3 pre-existing warnings)

## Risk
Low — one-line style-token substitution in a single screen style block.
