### PR TITLE
cleanup: remove ProfileEditScreen error color fallback

### DIFF
--- a/src/screens/ProfileEditScreen.tsx
+++ b/src/screens/ProfileEditScreen.tsx
@@ -483,7 +483,7 @@ const styles = StyleSheet.create({
     textAlignVertical: 'top',
   },
   error: {
-    color: theme.colors.error || '#ff4444',
+    color: theme.colors.error,
     fontSize: 12,
     marginTop: 4,
   },


### PR DESCRIPTION
## Summary
Remove a hardcoded  fallback in  so the screen consistently uses the semantic  token.

## Validation
-  (no matches)
- 
/Users/larry/RUNSTR/src/screens/ProfileEditScreen.tsx
  51:10  warning  'originalProfile' is assigned a value but never used                                                                             @typescript-eslint/no-unused-vars
  57:8   warning  React Hook useCallback has a missing dependency: 'loadCurrentProfile'. Either include it or remove the dependency array          react-hooks/exhaustive-deps
  65:6   warning  React Hook useEffect has missing dependencies: 'hasChanges' and 'saveDraft'. Either include them or remove the dependency array  react-hooks/exhaustive-deps

✖ 3 problems (0 errors, 3 warnings) (0 errors, 3 pre-existing warnings)

## Risk
Low — single style-token substitution, no logic changes.