### PR TITLE
fix: remove duplicate modalInput style key in captain dashboard

### DIFF
--- a/src/screens/CaptainDashboardScreen.tsx
+++ b/src/screens/CaptainDashboardScreen.tsx
@@ -1955,16 +1955,6 @@ const styles = StyleSheet.create({
     padding: 12,
     fontStyle: 'italic',
   },
-  modalInput: {
-    backgroundColor: theme.colors.cardBackground,
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-    borderRadius: 8,
-    padding: 12,
-    fontSize: 16,
-    color: theme.colors.text,
-    marginTop: 12,
-  },
   modalInputError: {
     borderColor: theme.colors.error,
   },


### PR DESCRIPTION
## Summary
Removes the duplicate `modalInput` style key from `CaptainDashboardScreen` so TypeScript no longer fails with duplicate object property error TS1117.

## Changes
- deleted the second `modalInput` style block in `StyleSheet.create`
- preserved the original modal input style used by existing modal fields

## Validation
- `rg -n '^\s*modalInput:\s*\{' src/screens/CaptainDashboardScreen.tsx` -> now returns a single definition
- `npm run -s typecheck` could not be fully executed in this environment (`tsc: command not found`)
- `npx eslint src/screens/CaptainDashboardScreen.tsx` could not run in this environment due missing flat config migration

## Risk
Low: removes duplicate style declaration only; no runtime logic changes.

## Rollback
Revert commit `4b5c75be` to restore previous style object.
