### PR TITLE
fix: resolve duplicate hasCompleted identifier in app initialization service

### DIFF
--- a/src/services/core/AppInitializationService.ts
+++ b/src/services/core/AppInitializationService.ts
@@ -18,7 +18,7 @@ class AppInitializationService {
   private isInitializing = false;
   private abortController: AbortController | null = null;
   private timeoutId: NodeJS.Timeout | null = null;
-  private hasCompleted = false;
+  private initializationCompleted = false;
 
   private constructor() {}
 
@@ -41,7 +41,7 @@ class AppInitializationService {
     }
 
     this.isInitializing = true;
-    this.hasCompleted = false; // Reset completion flag
+    this.initializationCompleted = false; // Reset completion flag
     const MAX_INIT_TIME = 12000; // 12 second timeout (increased for first launch)
 
     // Create AbortController for proper cancellation
@@ -164,8 +164,8 @@ class AppInitializationService {
         }
 
         // CRITICAL FIX: Only set flags if not aborted and not already completed
-        if (!signal.aborted && !this.hasCompleted) {
-          this.hasCompleted = true; // Mark as completed to prevent timeout from running
+        if (!signal.aborted && !this.initializationCompleted) {
+          this.initializationCompleted = true; // Mark as completed to prevent timeout from running
           this.isInitialized = true;
 
           // Cancel the timeout since we succeeded
@@ -196,9 +196,9 @@ class AppInitializationService {
     const timeoutPromise = new Promise<void>((resolve) => {
       this.timeoutId = setTimeout(() => {
         // Only execute timeout if initialization hasn't completed
-        if (!this.hasCompleted) {
+        if (!this.initializationCompleted) {
           console.warn('⚠️ AppInit: Timeout reached - partial data loaded');
-          this.hasCompleted = true; // Prevent success path from running
+          this.initializationCompleted = true; // Prevent success path from running
 
           // CRITICAL: Abort the initialization to prevent orphaned promises
           if (this.abortController) {


### PR DESCRIPTION
## Summary
- rename the internal boolean completion flag to `initializationCompleted` in `AppInitializationService`
- keep the public `hasCompleted()` async API intact while removing the class-member name collision
- preserve timeout/abort behavior by updating all internal checks to the renamed flag

## Validation
- `npm run -s typecheck` (verified no `TS2300 Duplicate identifier 'hasCompleted'` emitted for `AppInitializationService.ts`)
- `rg -n "initializationCompleted|hasCompleted" src/services/core/AppInitializationService.ts`
