### PR TITLE
docs: fix stale auth components README inventory

### DIFF
--- a/src/components/auth/README.md
+++ b/src/components/auth/README.md
@@ -1,8 +1,16 @@
 # Auth Components Directory
 
-Authentication-related UI components for user login and account management.
+This directory is intentionally empty.
 
-## Files
+## Status
 
-- **AppleSignInButton.tsx** - Apple Sign In button component (legacy, not currently used)
-- **GoogleSignInButton.tsx** - Google Sign In button component (legacy, not currently used)
+Legacy social sign-in button components were removed during auth flow cleanup.
+Authentication UI now lives in screen-level implementations.
+
+## Current auth entry points
+
+- `src/screens/LoginScreen.tsx` — login form and auth UI
+- `src/contexts/AuthContext.tsx` — authentication state + sign-in/sign-up flows
+- `src/services/auth/providers/amberAuthProvider.ts` — Android Amber auth provider
+
+If shared auth components are reintroduced, document them here with exact file names and ownership.


### PR DESCRIPTION
## Summary
Update  so it reflects the current codebase instead of listing deleted files.

## Changes
- mark  as intentionally empty
- remove deleted  and  references
- point readers to current auth entry points (, , Amber provider)

## Validation
- verified referenced paths exist in repo
- verified removed component names no longer appear in the README

## Risk
Low (docs-only change)

## Rollback
Revert commit  on this branch.
