### PR TITLE
cleanup: remove unused Text import in WorkoutHistoryScreen

### DIFF
--- a/src/screens/WorkoutHistoryScreen.tsx
+++ b/src/screens/WorkoutHistoryScreen.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, StyleSheet, TouchableOpacity } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { theme } from '../styles/theme';


### PR DESCRIPTION
## Summary
Remove an unused `Text` import from `WorkoutHistoryScreen` to reduce lint noise.

## Changes
- Delete unused `Text` from the React Native import list in `src/screens/WorkoutHistoryScreen.tsx`

## Validation
- `rg -n "import { View, StyleSheet, TouchableOpacity } from 'react-native';" src/screens/WorkoutHistoryScreen.tsx`
- `rg -n "\bText\b" src/screens/WorkoutHistoryScreen.tsx` (no matches)

## Risk
Low — import-only cleanup; no runtime logic changes.
