### PR TITLE
fix: route EventCreationModal alerts through CustomAlertManager

### DIFF
--- a/src/components/competition/EventCreationModal.tsx
+++ b/src/components/competition/EventCreationModal.tsx
@@ -21,7 +21,7 @@ import { NostrListService } from '../../services/nostr/NostrListService';
 import { GlobalNDKService } from '../../services/nostr/GlobalNDKService';
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import UnifiedSigningService from '../../services/auth/UnifiedSigningService';
-import { CustomAlert } from '../ui/CustomAlert';
+import { CustomAlertManager } from '../ui/CustomAlert';
 import type { NostrTeam } from '../../services/nostr/NostrTeamService';
 
 interface EventCreationModalProps {
@@ -126,7 +126,7 @@ export const EventCreationModal: React.FC<EventCreationModalProps> = ({
   const handleCreateEvent = async () => {
     const validationError = validateForm();
     if (validationError) {
-      CustomAlert.alert('Validation Error', validationError, [{ text: 'OK' }]);
+      CustomAlertManager.alert('Validation Error', validationError, [{ text: 'OK' }]);
       return;
     }
 
@@ -139,7 +139,7 @@ export const EventCreationModal: React.FC<EventCreationModalProps> = ({
       const signingService = UnifiedSigningService.getInstance();
       const signer = await signingService.getSigner();
       if (!signer) {
-        CustomAlert.alert(
+        CustomAlertManager.alert(
           'Error',
           'No authentication found. Please login first.',
           [{ text: 'OK' }]
@@ -277,10 +277,10 @@ export const EventCreationModal: React.FC<EventCreationModalProps> = ({
 
       onClose();
 
-      CustomAlert.alert('Success!', successMessage, [{ text: 'OK' }]);
+      CustomAlertManager.alert('Success!', successMessage, [{ text: 'OK' }]);
     } catch (error) {
       console.error('❌ Failed to create event:', error);
-      CustomAlert.alert(
+      CustomAlertManager.alert(
         'Error',
         `Failed to create event: ${
           error instanceof Error ? error.message : 'Unknown error'


### PR DESCRIPTION
## Summary
EventCreationModal was calling `CustomAlert.alert(...)`, but `CustomAlert` is a component and does not expose a static `alert` method.

## Changes
- Replace `CustomAlert` import with `CustomAlertManager`
- Swap four `CustomAlert.alert(...)` calls to `CustomAlertManager.alert(...)`

## Validation
- Before: `npm run -s typecheck 2>&1 | rg "EventCreationModal\.tsx\(.+Property 'alert'" -n` returned 4 TS2339 errors
- After: same command returns no output

## Risk
Low — this only changes which existing alert helper is called; no behavioral expansion beyond fixing the incorrect API usage.
