### PR TITLE
fix: resolve duplicate hasCompleted identifier in app initialization service

### DIFF
--- a/src/services/core/AppInitializationService.ts
+++ b/src/services/core/AppInitializationService.ts
@@ -230,7 +230,7 @@ class AppInitializationService {
   /**
    * Check if initialization has completed
    */
-  async hasCompleted(): Promise<boolean> {
+  async getCompletionStatus(): Promise<boolean> {
     try {
       const completed = await AsyncStorage.getItem(
         '@runstr:app_init_completed'


### PR DESCRIPTION
## Summary
Rename the async method `hasCompleted()` to `getCompletionStatus()` to remove the duplicate identifier collision with the existing `hasCompleted` class property.

## Why
`AppInitializationService` currently declares both a property and method named `hasCompleted`, which triggers TS2300 duplicate identifier errors and blocks typecheck.

## Validation
- `npm run -s typecheck > /tmp/runstr-h11-typecheck.log 2>&1 || true`
- Confirmed `AppInitializationService.ts(21,11|233,9): error TS2300` is no longer present in log

## Risk
Low — method rename only, no behavior change.

## Rollback
Revert this PR commit to restore prior symbol name (and duplicate identifier behavior).
