### PR TITLE
fix: import Alert in receive bitcoin form to resolve wallet typecheck failure

### DIFF
--- a/src/components/wallet/ReceiveBitcoinForm.tsx
+++ b/src/components/wallet/ReceiveBitcoinForm.tsx
@@ -10,6 +10,7 @@ import {
   TextInput,
   TouchableOpacity,
   StyleSheet,
+  Alert,
 } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { theme } from '../../styles/theme';


### PR DESCRIPTION
## Summary
- add missing Alert import to ReceiveBitcoinForm from react-native
- restore compile-time symbol resolution for Alert.alert calls used in amount validation and QR sharing

## Validation
- npx tsc --noEmit --pretty false 2>&1 | rg "ReceiveBitcoinForm|TS2304"
  - before: showed ReceiveBitcoinForm.tsx TS2304 errors for missing Alert
  - after: no ReceiveBitcoinForm TS2304 errors remain (other unrelated TS2304 errors still present in project)

## Risk
- low: import-only change, no runtime behavior change beyond fixing missing symbol reference