### PR TITLE
Fix missing Alert import in receive bitcoin form

### DIFF
--- a/src/components/wallet/ReceiveBitcoinForm.tsx
+++ b/src/components/wallet/ReceiveBitcoinForm.tsx
@@ -10,6 +10,7 @@ import {
   TextInput,
   TouchableOpacity,
   StyleSheet,
+  Alert,
 } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { theme } from '../../styles/theme';


### PR DESCRIPTION
## Summary
- add the missing `Alert` import in `ReceiveBitcoinForm`
- prevent runtime/reference failure when validation or share actions call `Alert.alert`

## Validation
- `npm run lint -- --no-cache` *(fails in automation environment: `expo: command not found`)*
- `npm run typecheck` *(fails in automation environment: `tsc: command not found`)*

## Risk
- Low (single import-only bugfix in one file)
