### PR TITLE
fix: persist analytics events to bounded local buffer

### DIFF
--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -6,6 +6,7 @@
 import Constants from 'expo-constants';
 import { Platform } from 'react-native';
 import { DiscoveryTeam, Team } from '../types';
+import { SafeStorage } from './storage';
 
 // Analytics event types
 export type AnalyticsEvent =
@@ -78,6 +79,14 @@ export interface ConversionAnalyticsProperties extends BaseAnalyticsProperties {
   viewedTeamsCount?: number;
   selectedTeamsCount?: number;
 }
+
+interface PersistedAnalyticsEvent {
+  event: AnalyticsEvent;
+  properties: Record<string, any>;
+}
+
+const ANALYTICS_EVENT_BUFFER_KEY = '@runstr:analytics:event-buffer';
+const MAX_BUFFERED_ANALYTICS_EVENTS = 200;
 
 // Main analytics class
 class Analytics {
@@ -152,6 +161,46 @@ class Analytics {
     return value;
   }
 
+  private parsePersistedEvents(
+    raw: string | null
+  ): PersistedAnalyticsEvent[] {
+    if (!raw) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+
+      return parsed.filter(
+        item =>
+          item &&
+          typeof item === 'object' &&
+          typeof item.event === 'string' &&
+          item.properties &&
+          typeof item.properties === 'object'
+      ) as PersistedAnalyticsEvent[];
+    } catch {
+      return [];
+    }
+  }
+
+  private async persistEvent(eventData: PersistedAnalyticsEvent): Promise<void> {
+    const existingRaw = await SafeStorage.getItem(ANALYTICS_EVENT_BUFFER_KEY);
+    const existingEvents = this.parsePersistedEvents(existingRaw);
+
+    const nextEvents = [...existingEvents, eventData].slice(
+      -MAX_BUFFERED_ANALYTICS_EVENTS
+    );
+
+    await SafeStorage.setItem(
+      ANALYTICS_EVENT_BUFFER_KEY,
+      JSON.stringify(nextEvents)
+    );
+  }
+
   // Track generic event
   track(event: AnalyticsEvent, properties?: Record<string, any>) {
     if (!this.isEnabled) return;
@@ -178,6 +227,10 @@ class Analytics {
 
     // Log to console in development
     console.log('📊 Analytics Event:', eventData);
+
+    void this.persistEvent(eventData).catch(error => {
+      console.warn('[Analytics] Failed to persist analytics event:', error);
+    });
 
     // TODO: Send to analytics providers
     // this.sendToFirebaseAnalytics(eventData);


### PR DESCRIPTION
## Summary
- persist each analytics event to a local AsyncStorage-backed buffer via SafeStorage
- cap persisted event history at 200 entries to prevent unbounded storage growth
- keep existing console logging while adding non-blocking durable event capture for later provider forwarding

## Validation
-  ✅
- src/components/competition/EventCreationModal.tsx(129,19): error TS2339: Property 'alert' does not exist on type 'FC<CustomAlertProps>'.
src/components/competition/EventCreationModal.tsx(142,21): error TS2339: Property 'alert' does not exist on type 'FC<CustomAlertProps>'.
src/components/competition/EventCreationModal.tsx(188,9): error TS2345: Argument of type '{ teamId: string; name: string; description: string; activityType: "Running"; competitionType: "Distance Challenge" | "Speed Challenge" | "Duration Challenge" | "Consistency Streak"; ... 5 more ...; targetUnit: string; }' is not assignable to parameter of type 'Omit<NostrEventDefinition, "status" | "createdAt" | "updatedAt" | "captainPubkey"> & { id?: string | undefined; }'.
  Property 'id' is missing in type '{ teamId: string; name: string; description: string; activityType: "Running"; competitionType: "Distance Challenge" | "Speed Challenge" | "Duration Challenge" | "Consistency Streak"; ... 5 more ...; targetUnit: string; }' but required in type 'Omit<NostrEventDefinition, "status" | "createdAt" | "updatedAt" | "captainPubkey">'.
src/components/competition/EventCreationModal.tsx(209,57): error TS2339: Property 'getHexPubkey' does not exist on type 'UnifiedSigningService'.
src/components/competition/EventCreationModal.tsx(280,19): error TS2339: Property 'alert' does not exist on type 'FC<CustomAlertProps>'.
src/components/competition/EventCreationModal.tsx(283,19): error TS2339: Property 'alert' does not exist on type 'FC<CustomAlertProps>'.
src/components/profile/NotificationModal.tsx(113,12): error TS2678: Type '"view_captain_dashboard"' is not comparable to type 'NotificationActionType'.
src/components/profile/NotificationModal.tsx(148,59): error TS2339: Property 'challengeId' does not exist on type 'NotificationMetadata'.
  Property 'challengeId' does not exist on type 'CompetitionNotificationMetadata'.
src/components/profile/shared/SocialShareModal.tsx(77,11): error TS2345: Argument of type 'Workout' is not assignable to parameter of type 'PublishableWorkout'.
  Types of property 'meditationType' are incompatible.
    Type 'string | undefined' is not assignable to type '"guided" | "unguided" | "breathwork" | "body_scan" | "gratitude" | undefined'.
      Type 'string' is not assignable to type '"guided" | "unguided" | "breathwork" | "body_scan" | "gratitude" | undefined'.
src/components/profile/tabs/AppleHealthTab.tsx(140,11): error TS18046: 'permissionResult' is of type 'unknown'.
src/components/profile/tabs/AppleHealthTab.tsx(158,11): error TS18046: 'permissionResult' is of type 'unknown'.
src/components/profile/tabs/AppleHealthTab.tsx(232,19): error TS2345: Argument of type '{}' is not assignable to parameter of type 'SetStateAction<Workout[]>'.
src/components/profile/tabs/AppleHealthTab.tsx(234,40): error TS2339: Property 'length' does not exist on type '{}'.
src/components/profile/tabs/PrivateWorkoutsTab.tsx(183,9): error TS2322: Type '{ userId: string; syncedToNostr: false; postedToSocial: false; canSyncToNostr: true; canPostToSocial: false; id: string; type: WorkoutType; startTime: string; endTime: string; duration: number; ... 36 more ...; supabaseError?: string | undefined; }[]' is not assignable to type 'UnifiedWorkout[]'.
  Type '{ userId: string; syncedToNostr: false; postedToSocial: false; canSyncToNostr: true; canPostToSocial: false; id: string; type: WorkoutType; startTime: string; endTime: string; ... 37 more ...; supabaseError?: string; }' is not assignable to type 'UnifiedWorkout'.
    Types of property 'source' are incompatible.
      Type '"healthkit" | "health_connect" | "gps_tracker" | "manual_entry" | "daily_steps" | "imported_nostr"' is not assignable to type 'WorkoutSource'.
        Type '"daily_steps"' is not assignable to type 'WorkoutSource'.
src/components/profile/tabs/PrivateWorkoutsTab.tsx(248,7): error TS2322: Type '(workout: Workout) => React.JSX.Element | null' is not assignable to type '(workout: Workout) => ReactElement<unknown, string | JSXElementConstructor<any>>'.
  Type 'Element | null' is not assignable to type 'ReactElement<unknown, string | JSXElementConstructor<any>>'.
    Type 'null' is not assignable to type 'ReactElement<unknown, string | JSXElementConstructor<any>>'.
src/components/rewards/RewardNotificationProvider.tsx(51,42): error TS2339: Property 'donationSplit' does not exist on type 'RewardNotificationState'.
src/components/team/CharitySection.tsx(203,11): error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.
src/components/team/CharitySection.tsx(247,9): error TS2322: Type 'string | undefined' is not assignable to type 'string'.
  Type 'undefined' is not assignable to type 'string'.
src/components/team/CharitySection.tsx(360,11): error TS2322: Type 'string | undefined' is not assignable to type 'string'.
  Type 'undefined' is not assignable to type 'string'.
src/components/team/EventsCard.tsx(47,33): error TS2339: Property 'durationMinutes' does not exist on type 'FormattedEvent'.
src/components/team/EventsCard.tsx(84,53): error TS2339: Property 'getHexPubkey' does not exist on type 'UnifiedSigningService'.
src/components/team/EventsCard.tsx(184,19): error TS2339: Property 'alert' does not exist on type 'FC<CustomAlertProps>'.
src/components/team/EventsCard.tsx(224,31): error TS2339: Property 'alert' does not exist on type 'FC<CustomAlertProps>'.
src/components/team/EventsCard.tsx(367,21): error TS2339: Property 'alert' does not exist on type 'FC<CustomAlertProps>'.
src/components/team/EventsCard.tsx(377,51): error TS2339: Property 'getHexPubkey' does not exist on type 'UnifiedSigningService'.
src/components/team/EventsCard.tsx(379,21): error TS2339: Property 'alert' does not exist on type 'FC<CustomAlertProps>'.
src/components/team/EventsCard.tsx(399,19): error TS2339: Property 'alert' does not exist on type 'FC<CustomAlertProps>'.
src/components/team/EventsCard.tsx(415,19): error TS2339: Property 'alert' does not exist on type 'FC<CustomAlertProps>'.
src/components/wallet/ReceiveBitcoinForm.tsx(83,7): error TS2304: Cannot find name 'Alert'.
src/components/wallet/ReceiveBitcoinForm.tsx(112,5): error TS2304: Cannot find name 'Alert'.
src/components/wallet/ReceiveModal.tsx(46,34): error TS2554: Expected 1 arguments, but got 0.
src/components/wallet/ReceiveModal.tsx(47,40): error TS2554: Expected 1 arguments, but got 0.
src/components/wallet/ReceiveModal.tsx(57,9): error TS2322: Type 'undefined' is not assignable to type 'Timeout'.
src/components/wallet/ReceiveModal.tsx(61,9): error TS2322: Type 'undefined' is not assignable to type 'Timeout'.
src/components/wallet/ReceiveModal.tsx(114,15): error TS2322: Type 'undefined' is not assignable to type 'Timeout'.
src/components/wallet/ReceiveModal.tsx(118,15): error TS2322: Type 'undefined' is not assignable to type 'Timeout'.
src/components/wallet/ReceiveModal.tsx(137,11): error TS2322: Type 'undefined' is not assignable to type 'Timeout'.
src/components/wallet/ReceiveModal.tsx(140,9): error TS2322: Type 'undefined' is not assignable to type 'Timeout'.
src/components/wallet/ReceiveModal.tsx(187,7): error TS2322: Type 'undefined' is not assignable to type 'Timeout'.
src/components/wallet/ReceiveModal.tsx(191,7): error TS2322: Type 'undefined' is not assignable to type 'Timeout'.
src/components/wallet/ReceiveModal.tsx(315,21): error TS2322: Type 'undefined' is not assignable to type 'Timeout'.
src/components/wallet/ReceiveModal.tsx(319,21): error TS2322: Type 'undefined' is not assignable to type 'Timeout'.
src/contexts/AuthContext.tsx(106,34): error TS2345: Argument of type 'string | null' is not assignable to parameter of type 'string'.
  Type 'null' is not assignable to type 'string'.
src/contexts/AuthContext.tsx(120,38): error TS2345: Argument of type 'string | null' is not assignable to parameter of type 'string'.
  Type 'null' is not assignable to type 'string'.
src/contexts/AuthContext.tsx(149,36): error TS2345: Argument of type 'string | null' is not assignable to parameter of type 'string'.
  Type 'null' is not assignable to type 'string'.
src/contexts/AuthContext.tsx(152,30): error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'SetStateAction<User | null>'.
src/contexts/AuthContext.tsx(166,31): error TS18047: 'hexPubkey' is possibly 'null'.
src/contexts/AuthContext.tsx(389,26): error TS2345: Argument of type 'User | undefined' is not assignable to parameter of type 'SetStateAction<User | null>'.
  Type 'undefined' is not assignable to type 'SetStateAction<User | null>'.
src/contexts/AuthContext.tsx(518,24): error TS2345: Argument of type 'User | undefined' is not assignable to parameter of type 'SetStateAction<User | null>'.
  Type 'undefined' is not assignable to type 'SetStateAction<User | null>'.
src/contexts/AuthContext.tsx(526,30): error TS2304: Cannot find name 'UnifiedSigningService'.
src/contexts/NavigationDataContext.tsx(726,25): error TS2345: Argument of type 'NostrTeam[]' is not assignable to parameter of type 'SetStateAction<DiscoveryTeam[]>'.
  Type 'NostrTeam[]' is not assignable to type 'DiscoveryTeam[]'.
    Type 'NostrTeam' is missing the following properties from type 'DiscoveryTeam': about, difficulty, stats, recentActivities, and 4 more.
src/contexts/NavigationDataContext.tsx(793,11): error TS2353: Object literal may only specify known properties, and 'activeChallenges' does not exist in type '{ id: string; name: string; memberCount: number; activeEvents: number; prizePool: number; shopUrl?: string | undefined; }'.
src/hooks/useCachedData.ts(144,20): error TS2576: Property 'getInstance' does not exist on type 'LeagueRankingService'. Did you mean to access the static member 'LeagueRankingService.getInstance' instead?
src/hooks/useCachedData.ts(166,30): error TS2339: Property 'teamId' does not exist on type 'LeagueParameters'.
src/hooks/useCachedData.ts(167,30): error TS2339: Property 'captainPubkey' does not exist on type 'LeagueParameters'.
src/hooks/useCachedData.ts(169,65): error TS2339: Property 'teamId' does not exist on type 'LeagueParameters'.
src/hooks/useCachedData.ts(169,86): error TS2339: Property 'captainPubkey' does not exist on type 'LeagueParameters'.
src/hooks/useCachedData.ts(174,36): error TS2339: Property 'teamId' does not exist on type 'LeagueParameters'.
src/hooks/useCachedData.ts(175,36): error TS2339: Property 'captainPubkey' does not exist on type 'LeagueParameters'.
src/hooks/useCachedData.ts(183,20): error TS2576: Property 'getInstance' does not exist on type 'LeagueRankingService'. Did you mean to access the static member 'LeagueRankingService.getInstance' instead?
src/hooks/useNavigationData.ts(81,50): error TS2551: Property 'getAllCompetitions' does not exist on type 'CompetitionService'. Did you mean 'getTeamCompetitions'?
src/hooks/useNavigationData.ts(85,56): error TS7006: Parameter 'comp' implicitly has an 'any' type.
src/hooks/useNavigationData.ts(94,44): error TS7006: Parameter 'comp' implicitly has an 'any' type.
src/hooks/useNavigationData.ts(115,11): error TS2353: Object literal may only specify known properties, and 'activityType' does not exist in type 'Team'.
src/hooks/useNavigationData.ts(513,37): error TS2339: Property 'pubkey' does not exist on type 'UserWithWallet'.
src/hooks/useNavigationData.ts(528,22): error TS2339: Property 'teamName' does not exist on type 'UserWithWallet'.
src/hooks/useNavigationData.ts(531,11): error TS2353: Object literal may only specify known properties, and 'activeChallenges' does not exist in type '{ id: string; name: string; memberCount: number; activeEvents: number; prizePool: number; shopUrl?: string | undefined; }'.
src/hooks/useSeason2.ts(310,19): error TS2322: Type '1301' is not assignable to type 'NDKKind'.
src/hooks/useSeason2.ts(531,15): error TS2322: Type '1301' is not assignable to type 'NDKKind'.
src/navigation/AppNavigator.tsx(239,32): error TS2304: Cannot find name 'currentUserNpub'.
src/navigation/AppNavigator.tsx(641,9): error TS2322: Type '"Season2"' is not assignable to type 'keyof RootStackParamList'.
src/navigation/AppNavigator.tsx(649,9): error TS2322: Type '"Leaderboards"' is not assignable to type 'keyof RootStackParamList'.
src/navigation/navigationHandlers.ts(57,44): error TS2304: Cannot find name 'RewardDistribution'.
src/navigation/navigationHandlers.ts(104,51): error TS2339: Property 'joinTeam' does not exist on type 'NostrTeamService'.
src/navigation/navigationHandlers.ts(542,46): error TS2304: Cannot find name 'RewardDistribution'.
src/screens/activity/CyclingTrackerScreen.tsx(155,19): error TS2339: Property 'show' does not exist on type 'FC<CustomAlertProps>'.
src/screens/activity/HikingTrackerScreen.tsx(118,19): error TS2339: Property 'show' does not exist on type 'FC<CustomAlertProps>'.
src/screens/activity/HikingTrackerScreen.tsx(177,13): error TS2367: This comparison appears to be unintentional because the types '"running" | "walking" | "cycling"' and '"hiking"' have no overlap.
src/screens/activity/HikingTrackerScreen.tsx(274,60): error TS2345: Argument of type '"hiking"' is not assignable to parameter of type '"running" | "walking" | "cycling"'.
src/screens/activity/HikingTrackerScreen.tsx(521,13): error TS2322: Type '{ type: "running" | "walking" | "cycling" | "hiking"; distance: number; duration: number; calories: number; elevation?: number | undefined; steps?: number | undefined; localWorkoutId?: string | undefined; routeId?: string | undefined; routeName?: string | undefined; rewardSent?: boolean | undefined; rewardAmount?: n...' is not assignable to type '{ type: "running" | "walking" | "cycling"; distance: number; duration: number; calories: number; elevation?: number | undefined; pace?: number | undefined; speed?: number | undefined; ... 6 more ...; rewardAmount?: number | undefined; }'.
  Types of property 'type' are incompatible.
    Type '"running" | "walking" | "cycling" | "hiking"' is not assignable to type '"running" | "walking" | "cycling"'.
      Type '"hiking"' is not assignable to type '"running" | "walking" | "cycling"'.
src/screens/activity/RunningTrackerScreen.tsx(205,19): error TS2339: Property 'show' does not exist on type 'FC<CustomAlertProps>'.
src/screens/activity/WalkingTrackerScreen.tsx(174,19): error TS2339: Property 'show' does not exist on type 'FC<CustomAlertProps>'.
src/screens/CaptainDashboardScreen.tsx(225,50): error TS2551: Property 'getAllCompetitions' does not exist on type 'CompetitionService'. Did you mean 'getTeamCompetitions'?
src/screens/CaptainDashboardScreen.tsx(228,56): error TS7006: Parameter 'comp' implicitly has an 'any' type.
src/screens/CaptainDashboardScreen.tsx(493,32): error TS2339: Property 'find' does not exist on type '{}'.
src/screens/CaptainDashboardScreen.tsx(503,23): error TS18046: 'teams' is of type 'unknown'.
src/screens/CaptainDashboardScreen.tsx(503,35): error TS7006: Parameter 't' implicitly has an 'any' type.
src/screens/CaptainDashboardScreen.tsx(717,23): error TS2304: Cannot find name 'loadTeamCharity'.
src/screens/CaptainDashboardScreen.tsx(907,9): error TS2588: Cannot assign to 'authData' because it is a constant.
src/screens/CaptainDashboardScreen.tsx(929,13): error TS2588: Cannot assign to 'authData' because it is a constant.
src/screens/CaptainDashboardScreen.tsx(949,13): error TS2588: Cannot assign to 'authData' because it is a constant.
src/screens/CaptainDashboardScreen.tsx(1326,50): error TS2339: Property 'secondary' does not exist on type '{ readonly background: "#000000"; readonly cardBackground: "#0a0a0a"; readonly card: "#0a0a0a"; readonly border: "#1a1a1a"; readonly orangeBright: "#FF9D42"; readonly orangeDeep: "#FF7B1C"; ... 30 more ...; readonly buttons: { ...; }; }'.
src/screens/CaptainDashboardScreen.tsx(1336,50): error TS2339: Property 'secondary' does not exist on type '{ readonly background: "#000000"; readonly cardBackground: "#0a0a0a"; readonly card: "#0a0a0a"; readonly border: "#1a1a1a"; readonly orangeBright: "#FF9D42"; readonly orangeDeep: "#FF7B1C"; ... 30 more ...; readonly buttons: { ...; }; }'.
src/screens/CaptainDashboardScreen.tsx(1348,50): error TS2339: Property 'secondary' does not exist on type '{ readonly background: "#000000"; readonly cardBackground: "#0a0a0a"; readonly card: "#0a0a0a"; readonly border: "#1a1a1a"; readonly orangeBright: "#FF9D42"; readonly orangeDeep: "#FF7B1C"; ... 30 more ...; readonly buttons: { ...; }; }'.
src/screens/CaptainDashboardScreen.tsx(1357,50): error TS2339: Property 'secondary' does not exist on type '{ readonly background: "#000000"; readonly cardBackground: "#0a0a0a"; readonly card: "#0a0a0a"; readonly border: "#1a1a1a"; readonly orangeBright: "#FF9D42"; readonly orangeDeep: "#FF7B1C"; ... 30 more ...; readonly buttons: { ...; }; }'.
src/screens/CaptainDashboardScreen.tsx(1370,50): error TS2339: Property 'secondary' does not exist on type '{ readonly background: "#000000"; readonly cardBackground: "#0a0a0a"; readonly card: "#0a0a0a"; readonly border: "#1a1a1a"; readonly orangeBright: "#FF9D42"; readonly orangeDeep: "#FF7B1C"; ... 30 more ...; readonly buttons: { ...; }; }'.
src/screens/CaptainDashboardScreen.tsx(1815,25): error TS2339: Property 'secondary' does not exist on type '{ readonly background: "#000000"; readonly cardBackground: "#0a0a0a"; readonly card: "#0a0a0a"; readonly border: "#1a1a1a"; readonly orangeBright: "#FF9D42"; readonly orangeDeep: "#FF7B1C"; ... 30 more ...; readonly buttons: { ...; }; }'.
src/screens/CaptainDashboardScreen.tsx(1844,25): error TS2339: Property 'secondary' does not exist on type '{ readonly background: "#000000"; readonly cardBackground: "#0a0a0a"; readonly card: "#0a0a0a"; readonly border: "#1a1a1a"; readonly orangeBright: "#FF9D42"; readonly orangeDeep: "#FF7B1C"; ... 30 more ...; readonly buttons: { ...; }; }'.
src/screens/CaptainDashboardScreen.tsx(1958,3): error TS1117: An object literal cannot have multiple properties with the same name.
src/screens/DonateScreen.tsx(145,11): error TS2322: Type 'string | undefined' is not assignable to type 'string'.
  Type 'undefined' is not assignable to type 'string'.
src/screens/EventDetailScreen.tsx(185,41): error TS2304: Cannot find name 'initialTeamId'.
src/screens/EventDetailScreen.tsx(186,55): error TS2304: Cannot find name 'currentUser'.
src/screens/EventDetailScreen.tsx(426,26): error TS2304: Cannot find name 'rankings'.
src/screens/EventDetailScreen.tsx(603,37): error TS2304: Cannot find name 'eventJoinService'.
src/screens/EventDetailScreen.tsx(621,28): error TS2304: Cannot find name 'eventJoinService'.
src/screens/EventDetailScreen.tsx(688,28): error TS2304: Cannot find name 'eventJoinService'.
src/screens/EventDetailScreen.tsx(882,38): error TS7006: Parameter 'l' implicitly has an 'any' type.
src/screens/FitnessTestResultsScreen.tsx(85,13): error TS2322: Type 'FitnessTestComponent | null' is not assignable to type '{ reps: number; score: number; } | null'.
  Type 'FitnessTestComponent' is not assignable to type '{ reps: number; score: number; }'.
    Types of property 'reps' are incompatible.
      Type 'number | undefined' is not assignable to type 'number'.
        Type 'undefined' is not assignable to type 'number'.
src/screens/FitnessTestResultsScreen.tsx(86,13): error TS2322: Type 'FitnessTestComponent | null' is not assignable to type '{ reps: number; score: number; } | null'.
  Type 'FitnessTestComponent' is not assignable to type '{ reps: number; score: number; }'.
    Types of property 'reps' are incompatible.
      Type 'number | undefined' is not assignable to type 'number'.
        Type 'undefined' is not assignable to type 'number'.
src/screens/FitnessTestResultsScreen.tsx(87,13): error TS2322: Type 'FitnessTestComponent | null' is not assignable to type '{ timeSeconds: number; score: number; } | null'.
  Type 'FitnessTestComponent' is not assignable to type '{ timeSeconds: number; score: number; }'.
    Types of property 'timeSeconds' are incompatible.
      Type 'number | undefined' is not assignable to type 'number'.
        Type 'undefined' is not assignable to type 'number'.
src/screens/FitnessTestResultsScreen.tsx(95,49): error TS2339: Property 'uploadCardAndPublish' does not exist on type 'WorkoutPublishingService'.
src/screens/LeagueDetailScreen.tsx(63,49): error TS2339: Property 'getLeagueById' does not exist on type 'typeof SimpleCompetitionService'.
src/screens/SettingsScreen.tsx(575,53): error TS2339: Property 'imported' does not exist on type 'ImportResult'.
src/screens/SettingsScreen.tsx(578,43): error TS2339: Property 'imported' does not exist on type 'ImportResult'.
src/screens/SettingsScreen.tsx(578,69): error TS2339: Property 'imported' does not exist on type 'ImportResult'.
src/screens/SimpleTeamScreen.tsx(90,28): error TS2554: Expected 1 arguments, but got 0.
src/screens/SimpleTeamScreen.tsx(662,5): error TS2345: Argument of type '{ container: { flex: number; backgroundColor: "#000000"; }; errorContainer: { flex: number; justifyContent: "center"; alignItems: "center"; padding: number; }; errorText: { color: "#FFB366"; fontSize: number; marginBottom: number; }; ... 50 more ...; skeletonBadge: { ...; }; }' is not assignable to parameter of type '{ container: { flex: number; backgroundColor: "#000000"; }; errorContainer: { flex: number; justifyContent: "center"; alignItems: "center"; padding: number; }; errorText: { color: "#FFB366"; fontSize: number; marginBottom: number; }; ... 50 more ...; skeletonBadge: { ...; }; } & NamedStyles<...>'.
  Property 'bannerOverlay' is incompatible with index signature.
    Object literal may only specify known properties, and 'background' does not exist in type 'ViewStyle | TextStyle | ImageStyle'.
src/screens/TeamDiscoveryScreen.tsx(291,51): error TS2339: Property 'joinTeam' does not exist on type 'NostrTeamService'.
src/screens/TeamScreen.tsx(64,9): error TS2322: Type '{ teamName: string; onMenuPress: () => void; onLeaveTeam: (() => void) | undefined; onJoinTeam: (() => void) | undefined; onTeamDiscovery: () => void; userIsMember: boolean; }' is not assignable to type 'IntrinsicAttributes & TeamHeaderProps'.
  Property 'onMenuPress' does not exist on type 'IntrinsicAttributes & TeamHeaderProps'.
src/services/activity/SimpleRunTracker.ts(483,11): error TS2353: Object literal may only specify known properties, and 'notificationChannelId' does not exist in type 'LocationTaskServiceOptions'.
src/services/activity/SimpleRunTracker.ts(1215,9): error TS2353: Object literal may only specify known properties, and 'notificationChannelId' does not exist in type 'LocationTaskServiceOptions'.
src/services/analytics/BodyCompositionAnalytics.ts(510,81): error TS2345: Argument of type '"yoga"' is not assignable to parameter of type 'WorkoutType'.
src/services/analytics/CardioPerformanceAnalytics.ts(37,7): error TS2322: Type 'undefined' is not assignable to type 'HeartRateTrend'.
src/services/analytics/CardioPerformanceAnalytics.ts(285,53): error TS2339: Property 'heartRate' does not exist on type 'LocalWorkout'.
src/services/analytics/CardioPerformanceAnalytics.ts(343,28): error TS2339: Property 'heartRate' does not exist on type 'LocalWorkout'.
src/services/analytics/CardioPerformanceAnalytics.ts(360,29): error TS2339: Property 'heartRate' does not exist on type 'LocalWorkout'.
src/services/analytics/CardioPerformanceAnalytics.ts(370,27): error TS2339: Property 'heartRate' does not exist on type 'LocalWorkout'.
src/services/auth/authService.ts(64,28): error TS2339: Property 'clearAll' does not exist on type 'typeof CaptainCache'.
src/services/auth/authService.ts(94,45): error TS2307: Cannot find module '../nutzap/nutzapService' or its corresponding type declarations.
src/services/auth/DeleteAccountService.ts(7,10): error TS2614: Module '"@nostr-dev-kit/ndk"' has no exported member 'NDK'. Did you mean to use 'import NDK from "@nostr-dev-kit/ndk"' instead?
src/services/auth/providers/amberAuthProvider.ts(96,35): error TS2304: Cannot find name 'nutzapService'.
src/services/auth/providers/nostrAuthProvider.ts(158,35): error TS2304: Cannot find name 'nutzapService'.
src/services/auth/providers/nostrAuthProvider.ts(448,35): error TS2304: Cannot find name 'nutzapService'.
src/services/cache/UnifiedNostrCache.ts(229,9): error TS2322: Type 'CacheEntry<T> | null' is not assignable to type 'CacheEntry<any> | undefined'.
  Type 'null' is not assignable to type 'CacheEntry<any> | undefined'.
src/services/cache/UnifiedNostrCache.ts(290,7): error TS2322: Type 'CacheEntry<T> | null' is not assignable to type 'CacheEntry<any> | undefined'.
  Type 'null' is not assignable to type 'CacheEntry<any> | undefined'.
src/services/cache/UnifiedNostrCache.ts(541,5): error TS2322: Type 'T | undefined' is not assignable to type 'T'.
  'T' could be instantiated with an arbitrary type which could be unrelated to 'T | undefined'.
src/services/competition/Competition1301QueryService.ts(108,42): error TS2339: Property 'npub' does not exist on type 'string'.
src/services/competition/Competition1301QueryService.ts(108,52): error TS2339: Property 'pubkey' does not exist on type 'string'.
src/services/competition/Competition1301QueryService.ts(249,31): error TS2339: Property 'activityType' does not exist on type 'NostrWorkout'.
src/services/competition/Competition1301QueryService.ts(366,46): error TS7006: Parameter 't' implicitly has an 'any' type.
src/services/competition/Competition1301QueryService.ts(409,7): error TS2353: Object literal may only specify known properties, and 'activityType' does not exist in type 'NostrWorkout'.
src/services/competition/Competition1301QueryService.ts(517,15): error TS18048: 'query.memberNpubs' is possibly 'undefined'.
src/services/competition/Competition1301QueryService.ts(642,48): error TS2339: Property 'activityType' does not exist on type 'NostrWorkout'.
src/services/competition/Competition1301QueryService.ts(648,68): error TS2339: Property 'activityType' does not exist on type 'NostrWorkout'.
src/services/competition/Competition1301QueryService.ts(677,103): error TS2339: Property 'activityType' does not exist on type 'NostrWorkout'.
src/services/competition/eventEligibilityService.ts(12,3): error TS2305: Module '"../../types/nostrCompetition"' has no exported member 'NostrEvent'.
src/services/competition/eventEligibilityService.ts(151,63): error TS2339: Property 'getTeamEvents' does not exist on type 'NostrCompetitionService'.
src/services/competition/eventEligibilityService.ts(241,11): error TS2741: Property 'strength' is missing in type '{ running: "Running"[]; walking: "Walking"[]; cycling: "Cycling"[]; hiking: ("Running" | "Walking")[]; gym: "Strength Training"[]; strength_training: "Strength Training"[]; meditation: never[]; diet: never[]; fasting: never[]; other: never[]; }' but required in type 'Record<WorkoutType, NostrActivityType[]>'.
src/services/competition/eventEligibilityService.ts(409,57): error TS2339: Property 'submitEventEntry' does not exist on type 'NostrCompetitionService'.
src/services/competition/JoinRequestService.ts(54,15): error TS2322: Type '1106 | 1101' is not assignable to type 'NDKKind'.
  Type '1106' is not assignable to type 'NDKKind'.
src/services/competition/JoinRequestService.ts(120,15): error TS2322: Type '1106 | 1101' is not assignable to type 'NDKKind'.
  Type '1106' is not assignable to type 'NDKKind'.
src/services/competition/JoinRequestService.ts(152,42): error TS2339: Property 'addMember' does not exist on type 'NostrListService'.
src/services/competition/leaderboardService.ts(100,50): error TS2339: Property 'getTeamMembers' does not exist on type 'NostrTeamService'.
src/services/competition/leaderboardService.ts(246,48): error TS2339: Property 'getTeamMembers' does not exist on type 'NostrTeamService'.
src/services/competition/leaderboardService.ts(352,11): error TS2345: Argument of type 'WorkoutEvent' is not assignable to parameter of type 'Event'.
  Type 'WorkoutEvent' is missing the following properties from type 'Event': kind, sig
src/services/competition/leagueRankingService.ts(326,16): error TS2678: Type '"5K Race"' is not comparable to type 'NostrLeagueCompetitionType'.
src/services/competition/leagueRankingService.ts(327,16): error TS2678: Type '"10K Race"' is not comparable to type 'NostrLeagueCompetitionType'.
src/services/competition/leagueRankingService.ts(328,16): error TS2678: Type '"Half Marathon"' is not comparable to type 'NostrLeagueCompetitionType'.
src/services/competition/leagueRankingService.ts(329,16): error TS2678: Type '"Marathon"' is not comparable to type 'NostrLeagueCompetitionType'.
src/services/competition/NostrLeaderboardService.ts(368,17): error TS2322: Type '30150' is not assignable to type 'NDKKind'.
src/services/competition/SimpleCompetitionService.ts(82,17): error TS2322: Type '30100' is not assignable to type 'NDKKind'.
src/services/competition/SimpleCompetitionService.ts(135,17): error TS2322: Type '30101' is not assignable to type 'NDKKind'.
src/services/competition/SimpleCompetitionService.ts(285,17): error TS2322: Type '30101' is not assignable to type 'NDKKind'.
src/services/competition/SimpleCompetitionService.ts(309,19): error TS2322: Type '30101' is not assignable to type 'NDKKind'.
src/services/competition/SimpleCompetitionService.ts(462,19): error TS2339: Property 'captainId' does not exist on type '{}'.
src/services/competition/SimpleCompetitionService.ts(464,53): error TS2339: Property 'captainId' does not exist on type '{}'.
src/services/competition/SimpleCompetitionService.ts(469,36): error TS2339: Property 'captainId' does not exist on type '{}'.
src/services/competition/SimpleCompetitionService.ts(516,17): error TS2322: Type '30100' is not assignable to type 'NDKKind'.
src/services/competition/SimpleCompetitionService.ts(564,17): error TS2322: Type '30101' is not assignable to type 'NDKKind'.
src/services/competition/SimpleCompetitionService.ts(621,19): error TS2322: Type '30101' is not assignable to type 'NDKKind'.
src/services/competition/SimpleCompetitionService.ts(675,17): error TS2322: Type '30102' is not assignable to type 'NDKKind'.
src/services/competition/SimpleCompetitionService.ts(751,9): error TS2322: Type 'number' is not assignable to type '24'.
src/services/competition/SimpleCompetitionService.ts(753,9): error TS2322: Type 'number' is not assignable to type '2'.
src/services/competition/SimpleCompetitionService.ts(863,9): error TS2322: Type 'string | undefined' is not assignable to type 'string'.
  Type 'undefined' is not assignable to type 'string'.
src/services/competition/SimpleLeaderboardService.ts(470,31): error TS2339: Property 'getCachedLeaderboardWorkouts' does not exist on type 'typeof UnifiedCacheService'.
src/services/competition/SimpleLeaderboardService.ts(512,33): error TS2339: Property 'nip19' does not exist on type 'NDK'.
src/services/competition/SimpleLeaderboardService.ts(545,17): error TS2322: Type '1301' is not assignable to type 'NDKKind'.
src/services/competition/SimpleLeaderboardService.ts(629,33): error TS2339: Property 'cacheLeaderboardWorkouts' does not exist on type 'typeof UnifiedCacheService'.
src/services/competition/SimpleLeaderboardService.ts(729,9): error TS2322: Type 'number | undefined' is not assignable to type 'number'.
  Type 'undefined' is not assignable to type 'number'.
src/services/competition/SimpleLeaderboardService.ts(992,9): error TS2740: Type '{}' is missing the following properties from type '{ teamId: string; date: string; leaderboard5k: LeaderboardEntry[]; leaderboard10k: LeaderboardEntry[]; leaderboardHalf: LeaderboardEntry[]; leaderboardMarathon: LeaderboardEntry[]; }': teamId, date, leaderboard5k, leaderboard10k, and 2 more.
src/services/competition/SimpleLeaderboardService.ts(1006,15): error TS2322: Type '1301' is not assignable to type 'NDKKind'.
src/services/competition/SimpleLeaderboardService.ts(1255,9): error TS2740: Type '{}' is missing the following properties from type '{ date: string; leaderboard5k: LeaderboardEntry[]; leaderboard10k: LeaderboardEntry[]; leaderboardHalf: LeaderboardEntry[]; leaderboardMarathon: LeaderboardEntry[]; leaderboardSteps: LeaderboardEntry[]; }': date, leaderboard5k, leaderboard10k, leaderboardHalf, and 2 more.
src/services/competition/SimpleLeaderboardService.ts(1268,15): error TS2322: Type '1301' is not assignable to type 'NDKKind'.
src/services/competition/SimpleLeaderboardService.ts(1387,51): error TS2345: Argument of type '300' is not assignable to parameter of type 'keyof CacheConfig | undefined'.
src/services/core/AppInitializationService.ts(21,11): error TS2300: Duplicate identifier 'hasCompleted'.
src/services/core/AppInitializationService.ts(233,9): error TS2300: Duplicate identifier 'hasCompleted'.
src/services/events/RunstrAutoPayoutService.ts(107,12): error TS2678: Type '"random_lottery"' is not comparable to type 'RunstrPayoutScheme'.
src/services/events/RunstrAutoPayoutService.ts(404,12): error TS2678: Type '"random_lottery"' is not comparable to type 'RunstrPayoutScheme'.
src/services/fitness/FitnessTestService.ts(315,9): error TS2322: Type 'FitnessTestComponent | null' is not assignable to type '{ reps: number; score: number; } | null'.
  Type 'FitnessTestComponent' is not assignable to type '{ reps: number; score: number; }'.
    Types of property 'reps' are incompatible.
      Type 'number | undefined' is not assignable to type 'number'.
        Type 'undefined' is not assignable to type 'number'.
src/services/fitness/FitnessTestService.ts(316,9): error TS2322: Type 'FitnessTestComponent | null' is not assignable to type '{ reps: number; score: number; } | null'.
  Type 'FitnessTestComponent' is not assignable to type '{ reps: number; score: number; }'.
    Types of property 'reps' are incompatible.
      Type 'number | undefined' is not assignable to type 'number'.
        Type 'undefined' is not assignable to type 'number'.
src/services/fitness/FitnessTestService.ts(317,9): error TS2322: Type 'FitnessTestComponent | null' is not assignable to type '{ timeSeconds: number; score: number; } | null'.
  Type 'FitnessTestComponent' is not assignable to type '{ timeSeconds: number; score: number; }'.
    Types of property 'timeSeconds' are incompatible.
      Type 'number | undefined' is not assignable to type 'number'.
        Type 'undefined' is not assignable to type 'number'.
src/services/fitness/healthKitService.ts(50,7): error TS18046: 'e' is of type 'unknown'.
src/services/fitness/healthKitService.ts(362,5): error TS2322: Type 'unknown' is not assignable to type '{ success: boolean; error?: string | undefined; }'.
src/services/fitness/healthKitService.ts(1370,16): error TS18046: 'error' is of type 'unknown'.
src/services/fitness/nostrWorkoutService.ts(482,11): error TS2353: Object literal may only specify known properties, and 'yoga' does not exist in type '{ running: number; walking: number; cycling: number; other: number; hiking: number; gym: number; strength_training: number; strength: number; meditation: number; diet: number; fasting: number; }'.
src/services/fitness/nostrWorkoutSyncService.ts(509,11): error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.
src/services/fitness/Nuclear1301Service.ts(362,17): error TS2739: Type '{ id: any; userId: string; type: any; startTime: string; endTime: string; duration: number; distance: number; calories: number; pace: number | undefined; sets: number | undefined; reps: number | undefined; ... 10 more ...; syncedAt: string; }' is missing the following properties from type 'NostrWorkout': nostrCreatedAt, unitSystem
src/services/fitness/Nuclear1301Service.ts(404,17): error TS2739: Type '{ id: any; userId: string; type: any; startTime: string; endTime: string; duration: number; distance: number; calories: number; source: "nostr"; nostrEventId: any; nostrPubkey: any; syncedAt: string; }' is missing the following properties from type 'NostrWorkout': nostrCreatedAt, unitSystem
src/services/fitness/Nuclear1301Service.ts(558,17): error TS2739: Type '{ id: any; userId: string; type: any; startTime: string; endTime: string; duration: number; distance: number; calories: number; sets: number | undefined; reps: number | undefined; weight: number | undefined; ... 5 more ...; syncedAt: string; }' is missing the following properties from type 'NostrWorkout': nostrCreatedAt, unitSystem
src/services/fitness/SimpleWorkoutService.ts(426,59): error TS2345: Argument of type 'Filter[]' is not assignable to parameter of type 'Filter'.
  Index signature for type '`#${string}`' is missing in type 'Filter[]'.
src/services/fitness/SimpleWorkoutService.ts(605,64): error TS18046: 'error' is of type 'unknown'.
src/services/index.ts(11,35): error TS2307: Cannot find module './team/TeamMemberService' or its corresponding type declarations.
src/services/index.ts(21,10): error TS2724: '"./notificationService"' has no exported member named 'notificationService'. Did you mean 'NotificationService'?
src/services/index.ts(24,30): error TS2307: Cannot find module './cache/CacheService' or its corresponding type declarations.
src/services/integrations/nostrCompetitionBridge.ts(397,7): error TS2322: Type '"yoga"' is not assignable to type 'WorkoutType'.
src/services/integrations/nostrCompetitionBridge.ts(418,7): error TS2353: Object literal may only specify known properties, and 'yoga' does not exist in type 'Record<WorkoutType, number>'.
src/services/journal/JournalService.ts(11,30): error TS7016: Could not find a declaration file for module 'uuid'. '/Users/larry/RUNSTR/node_modules/uuid/dist/esm-browser/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/uuid` if it exists or add a new declaration (.d.ts) file containing `declare module 'uuid';`
src/services/nostr/GlobalNDKService.ts(108,7): error TS2353: Object literal may only specify known properties, and 'autoFetchUserMutelist' does not exist in type 'NDKConstructorParams'.
src/services/nostr/GlobalNDKService.ts(470,9): error TS2353: Object literal may only specify known properties, and 'autoFetchUserMutelist' does not exist in type 'NDKConstructorParams'.
src/services/nostr/NostrCompetitionService.ts(684,27): error TS2576: Property 'createLeague' does not exist on type 'NostrCompetitionService'. Did you mean to access the static member 'NostrCompetitionService.createLeague' instead?
src/services/nostr/NostrCompetitionService.ts(689,27): error TS2576: Property 'createEvent' does not exist on type 'NostrCompetitionService'. Did you mean to access the static member 'NostrCompetitionService.createEvent' instead?
src/services/nostr/NostrPrefetchService.ts(85,38): error TS2345: Argument of type 'string | null' is not assignable to parameter of type 'string'.
  Type 'null' is not assignable to type 'string'.
src/services/nostr/NostrPrefetchService.ts(312,58): error TS2345: Argument of type 'string | null' is not assignable to parameter of type 'string'.
  Type 'null' is not assignable to type 'string'.
src/services/nostr/NostrPrefetchService.ts(315,36): error TS2345: Argument of type 'string | null' is not assignable to parameter of type 'string'.
  Type 'null' is not assignable to type 'string'.
src/services/nostr/NostrProfilePublisher.ts(288,35): error TS2345: Argument of type 'string | null' is not assignable to parameter of type 'string'.
  Type 'null' is not assignable to type 'string'.
src/services/nostr/NostrProfilePublisher.ts(304,27): error TS2339: Property 'id' does not exist on type '{}'.
src/services/nostr/NostrProfilePublisher.ts(306,34): error TS2339: Property 'createdAt' does not exist on type '{}'.
src/services/nostr/NostrProfilePublisher.ts(310,69): error TS2339: Property 'name' does not exist on type '{}'.
src/services/nostr/NostrProfilePublisher.ts(314,25): error TS2339: Property 'displayName' does not exist on type '{}'.
src/services/nostr/NostrProtocolHandler.ts(302,13): error TS2322: Type '{ id: string; sig: string; created_at: number; content: string; tags: NDKTag[]; kind?: NDKKind | number; pubkey: string; }' is not assignable to type 'Event'.
  Types of property 'kind' are incompatible.
    Type 'number | undefined' is not assignable to type 'number'.
      Type 'undefined' is not assignable to type 'number'.
src/services/nostr/NostrTeamCreationService.ts(33,15): error TS2304: Cannot find name 'NostrEvent'.
src/services/nostr/NostrTeamCreationService.ts(34,21): error TS2304: Cannot find name 'NostrEvent'.
src/services/nostr/NostrTeamCreationService.ts(189,9): error TS2345: Argument of type '{ pubkey: string; addedAt: number; }[]' is not assignable to parameter of type 'string[]'.
  Type '{ pubkey: string; addedAt: number; }' is not assignable to type 'string'.
src/services/nostr/NostrTeamCreationService.ts(200,44): error TS2304: Cannot find name 'NostrEvent'.
src/services/nostr/NostrTeamCreationService.ts(201,56): error TS2304: Cannot find name 'NostrEvent'.
src/services/nostr/NostrTeamCreationService.ts(282,56): error TS2304: Cannot find name 'NostrEvent'.
src/services/nostr/NostrTeamCreationService.ts(320,14): error TS2339: Property 'charityId' does not exist on type 'TeamCreationData'.
src/services/nostr/NostrTeamCreationService.ts(321,34): error TS2339: Property 'charityId' does not exist on type 'TeamCreationData'.
src/services/nostr/NostrTeamCreationService.ts(324,14): error TS2339: Property 'flashUrl' does not exist on type 'TeamCreationData'.
src/services/nostr/NostrTeamCreationService.ts(325,32): error TS2339: Property 'flashUrl' does not exist on type 'TeamCreationData'.
src/services/nostr/SimpleNostrService.ts(326,59): error TS2345: Argument of type 'Filter[]' is not assignable to parameter of type 'Filter'.
  Index signature for type '`#${string}`' is missing in type 'Filter[]'.
src/services/nostr/workoutCardGenerator.ts(936,12): error TS7053: Element implicitly has an 'any' type because expression of type 'WorkoutType' can't be used to index type '{ running: string; cycling: string; walking: string; hiking: string; gym: string; strength_training: string; yoga: string; meditation: string; other: string; }'.
  Property 'strength' does not exist on type '{ running: string; cycling: string; walking: string; hiking: string; gym: string; strength_training: string; yoga: string; meditation: string; other: string; }'.
src/services/nostr/workoutCardGenerator.ts(1226,18): error TS7053: Element implicitly has an 'any' type because expression of type 'WorkoutType' can't be used to index type '{ running: string; cycling: string; walking: string; hiking: string; gym: string; strength_training: string; yoga: string; meditation: string; other: string; }'.
  Property 'strength' does not exist on type '{ running: string; cycling: string; walking: string; hiking: string; gym: string; strength_training: string; yoga: string; meditation: string; other: string; }'.
src/services/nostr/workoutPublishingService.ts(224,9): error TS2345: Argument of type 'Charity | null | undefined' is not assignable to parameter of type 'Charity | null'.
  Type 'undefined' is not assignable to type 'Charity | null'.
src/services/nostr/workoutPublishingService.ts(504,53): error TS2339: Property 'getTeamById' does not exist on type 'typeof NdkTeamService'.
src/services/notifications/NostrNotificationEventHandler.ts(102,19): error TS2322: Type '1101' is not assignable to type 'NDKKind'.
src/services/notifications/NostrNotificationEventHandler.ts(102,25): error TS2322: Type '1102' is not assignable to type 'NDKKind'.
src/services/notifications/NotificationService.ts(82,40): error TS2554: Expected 0 arguments, but got 1.
src/services/notifications/TeamContextService.ts(190,48): error TS2339: Property 'getTeamMembers' does not exist on type 'NostrTeamService'.
src/services/notifications/TeamContextService.ts(235,46): error TS2339: Property 'getTeamMembers' does not exist on type 'NostrTeamService'.
src/services/notifications/TeamJoinNotificationHandler.ts(86,19): error TS2322: Type '1104' is not assignable to type 'NDKKind'.
src/services/notifications/TeamJoinNotificationHandler.ts(214,15): error TS2820: Type '"view_join_requests"' is not assignable to type 'NotificationActionType'. Did you mean '"deny_join_request"'?
src/services/notifications/UnifiedNotificationStore.ts(447,11): error TS2739: Type '{ challenge_request: string; challenge_accepted: string; challenge_declined: string; competition_announcement: string; competition_reminder: string; competition_results: string; incoming_zap: string; team_join_request: string; workout_comment: string; workout_zap: string; }' is missing the following properties from type 'Record<UnifiedNotificationType, string>': challenge_received, event_join_request
src/services/nutzap/LightningZapService.ts(295,58): error TS2345: Argument of type 'NDKEvent' is not assignable to parameter of type 'NostrEvent'.
  Types of property 'created_at' are incompatible.
    Type 'number | undefined' is not assignable to type 'number'.
      Type 'undefined' is not assignable to type 'number'.
src/services/nutzap/LightningZapService.ts(302,7): error TS2322: Type 'string' is not assignable to type 'NDKEvent'.
src/services/satlantis/SatlantisEventJoinService.ts(222,19): error TS2322: Type 'string | undefined' is not assignable to type 'string'.
  Type 'undefined' is not assignable to type 'string'.
src/services/season/LeaderboardBaselineService.ts(361,15): error TS2322: Type '{ pubkey: string; npub: string | undefined; name: string; picture: string | undefined; totalDistanceKm: number; workoutCount: number; isFinisher: boolean; finisherRank: number | undefined; isSeasonParticipant: boolean; isLocalJoin: boolean; }[]' is not assignable to type 'RunningBitcoinParticipant[]'.
  Property 'isJoined' is missing in type '{ pubkey: string; npub: string | undefined; name: string; picture: string | undefined; totalDistanceKm: number; workoutCount: number; isFinisher: boolean; finisherRank: number | undefined; isSeasonParticipant: boolean; isLocalJoin: boolean; }' but required in type 'RunningBitcoinParticipant'.
src/services/season/LeaderboardBaselineService.ts(394,15): error TS2322: Type '{ pubkey: string; npub: string | undefined; name: string; picture: string | undefined; totalDistanceKm: number; workoutCount: number; isSeasonParticipant: boolean; isLocalJoin: boolean; rank: number; }[]' is not assignable to type 'JanuaryWalkingParticipant[]'.
  Type '{ pubkey: string; npub: string | undefined; name: string; picture: string | undefined; totalDistanceKm: number; workoutCount: number; isSeasonParticipant: boolean; isLocalJoin: boolean; rank: number; }' is missing the following properties from type 'JanuaryWalkingParticipant': totalSteps, isJoined
src/services/season/LeaderboardBaselineService.ts(410,39): error TS2339: Property 'totalDistanceKm' does not exist on type 'JanuaryWalkingParticipant'.
src/services/season/LeaderboardBaselineService.ts(410,59): error TS2339: Property 'totalDistanceKm' does not exist on type 'JanuaryWalkingParticipant'.
src/services/season/LeaderboardBaselineService.ts(418,11): error TS2353: Object literal may only specify known properties, and 'totalDistanceKm' does not exist in type 'JanuaryWalkingLeaderboard'.
src/services/season/LeaderboardBaselineService.ts(527,9): error TS2353: Object literal may only specify known properties, and 'isSeasonParticipant' does not exist in type 'RunningBitcoinParticipant'.
src/services/season/LeaderboardBaselineService.ts(573,17): error TS2339: Property 'totalDistanceKm' does not exist on type '{ pubkey: string; npub?: string | undefined; name: string; picture?: string | undefined; totalSteps: number; workoutCount: number; isJoined: boolean; rank: number; }'.
src/services/season/LeaderboardBaselineService.ts(583,9): error TS2353: Object literal may only specify known properties, and 'totalDistanceKm' does not exist in type 'JanuaryWalkingParticipant'.
src/services/season/LeaderboardBaselineService.ts(592,42): error TS2339: Property 'totalDistanceKm' does not exist on type 'JanuaryWalkingParticipant'.
src/services/season/LeaderboardBaselineService.ts(592,62): error TS2339: Property 'totalDistanceKm' does not exist on type 'JanuaryWalkingParticipant'.
src/services/season/LeaderboardBaselineService.ts(597,71): error TS2339: Property 'totalDistanceKm' does not exist on type 'JanuaryWalkingParticipant'.
src/services/season/LeaderboardBaselineService.ts(602,7): error TS2353: Object literal may only specify known properties, and 'totalDistanceKm' does not exist in type 'JanuaryWalkingLeaderboard'.
src/services/season/Season1Service.ts(51,7): error TS18046: 'leaderboard' is of type 'unknown'.
src/services/team/LocalTeamMembershipService.ts(259,55): error TS2339: Property 'isUserTeamMember' does not exist on type 'TeamMembershipService'.
src/services/team/LocalTeamMembershipService.ts(263,33): error TS2551: Property 'joinTeamLocal' does not exist on type 'TeamMembershipService'. Did you mean 'joinTeamLocally'?
src/services/team/NdkTeamService.ts(272,56): error TS2339: Property 'image' does not exist on type '{ id: string; name: string; description: string; captain: string; captainHex: string; createdAt: number; rawEvent: { created_at: number; content: string; tags: string[][]; kind: number; pubkey: string; id: string; sig: string; }; }'.
src/services/team/TeamMemberCache.ts(28,14): error TS2323: Cannot redeclare exported variable 'TeamMemberCache'.
src/services/team/TeamMemberCache.ts(362,10): error TS2323: Cannot redeclare exported variable 'TeamMemberCache'.
src/services/team/TeamMemberCache.ts(362,10): error TS2484: Export declaration conflicts with exported declaration of 'TeamMemberCache'.
src/services/user/profileService.ts(63,9): error TS2322: Type 'null' is not assignable to type 'string | undefined'.
src/services/wallet/NWCStorageService.ts(54,9): error TS2353: Object literal may only specify known properties, and 'websocketImplementation' does not exist in type 'NewNWCClientOptions'.
src/services/wallet/NWCWalletService.ts(144,9): error TS2353: Object literal may only specify known properties, and 'websocketImplementation' does not exist in type 'NewNWCClientOptions'.
src/services/wallet/PaymentRouter.ts(56,32): error TS2551: Property 'ENABLE_CASHU_WALLET' does not exist on type '{ readonly ENABLE_NWC_WALLET: true; readonly ENABLE_DAILY_REWARDS: true; readonly ENABLE_CHARITY_ZAPS: true; readonly ENABLE_EVENT_TICKETS: true; }'. Did you mean 'ENABLE_NWC_WALLET'?
src/services/wallet/PaymentRouter.ts(70,27): error TS2551: Property 'ENABLE_CASHU_WALLET' does not exist on type '{ readonly ENABLE_NWC_WALLET: true; readonly ENABLE_DAILY_REWARDS: true; readonly ENABLE_CHARITY_ZAPS: true; readonly ENABLE_EVENT_TICKETS: true; }'. Did you mean 'ENABLE_NWC_WALLET'?
src/services/wallet/PaymentRouter.ts(73,28): error TS2552: Cannot find name 'WalletCore'. Did you mean 'walletCore'?
src/services/wallet/PaymentRouter.ts(119,11): error TS2554: Expected 1-2 arguments, but got 3.
src/services/wallet/PaymentRouter.ts(128,27): error TS2551: Property 'ENABLE_CASHU_WALLET' does not exist on type '{ readonly ENABLE_NWC_WALLET: true; readonly ENABLE_DAILY_REWARDS: true; readonly ENABLE_CHARITY_ZAPS: true; readonly ENABLE_EVENT_TICKETS: true; }'. Did you mean 'ENABLE_NWC_WALLET'?
src/services/wallet/PaymentRouter.ts(166,27): error TS2551: Property 'ENABLE_CASHU_WALLET' does not exist on type '{ readonly ENABLE_NWC_WALLET: true; readonly ENABLE_DAILY_REWARDS: true; readonly ENABLE_CHARITY_ZAPS: true; readonly ENABLE_EVENT_TICKETS: true; }'. Did you mean 'ENABLE_NWC_WALLET'?
src/services/wallet/PaymentRouter.ts(167,28): error TS2552: Cannot find name 'WalletCore'. Did you mean 'walletCore'?
src/services/wallet/PaymentRouter.ts(199,27): error TS2551: Property 'ENABLE_CASHU_WALLET' does not exist on type '{ readonly ENABLE_NWC_WALLET: true; readonly ENABLE_DAILY_REWARDS: true; readonly ENABLE_CHARITY_ZAPS: true; readonly ENABLE_EVENT_TICKETS: true; }'. Did you mean 'ENABLE_NWC_WALLET'?
src/services/wallet/PaymentRouter.ts(218,25): error TS2551: Property 'ENABLE_CASHU_WALLET' does not exist on type '{ readonly ENABLE_NWC_WALLET: true; readonly ENABLE_DAILY_REWARDS: true; readonly ENABLE_CHARITY_ZAPS: true; readonly ENABLE_EVENT_TICKETS: true; }'. Did you mean 'ENABLE_NWC_WALLET'?
src/store/teamStore.ts(187,35): error TS2304: Cannot find name 'RealtimeChannel'.
src/store/userStore.ts(226,61): error TS2339: Property 'getRecommendedTeams' does not exist on type 'typeof TeamMembershipService'.
src/store/userStore.ts(251,52): error TS2339: Property 'switchTeams' does not exist on type 'typeof TeamMembershipService'.
src/store/userStore.ts(289,58): error TS2339: Property 'getTeamSwitchCooldown' does not exist on type 'typeof TeamMembershipService'.
src/store/userStore.ts(323,51): error TS2339: Property 'getTeamParticipationStats' does not exist on type 'typeof TeamMembershipService'.
src/store/userStore.ts(356,39): error TS2339: Property 'initializeUserForTeamDiscovery' does not exist on type 'typeof TeamMembershipService'.
src/types/nutzap.ts(6,23): error TS2307: Cannot find module '@cashu/cashu-ts' or its corresponding type declarations.
src/utils/applyGlobalPolyfills.ts(29,5): error TS2322: Type 'typeof TextEncoder' is not assignable to type '{ new (): TextEncoder; prototype: TextEncoder; }'.
  Types of property 'prototype' are incompatible.
    Type 'TextEncoder' is missing the following properties from type 'TextEncoder': encodeInto, encoding
src/utils/applyGlobalPolyfills.ts(32,5): error TS2322: Type 'typeof TextDecoder' is not assignable to type '{ new (label?: string | undefined, options?: TextDecoderOptions | undefined): TextDecoder; prototype: TextDecoder; }'.
  Types of property 'prototype' are incompatible.
    Type 'TextDecoder' is missing the following properties from type 'TextDecoder': encoding, fatal, ignoreBOM
src/utils/ndkConversion.ts(236,3): error TS2322: Type 'string | boolean' is not assignable to type 'boolean'.
  Type 'string' is not assignable to type 'boolean'.
src/utils/secretDecryptor.ts(9,38): error TS2307: Cannot find module '../config/encryptedSecrets' or its corresponding type declarations.
src/utils/testCompetitions.ts(287,9): error TS2345: Argument of type '{ teamId: string; name: string; description: string; activityType: "Running"; competitionType: "5K Race"; eventDate: string; entryFeesSats: number; maxParticipants: number; requireApproval: boolean; targetValue: number; targetUnit: string; }' is not assignable to parameter of type 'Omit<NostrEventDefinition, "status" | "createdAt" | "updatedAt" | "captainPubkey"> & { id?: string | undefined; }'.
  Property 'id' is missing in type '{ teamId: string; name: string; description: string; activityType: "Running"; competitionType: "5K Race"; eventDate: string; entryFeesSats: number; maxParticipants: number; requireApproval: boolean; targetValue: number; targetUnit: string; }' but required in type 'Omit<NostrEventDefinition, "status" | "createdAt" | "updatedAt" | "captainPubkey">'.
src/utils/testCompetitions.ts(340,45): error TS2339: Property 'getTeamMembers' does not exist on type 'typeof TeamMemberCache'.
src/utils/webSocketDebugger.ts(36,9): error TS2415: Class 'DebugWebSocket' incorrectly extends base class 'WebSocket'.
  Property 'url' is private in type 'DebugWebSocket' but not in type 'WebSocket'. ❌ *(fails on pre-existing repository-wide TypeScript errors unrelated to this one-file analytics patch)*

## Risk
Low — single-file analytics-path change, bounded storage, and fire-and-forget persistence with guarded error handling.
