### PR TITLE
cleanup: remove unused TouchableOpacity import in HikingTrackerScreen

### DIFF
--- a/src/screens/activity/HikingTrackerScreen.tsx
+++ b/src/screens/activity/HikingTrackerScreen.tsx
@@ -10,7 +10,6 @@ import {
   View,
   Text,
   StyleSheet,
-  TouchableOpacity,
   AppState,
   AppStateStatus,
   StatusBar,


### PR DESCRIPTION
## Summary\n- remove unused \ import from \\n- keep change single-file and import-only to reduce lint noise\n\n## Why\nThe file imported \ without using it, creating avoidable no-unused-vars/lint noise in the hiking tracker path.\n\n## Validation\n- \ (no matches)\n- \ (import-only delta)\n\n## Risk\nLow — removes an unused import only.\n\n## Rollback\nRevert this PR/commit to restore prior import list.