### PR TITLE
Fix missing Alert import in ReceiveBitcoinForm

### DIFF
--- a/src/components/wallet/ReceiveBitcoinForm.tsx
+++ b/src/components/wallet/ReceiveBitcoinForm.tsx
@@ -10,6 +10,7 @@ import {
   TextInput,
   TouchableOpacity,
   StyleSheet,
+  Alert,
 } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { theme } from '../../styles/theme';


### PR DESCRIPTION
## Summary
- add `Alert` to the React Native imports in `ReceiveBitcoinForm`
- keep existing receive form validation and share flows unchanged

## Problem
`ReceiveBitcoinForm` calls `Alert.alert(...)` in submit/share handlers but did not import `Alert`, causing TypeScript `TS2304 Cannot find name 'Alert'` errors for this file.

## Validation
- `npm run -s typecheck 2>&1 | rg 'ReceiveBitcoinForm\\.tsx' -n` (no output after patch)

## Risk
Low: import-only fix with no logic changes.
