### PR TITLE
chore: remove unused React Native imports in background sync service

### DIFF
--- a/src/services/fitness/backgroundSyncService.ts
+++ b/src/services/fitness/backgroundSyncService.ts
@@ -9,7 +9,6 @@
  * See AuthContext.tsx lines 629-650 for where this was disabled.
  */
 
-import { AppState, Platform } from 'react-native';
 import healthKitService from './healthKitService';
 // import workoutDataProcessor from './workoutDataProcessor';  // REMOVED: Pure Nostr - workouts processed via kind 1301 events
 // import teamLeaderboardService from './teamLeaderboardService';  // REMOVED: Pure Nostr - leaderboards query kind 1301 events directly


### PR DESCRIPTION
## Summary\n- remove unused `AppState` and `Platform` imports from `backgroundSyncService`\n- keep file behavior unchanged while reducing lint noise\n\n## Validation\n- rg -n "import { AppState, Platform } from 'react-native'" src/services/fitness/backgroundSyncService.ts (no matches)\n- git diff -- src/services/fitness/backgroundSyncService.ts (import-only change)\n\n## Risk\n- Low: this removes unused imports only\n\n## Rollback\n- Revert this PR commit to restore previous import line\n