### PR TITLE
cleanup: remove unused Button import from ProfileHeader

### DIFF
--- a/src/components/profile/ProfileHeader.tsx
+++ b/src/components/profile/ProfileHeader.tsx
@@ -8,7 +8,6 @@ import { View, Text, StyleSheet, Image } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { theme } from '../../styles/theme';
 import { User } from '../../types';
-import { Button } from '../ui/Button';
 import { Avatar } from '../ui/Avatar';
 
 interface ProfileHeaderProps {


### PR DESCRIPTION
## Summary
- remove unused `Button` import from `ProfileHeader`
- keep patch scoped to one-file lint cleanup

## Validation
- `rg -F "import { Button } from '../ui/Button';" src/components/profile/ProfileHeader.tsx` (no matches)

## Risk
- Low (import-only cleanup; no runtime behavior changes)
