### PR TITLE
docs: repoint archived files in docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ Centralized documentation for the RUNSTR REWARDS project, including implementati
 ## Documentation Categories
 
 ### Project Overview
-- **ROADMAP.md** - Project roadmap and future plans
+- **archive/ROADMAP.md** - Project roadmap and future plans
 
 ### Integration Guides
 - **AMBER_INTEGRATION.md** - Amber signer integration guide
@@ -24,69 +24,69 @@ Centralized documentation for the RUNSTR REWARDS project, including implementati
 - **ENVIRONMENT_SETUP.md** - Environment variables and secrets setup
 
 ### Testing Documentation
-- **PHASE_1_2_TESTING_GUIDE.md** - Complete testing guide for Phase 1 & 2
+- **archive/PHASE_1_2_TESTING_GUIDE.md** - Complete testing guide for Phase 1 & 2
 - **PRE_LAUNCH_REVIEW_GUIDE.md** - Pre-launch review workflow
-- **PRE_LAUNCH_REVIEW_SCRIPT.md** - Claude's manual review script
+- **archive/PRE_LAUNCH_REVIEW_SCRIPT.md** - Claude's manual review script
 - **CLAUDE_REVIEW_PROMPT.md** - Ready-to-paste Claude review prompt
-- **AMBER_TEST_SUITE.md** - Amber integration test suite
-- **AUDIT_REPORT.md** - Automated audit results
-- **TEST_SCRIPTS_SUMMARY.md** - Test scripts documentation
-- **NOTIFICATION_TESTING.md** - Notification testing guide
-- **PHASE1_TESTING_GUIDE.md** - Phase 1 specific testing
+- **archive/AMBER_TEST_SUITE.md** - Amber integration test suite
+- **archive/AUDIT_REPORT.md** - Automated audit results
+- **archive/TEST_SCRIPTS_SUMMARY.md** - Test scripts documentation
+- **archive/NOTIFICATION_TESTING.md** - Notification testing guide
+- **archive/PHASE1_TESTING_GUIDE.md** - Phase 1 specific testing
 
 ### Deployment & Publishing
-- **ZAPSTORE_PUBLISHING.md** - ZapStore publishing guide
-- **APP_STORE_RESPONSE.md** - App Store submission responses
+- **archive/ZAPSTORE_PUBLISHING.md** - ZapStore publishing guide
+- **archive/APP_STORE_RESPONSE.md** - App Store submission responses
 
 ### Architecture & Planning
 - **DATA_ARCHITECTURE_AND_CACHING_STRATEGY.md** - Data architecture and caching design
-- **CACHING_MIGRATION_GUIDE.md** - Cache migration from legacy to unified system
-- **DATABASE_IMPLEMENTATION_PLAN.md** - Database architecture strategy (deprecated)
-- **NOSTR_FITNESS_ECOSYSTEM_VISION.md** - Vision for Nostr fitness ecosystem
-- **NOSTR_MVP_STRATEGY.md** - MVP strategy for Nostr implementation
+- **archive/CACHING_MIGRATION_GUIDE.md** - Cache migration from legacy to unified system
+- **archive/DATABASE_IMPLEMENTATION_PLAN.md** - Database architecture strategy (deprecated)
+- **archive/NOSTR_FITNESS_ECOSYSTEM_VISION.md** - Vision for Nostr fitness ecosystem
+- **archive/NOSTR_MVP_STRATEGY.md** - MVP strategy for Nostr implementation
 - **Decentralized-Fitness.md** - Decentralized fitness platform concepts
-- **ZAP_ARENA_VISION.md** - Zap Arena competition system vision
+- **archive/ZAP_ARENA_VISION.md** - Zap Arena competition system vision
 - **WORKOUT_ARCHITECTURE.md** - Workout data architecture
 - **TEAM_MANAGEMENT_SYSTEM.md** - Team management system design
 
 ### Implementation Guides
-- **PHASE_2_IMPLEMENTATION_GUIDE.md** - Phase 2 development guide
-- **PHASE2_IMPLEMENTATION.md** - Phase 2 implementation details
-- **COMPETITION_REWARDS_IMPLEMENTATION.md** - Competition rewards system
-- **COMPETITION_SIMPLIFICATION.md** - Competition system simplification
-- **WALLET_PERSISTENCE_IMPROVEMENTS.md** - Wallet persistence improvements
-- **ACTIVITY_TRACKING_SIMPLIFICATION.md** - Activity tracking simplification
-- **nutzap-plan.md** - NutZap integration planning
+- **archive/PHASE_2_IMPLEMENTATION_GUIDE.md** - Phase 2 development guide
+- **archive/PHASE2_IMPLEMENTATION.md** - Phase 2 implementation details
+- **archive/COMPETITION_REWARDS_IMPLEMENTATION.md** - Competition rewards system
+- **archive/COMPETITION_SIMPLIFICATION.md** - Competition system simplification
+- **archive/WALLET_PERSISTENCE_IMPROVEMENTS.md** - Wallet persistence improvements
+- **archive/ACTIVITY_TRACKING_SIMPLIFICATION.md** - Activity tracking simplification
+- **archive/nutzap-plan.md** - NutZap integration planning
 - **events-and-leagues.md** - Events and leagues system
 
 ### Setup & Configuration
-- **SETUP_INSTRUCTIONS.md** - Project setup and configuration
-- **METRO_XCODE_DEBUGGING_GUIDE.md** - Metro bundler and Xcode debugging
-- **APPLY_MIGRATION_INSTRUCTIONS.md** - Database migration instructions
+- **archive/SETUP_INSTRUCTIONS.md** - Project setup and configuration
+- **archive/METRO_XCODE_DEBUGGING_GUIDE.md** - Metro bundler and Xcode debugging
+- **archive/APPLY_MIGRATION_INSTRUCTIONS.md** - Database migration instructions
 
 ### Problem Solving & Fixes
-- **1301_FITNESS_NOTES_BREAKTHROUGH.md** - Kind 1301 event breakthrough
-- **1301-PROBLEM-SOLVING.md** - Kind 1301 problem solving
-- **ACTIVITY_FILTERING_FIX_SUMMARY.md** - Activity filtering fixes
-- **CAPTAIN_DETECTION_FIX_ATTEMPTS.md** - Captain detection fix attempts
-- **CAPTAIN_DETECTION_INVESTIGATION.md** - Captain detection investigation
-- **TEAM_CREATION_ISSUE_SUMMARY.md** - Team creation issues
-- **TEAM_CREATION_RESOLUTION_SUMMARY.md** - Team creation resolution
-- **SUPABASE_FIX.md** - Supabase-related fixes (deprecated)
-- **PERFORMANCE_FIX_40S_FREEZE.md** - 40-second freeze performance fix
+- **archive/1301_FITNESS_NOTES_BREAKTHROUGH.md** - Kind 1301 event breakthrough
+- **archive/1301-PROBLEM-SOLVING.md** - Kind 1301 problem solving
+- **archive/ACTIVITY_FILTERING_FIX_SUMMARY.md** - Activity filtering fixes
+- **archive/CAPTAIN_DETECTION_FIX_ATTEMPTS.md** - Captain detection fix attempts
+- **archive/CAPTAIN_DETECTION_INVESTIGATION.md** - Captain detection investigation
+- **archive/TEAM_CREATION_ISSUE_SUMMARY.md** - Team creation issues
+- **archive/TEAM_CREATION_RESOLUTION_SUMMARY.md** - Team creation resolution
+- Supabase fix note was retired (no standalone doc remains).
+- **archive/PERFORMANCE_FIX_40S_FREEZE.md** - 40-second freeze performance fix
 
 ### Issue Tracking & Bug Reports
-- **GITHUB_ISSUE_CAPTAIN_NOTIFICATIONS.md** - Captain notification issue
-- **github-issue-wallet-duplication.md** - Wallet duplication issue
+- **archive/GITHUB_ISSUE_CAPTAIN_NOTIFICATIONS.md** - Captain notification issue
+- **archive/github-issue-wallet-duplication.md** - Wallet duplication issue
 - **FITNESS_TRACKER_MEMORY.md** - Fitness tracker memory management
 
 ### Development History & Progress
 - **LESSONS_LEARNED.md** - Lessons learned during development
-- **LESSONS_FROM_REFERENCE_IMPLEMENTATION.md** - Lessons from reference apps
-- **ENHANCED_TEAM_DISCOVERY_SUMMARY.md** - Team discovery implementation
-- **RUNSTR_PROGRESS_REPORT.md** - Project progress reports
-- **MVP Plan.md** - Original MVP planning
-- **september-to-do-list.md** - September development todos
+- **archive/LESSONS_FROM_REFERENCE_IMPLEMENTATION.md** - Lessons from reference apps
+- **archive/ENHANCED_TEAM_DISCOVERY_SUMMARY.md** - Team discovery implementation
+- **archive/RUNSTR_PROGRESS_REPORT.md** - Project progress reports
+- **archive/MVP Plan.md** - Original MVP planning
+- **archive/september-to-do-list.md** - September development todos
 - **NOSTR_AGENT_MEMORY.md** - Nostr agent development memory
 
 ## File Statistics


### PR DESCRIPTION
## Summary
- update docs/README.md entries that referenced files moved into docs/archive/
- remove one stale Supabase bullet that no longer has a backing doc
- keep the change limited to docs index routing (no code/runtime behavior changes)

## Validation
- ran a docs-index check to ensure every bold *.md entry in docs/README.md resolves to an existing docs file
- result: MISSING_BOLD_ENTRIES 0

## Risk
- Low (documentation-only path updates)