### PR TITLE
Fix EventCreationModal deprecated alert/signing API usage

### DIFF
--- a/src/components/competition/EventCreationModal.tsx
+++ b/src/components/competition/EventCreationModal.tsx
@@ -21,7 +21,7 @@ import { NostrListService } from '../../services/nostr/NostrListService';
 import { GlobalNDKService } from '../../services/nostr/GlobalNDKService';
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import UnifiedSigningService from '../../services/auth/UnifiedSigningService';
-import { CustomAlert } from '../ui/CustomAlert';
+import { CustomAlertManager } from '../ui/CustomAlert';
 import type { NostrTeam } from '../../services/nostr/NostrTeamService';
 
 interface EventCreationModalProps {
@@ -126,7 +126,7 @@ export const EventCreationModal: React.FC<EventCreationModalProps> = ({
   const handleCreateEvent = async () => {
     const validationError = validateForm();
     if (validationError) {
-      CustomAlert.alert('Validation Error', validationError, [{ text: 'OK' }]);
+      CustomAlertManager.alert('Validation Error', validationError, [{ text: 'OK' }]);
       return;
     }
 
@@ -139,7 +139,7 @@ export const EventCreationModal: React.FC<EventCreationModalProps> = ({
       const signingService = UnifiedSigningService.getInstance();
       const signer = await signingService.getSigner();
       if (!signer) {
-        CustomAlert.alert(
+        CustomAlertManager.alert(
           'Error',
           'No authentication found. Please login first.',
           [{ text: 'OK' }]
@@ -206,7 +206,7 @@ export const EventCreationModal: React.FC<EventCreationModalProps> = ({
           const listService = NostrListService.getInstance();
 
           // Get captain's hex pubkey
-          const captainHexPubkey = await signingService.getHexPubkey();
+          const captainHexPubkey = await signingService.getUserPubkey();
           if (!captainHexPubkey) {
             throw new Error('Could not determine captain public key');
           }
@@ -277,10 +277,10 @@ export const EventCreationModal: React.FC<EventCreationModalProps> = ({
 
       onClose();
 
-      CustomAlert.alert('Success!', successMessage, [{ text: 'OK' }]);
+      CustomAlertManager.alert('Success!', successMessage, [{ text: 'OK' }]);
     } catch (error) {
       console.error('❌ Failed to create event:', error);
-      CustomAlert.alert(
+      CustomAlertManager.alert(
         'Error',
         `Failed to create event: ${
           error instanceof Error ? error.message : 'Unknown error'


### PR DESCRIPTION
## Summary
Align EventCreationModal with current auth/alert APIs so event-creation flows no longer call removed methods.

## Changes
- Replace CustomAlert.alert(...) with CustomAlertManager.alert(...)
- Replace UnifiedSigningService.getHexPubkey() with getUserPubkey() when building participant-list metadata

## Validation
- Before: `npm run -s typecheck 2>&1 | rg "EventCreationModal\.tsx" -n` returned 6 API-mismatch errors (CustomAlert.alert/getHexPubkey) plus 1 pre-existing event payload typing error.
- After: same command returns only the pre-existing event payload typing error.

## Risk
Low — only swaps deprecated method calls to current equivalents in a single component.

## Rollback
Revert this PR commit to restore previous behavior.
