### PR TITLE
cleanup: remove unused View import in NotificationBadge

### DIFF
--- a/src/components/profile/NotificationBadge.tsx
+++ b/src/components/profile/NotificationBadge.tsx
@@ -4,13 +4,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  TouchableOpacity,
-  Animated,
-} from 'react-native';
+import { Text, StyleSheet, TouchableOpacity, Animated } from 'react-native';
 import { theme } from '../../styles/theme';
 import { unifiedNotificationStore } from '../../services/notifications/UnifiedNotificationStore';
 


### PR DESCRIPTION
## Summary
- remove unused `View` import from `NotificationBadge`

## Why
- keeps profile notification badge module lint-clean and reduces import noise in an active UI surface

## Validation
- `pnpm`/global lint run was not available in isolated worktree due missing `eslint-config-expo`; patch was validated by direct source inspection and git diff only

## Risk
- low (import-only change; no runtime logic touched)
