### PR TITLE
Cleanup background sync unused React Native import

### DIFF
--- a/src/services/fitness/backgroundSyncService.ts
+++ b/src/services/fitness/backgroundSyncService.ts
@@ -9,7 +9,6 @@
  * See AuthContext.tsx lines 629-650 for where this was disabled.
  */
 
-import { AppState, Platform } from 'react-native';
 import healthKitService from './healthKitService';
 // import workoutDataProcessor from './workoutDataProcessor';  // REMOVED: Pure Nostr - workouts processed via kind 1301 events
 // import teamLeaderboardService from './teamLeaderboardService';  // REMOVED: Pure Nostr - leaderboards query kind 1301 events directly


### PR DESCRIPTION
## Summary\n- remove the unused react-native import from \n- keep the existing disabled AppState listener comments intact\n\n## Validation\n- \n\n## Risk\n- Low (no runtime behavior changes; lint-only cleanup)