### PR TITLE
refactor: remove orphan modal style tokens from captain dashboard

### DIFF
--- a/src/screens/CaptainDashboardScreen.tsx
+++ b/src/screens/CaptainDashboardScreen.tsx
@@ -1880,24 +1880,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 
-  modalButtonPrimary: {
-    backgroundColor: theme.colors.orangeBright, // Light orange for consistency
-  },
-
-  modalButtonSecondary: {
-    backgroundColor: theme.colors.border,
-  },
-
   modalButtonText: {
     fontSize: 14,
     fontWeight: theme.typography.weights.semiBold,
     color: theme.colors.accentText,
-  },
-
-  modalButtonTextSecondary: {
-    fontSize: 14,
-    fontWeight: theme.typography.weights.medium,
-    color: theme.colors.text,
   },
 
   // Charity styles
@@ -1979,13 +1965,6 @@ const styles = StyleSheet.create({
     marginTop: 8,
     lineHeight: 18,
   },
-  modalBtnDanger: {
-    backgroundColor: theme.colors.error,
-  },
-  modalBtnDisabled: {
-    opacity: 0.5,
-  },
-
   editBtn: {
     paddingHorizontal: 16,
     paddingVertical: 6,
@@ -2030,12 +2009,6 @@ const styles = StyleSheet.create({
     marginBottom: 20,
     fontStyle: 'italic',
     paddingHorizontal: 8,
-  },
-
-  modalButtons: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    gap: 12,
   },
 
   cancelButton: {


### PR DESCRIPTION
## Summary
Remove six unused modal style tokens from `CaptainDashboardScreen` so the style sheet only contains actively referenced modal styles.

## Changes
- remove `modalButtonPrimary` and `modalButtonSecondary`
- remove `modalButtonTextSecondary`
- remove `modalBtnDanger`, `modalBtnDisabled`, and `modalButtons`

## Validation
- `rg -n "modalButtonPrimary|modalButtonSecondary|modalButtonTextSecondary|modalBtnDanger|modalBtnDisabled|modalButtons" src/screens/CaptainDashboardScreen.tsx` returns no matches
- `npm run -s typecheck` *(blocked in this environment: `tsc: command not found`)*

## Risk
Low — deletes only orphaned StyleSheet keys with no `styles.<key>` call sites.

## Rollback
Revert this PR commit to restore the removed style keys.
