### PR TITLE
refactor: remove orphan modal style tokens from captain dashboard

### DIFF
--- a/src/screens/CaptainDashboardScreen.tsx
+++ b/src/screens/CaptainDashboardScreen.tsx
@@ -1880,24 +1880,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 
-  modalButtonPrimary: {
-    backgroundColor: theme.colors.orangeBright, // Light orange for consistency
-  },
-
-  modalButtonSecondary: {
-    backgroundColor: theme.colors.border,
-  },
-
   modalButtonText: {
     fontSize: 14,
     fontWeight: theme.typography.weights.semiBold,
     color: theme.colors.accentText,
-  },
-
-  modalButtonTextSecondary: {
-    fontSize: 14,
-    fontWeight: theme.typography.weights.medium,
-    color: theme.colors.text,
   },
 
   // Charity styles
@@ -1979,12 +1965,6 @@ const styles = StyleSheet.create({
     marginTop: 8,
     lineHeight: 18,
   },
-  modalBtnDanger: {
-    backgroundColor: theme.colors.error,
-  },
-  modalBtnDisabled: {
-    opacity: 0.5,
-  },
 
   editBtn: {
     paddingHorizontal: 16,
@@ -2030,12 +2010,6 @@ const styles = StyleSheet.create({
     marginBottom: 20,
     fontStyle: 'italic',
     paddingHorizontal: 8,
-  },
-
-  modalButtons: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    gap: 12,
   },
 
   cancelButton: {


### PR DESCRIPTION
## Summary
Remove six unused modal style tokens from `CaptainDashboardScreen` to reduce dead design code and keep style contracts clean.

## Changes
- removed `modalButtonPrimary`, `modalButtonSecondary`, and `modalButtonTextSecondary`
- removed `modalBtnDanger` and `modalBtnDisabled`
- removed unused `modalButtons` style block

## Validation
- `rg -n "\b(modalButtonPrimary|modalButtonSecondary|modalButtonTextSecondary|modalBtnDanger|modalBtnDisabled|modalButtons)\b" src/screens/CaptainDashboardScreen.tsx` (no matches)
- `npm run -s typecheck` (fails in environment: `tsc: command not found`)
- `npx eslint src/screens/CaptainDashboardScreen.tsx` (fails in environment: ESLint v10 flat-config requirement)

## Risk
Low: deleted style keys had zero call sites in the file before removal.

## Rollback
Revert commit `d8f80ea2`.
