### PR TITLE
perf: cap global daily leaderboard relay query

### DIFF
--- a/src/services/competition/SimpleLeaderboardService.ts
+++ b/src/services/competition/SimpleLeaderboardService.ts
@@ -1267,6 +1267,7 @@ export class SimpleLeaderboardService {
     const filter: NDKFilter = {
       kinds: [1301],
       since: todayMidnight,
+      limit: 200, // Bound relay fan-out for global daily leaderboard fetch
     };
 
     console.log(`📊 [GlobalLeaderboard] Query filter:`, JSON.stringify(filter, null, 2));


### PR DESCRIPTION
## Summary
Cap the global daily leaderboard relay query to a bounded event window to reduce unnecessary relay fan-out.

## Changes
- added limit: 200 to the global NDKFilter in SimpleLeaderboardService.getGlobalDailyLeaderboards

## Why
The global leaderboard path previously queried all kind 1301 events since midnight with no upper bound, which can increase relay/network load on high-volume days.

## Validation
- npx eslint src/services/competition/SimpleLeaderboardService.ts (passes with 2 pre-existing warnings, 0 errors)

## Risk
Low — only narrows fetch volume for this query path; downstream ranking logic unchanged.