### PR TITLE
cleanup: remove unused TouchableOpacity import from WalkingTrackerScreen

### DIFF
--- a/src/screens/activity/WalkingTrackerScreen.tsx
+++ b/src/screens/activity/WalkingTrackerScreen.tsx
@@ -10,7 +10,6 @@ import {
   View,
   Text,
   StyleSheet,
-  TouchableOpacity,
   AppState,
   AppStateStatus,
   StatusBar,


### PR DESCRIPTION
## Summary\n- remove unused `TouchableOpacity` import from `WalkingTrackerScreen`\n- keep change scoped to a single file and single concern\n\n## Validation\n- `rg -n \"\bTouchableOpacity\b\" src/screens/activity/WalkingTrackerScreen.tsx` returns no matches\n- `git diff -- src/screens/activity/WalkingTrackerScreen.tsx` shows a one-line import-only deletion\n\n## Risk\n- Low: import cleanup only, no runtime logic changes