### PR TITLE
refactor: dedupe teams selected charity lookup

### DIFF
--- a/src/screens/TeamsScreen.tsx
+++ b/src/screens/TeamsScreen.tsx
@@ -23,7 +23,7 @@ import Toast from 'react-native-toast-message';
 import { useTranslation } from 'react-i18next';
 import { theme } from '../styles/theme';
 import { TexturedBackground } from '../components/ui/TexturedBackground';
-import { CHARITIES, Charity, isPPQTeam, isCoinOSTeam } from '../constants/charities';
+import { CHARITIES, Charity, getCharityById, isPPQTeam, isCoinOSTeam } from '../constants/charities';
 import { ExternalZapModal } from '../components/nutzap/ExternalZapModal';
 import { useNWCZap } from '../hooks/useNWCZap';
 import { NWCWalletService } from '../services/wallet/NWCWalletService';
@@ -462,7 +462,7 @@ const TeamsScreenComponent: React.FC = () => {
 
   // Find selected team object (memoized to avoid repeated linear scans)
   const selectedTeam = useMemo(
-    () => (selectedTeamId ? CHARITIES.find((c) => c.id === selectedTeamId) : null),
+    () => (selectedTeamId ? (getCharityById(selectedTeamId) ?? null) : null),
     [selectedTeamId]
   );
 


### PR DESCRIPTION
## Summary
Use the shared getCharityById helper in TeamsScreen for resolving the selected team instead of re-implementing a local CHARITIES.find lookup.

## Changes
- import getCharityById in src/screens/TeamsScreen.tsx
- replace local selected-team CHARITIES.find with helper call

## Validation
- expo lint (fails in current repo environment: Expo lint invokes npx eslint ., and ESLint v10 requires flat config)
- tsc --noEmit (fails on existing baseline/environment issues, including missing expo/tsconfig.base in this context)

## Risk
Low — behavior-preserving lookup deduplication in one file.

## Rollback
Revert commit 95cd3824.
