### PR TITLE
fix: persist analytics events to bounded local buffer

### DIFF
--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -6,6 +6,7 @@
 import Constants from 'expo-constants';
 import { Platform } from 'react-native';
 import { DiscoveryTeam, Team } from '../types';
+import { SafeStorage } from './storage';
 
 // Analytics event types
 export type AnalyticsEvent =
@@ -79,6 +80,14 @@ export interface ConversionAnalyticsProperties extends BaseAnalyticsProperties {
   selectedTeamsCount?: number;
 }
 
+interface PersistedAnalyticsEvent {
+  event: AnalyticsEvent;
+  properties: Record<string, any>;
+}
+
+const ANALYTICS_EVENT_BUFFER_KEY = '@runstr:analytics:event-buffer';
+const MAX_BUFFERED_ANALYTICS_EVENTS = 200;
+
 // Main analytics class
 class Analytics {
   private isEnabled: boolean = true;
@@ -132,6 +141,46 @@ class Analytics {
     };
   }
 
+  private parsePersistedEvents(
+    raw: string | null
+  ): PersistedAnalyticsEvent[] {
+    if (!raw) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+
+      return parsed.filter(
+        item =>
+          item &&
+          typeof item === 'object' &&
+          typeof item.event === 'string' &&
+          item.properties &&
+          typeof item.properties === 'object'
+      );
+    } catch {
+      return [];
+    }
+  }
+
+  private async persistEvent(eventData: PersistedAnalyticsEvent): Promise<void> {
+    const existingRaw = await SafeStorage.getItem(ANALYTICS_EVENT_BUFFER_KEY);
+    const existingEvents = this.parsePersistedEvents(existingRaw);
+
+    const nextEvents = [...existingEvents, eventData].slice(
+      -MAX_BUFFERED_ANALYTICS_EVENTS
+    );
+
+    await SafeStorage.setItem(
+      ANALYTICS_EVENT_BUFFER_KEY,
+      JSON.stringify(nextEvents)
+    );
+  }
+
   // Track generic event
   track(event: AnalyticsEvent, properties?: Record<string, any>) {
     if (!this.isEnabled) return;
@@ -153,6 +202,10 @@ class Analytics {
 
     // Log to console in development
     console.log('📊 Analytics Event:', eventData);
+
+    void this.persistEvent(eventData).catch(error => {
+      console.warn('[Analytics] Failed to persist analytics event:', error);
+    });
 
     // TODO: Send to analytics providers
     // this.sendToFirebaseAnalytics(eventData);


### PR DESCRIPTION
## Summary
- persist each analytics event to a local AsyncStorage-backed buffer via SafeStorage
- cap persisted event history at 200 entries to avoid unbounded growth
- keep existing console logging while adding durable event capture for later provider forwarding

## Validation
- `npx eslint src/utils/analytics.ts` *(fails in this environment: ESLint v10 expects flat config and no local eslint setup available)*
- `npm run -s typecheck` *(fails in this environment: `tsc` command not found; dependencies/toolchain not installed in this worktree)*

## Risk
Low — single-file analytics-path change, non-blocking persistence, and bounded storage.
