### PR TITLE
refactor: remove error-color fallbacks from auth and rewards/settings flows

### DIFF
--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -490,7 +490,7 @@ const styles = StyleSheet.create({
     minHeight: 50,
   },
   textInputError: {
-    borderColor: theme.colors.error || '#ff4444',
+    borderColor: theme.colors.error,
   },
   inputHelper: {
     fontSize: 12,
@@ -505,7 +505,7 @@ const styles = StyleSheet.create({
   },
   errorText: {
     fontSize: 14,
-    color: theme.colors.error || '#ff4444',
+    color: theme.colors.error,
     textAlign: 'center',
     padding: 12,
     backgroundColor: 'rgba(255, 68, 68, 0.1)',

--- a/src/screens/ProfileEditScreen.tsx
+++ b/src/screens/ProfileEditScreen.tsx
@@ -483,7 +483,7 @@ const styles = StyleSheet.create({
     textAlignVertical: 'top',
   },
   error: {
-    color: theme.colors.error || '#ff4444',
+    color: theme.colors.error,
     fontSize: 12,
     marginTop: 4,
   },

--- a/src/screens/RewardsScreen.tsx
+++ b/src/screens/RewardsScreen.tsx
@@ -709,7 +709,7 @@ const styles = StyleSheet.create({
     color: theme.colors.text,
   },
   lightningAddressInputError: {
-    borderColor: theme.colors.error || '#ff4444',
+    borderColor: theme.colors.error,
   },
   lightningAddressSaveButton: {
     backgroundColor: theme.colors.accent,
@@ -725,7 +725,7 @@ const styles = StyleSheet.create({
     opacity: 0.6,
   },
   lightningAddressError: {
-    color: theme.colors.error || '#ff4444',
+    color: theme.colors.error,
     fontSize: 12,
     marginTop: 6,
   },

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1777,7 +1777,7 @@ const styles = StyleSheet.create({
   },
 
   lightningAddressInputError: {
-    borderColor: theme.colors.error || '#ff4444',
+    borderColor: theme.colors.error,
   },
 
   lightningAddressSaveButton: {
@@ -1796,7 +1796,7 @@ const styles = StyleSheet.create({
   },
 
   lightningAddressError: {
-    color: theme.colors.error || '#ff4444',
+    color: theme.colors.error,
     fontSize: 12,
     marginTop: 6,
   },


### PR DESCRIPTION
## Summary\nRemove  fallbacks in Login, Profile Edit, Rewards, and Settings screens so these surfaces consistently use the semantic error token.\n\n## Changes\n- Replace hardcoded error fallback patterns with  in four screens\n- Keep patch limited to style token usage (no behavior changes)\n\n## Validation\n- src/screens/CaptainDashboardScreen.tsx:1969:    borderColor: theme.colors.error,
src/screens/CaptainDashboardScreen.tsx:1973:    color: theme.colors.error,
src/screens/CaptainDashboardScreen.tsx:1983:    backgroundColor: theme.colors.error,
src/screens/LeagueDetailScreen.tsx:307:    backgroundColor: theme.colors.error + '20',
src/screens/LeagueDetailScreen.tsx:308:    borderColor: theme.colors.error,
src/screens/LoginScreen.tsx:493:    borderColor: theme.colors.error,
src/screens/LoginScreen.tsx:508:    color: theme.colors.error,
src/screens/ProfileEditScreen.tsx:486:    color: theme.colors.error,
src/screens/RewardsScreen.tsx:712:    borderColor: theme.colors.error,
src/screens/RewardsScreen.tsx:728:    color: theme.colors.error,
src/screens/SettingsScreen.tsx:1233:                <ActivityIndicator size="small" color={theme.colors.error} />
src/screens/SettingsScreen.tsx:1553:    backgroundColor: theme.colors.error,
src/screens/SettingsScreen.tsx:1780:    borderColor: theme.colors.error,
src/screens/SettingsScreen.tsx:1799:    color: theme.colors.error, (no matches)\n\n## Risk\nLow — style-token cleanup only.\n\n## Rollback\nRevert this PR commit to restore prior fallback literals.