### PR TITLE
Fix location settings navigation fallback for permission prompts

### DIFF
--- a/src/services/activity/LocationPermissionService.ts
+++ b/src/services/activity/LocationPermissionService.ts
@@ -247,10 +247,20 @@ class LocationPermissionService {
    * Open device settings for location permissions
    */
   async openLocationSettings(): Promise<void> {
-    if (Platform.OS === 'ios') {
-      Linking.openURL('app-settings:');
-    } else {
-      Linking.openSettings();
+    try {
+      if (Platform.OS === 'ios') {
+        const settingsUrl = 'app-settings:';
+        const canOpenSettingsUrl = await Linking.canOpenURL(settingsUrl);
+
+        if (canOpenSettingsUrl) {
+          await Linking.openURL(settingsUrl);
+          return;
+        }
+      }
+
+      await Linking.openSettings();
+    } catch (error) {
+      console.error('Error opening location settings:', error);
     }
   }
 


### PR DESCRIPTION
## Summary
- guard iOS `app-settings:` deep link with `Linking.canOpenURL` before trying to open it
- fallback to `Linking.openSettings()` when the iOS scheme is unavailable
- wrap settings navigation in try/catch so permission alerts no longer fail silently on deep-link errors

## Why
Some devices/environments can reject `app-settings:` and leave users stuck when they tap **Open Settings** from location-permission alerts. This keeps the flow resilient and preserves a path into system settings.

## Validation
- `npm run lint` *(fails in this automation environment: `expo` binary not installed)*
- `npm run typecheck` *(fails in this automation environment: `tsc` binary not installed)*

## Risk
Low — scoped to settings-link handling and adds fallback/error handling only.
