### PR TITLE
chore(profile): remove unused Alert import from ProfileScreen

### DIFF
--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -51,7 +51,6 @@ import JoinRequestService from '../services/competition/JoinRequestService';
 import { UnifiedSigningService } from '../services/auth/UnifiedSigningService';
 import { GlobalNDKService } from '../services/nostr/GlobalNDKService';
 import { NDKEvent } from '@nostr-dev-kit/ndk';
-import { Alert } from 'react-native';
 import { NostrFetchLogger } from '../utils/NostrFetchLogger';
 import Toast from 'react-native-toast-message';
 import { MusicPlayerPreferencesService } from '../services/music/MusicPlayerPreferencesService';


### PR DESCRIPTION
## Summary\nRemove an unused \ import from \ to reduce lint noise and keep the file clean.\n\n## Why\nThe symbol was imported but never referenced, which creates avoidable maintenance/lint overhead in a user-facing screen.\n\n## Risk\nLow — import-only cleanup with no runtime logic changes.\n\n## Validation\n- \ (no matches)\n- \ (single-line import removal)