### PR TITLE
fix(team): use Alert API in EventsCard error handlers

### DIFF
--- a/src/components/team/EventsCard.tsx
+++ b/src/components/team/EventsCard.tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   ScrollView,
   TouchableOpacity,
+  Alert,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { Card } from '../ui/Card';
@@ -13,7 +14,6 @@ import { theme } from '../../styles/theme';
 import { NostrListService } from '../../services/nostr/NostrListService';
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import { UnifiedSigningService } from '../../services/auth/UnifiedSigningService';
-import { CustomAlert } from '../ui/CustomAlert';
 import { GlobalNDKService } from '../../services/nostr/GlobalNDKService';
 
 // QR Code
@@ -181,7 +181,7 @@ export const EventsCard: React.FC<EventsCardProps> = ({
       setQrModalVisible(true);
     } catch (error) {
       console.error('Failed to generate event QR:', error);
-      CustomAlert.alert('Error', 'Failed to generate QR code', [
+      Alert.alert('Error', 'Failed to generate QR code', [
         { text: 'OK' },
       ]);
     }
@@ -221,7 +221,7 @@ export const EventsCard: React.FC<EventsCardProps> = ({
                 // Check if event has minimum required data
                 if (!event?.id) {
                   console.error('❌ Cannot navigate: Event missing ID');
-                  CustomAlert.alert(
+                  Alert.alert(
                     'Error',
                     'Unable to open event. Please try refreshing the page.',
                     [{ text: 'OK' }]
@@ -364,7 +364,7 @@ export const EventsCard: React.FC<EventsCardProps> = ({
       // Get signer (works for both nsec and Amber)
       const signer = await UnifiedSigningService.getInstance().getSigner();
       if (!signer) {
-        CustomAlert.alert(
+        Alert.alert(
           'Error',
           'No authentication found. Please login first.',
           [{ text: 'OK' }]
@@ -376,7 +376,7 @@ export const EventsCard: React.FC<EventsCardProps> = ({
       const userHexPubkey =
         await UnifiedSigningService.getInstance().getHexPubkey();
       if (!userHexPubkey) {
-        CustomAlert.alert('Error', 'Could not determine user public key', [
+        Alert.alert('Error', 'Could not determine user public key', [
           { text: 'OK' },
         ]);
         return;
@@ -396,7 +396,7 @@ export const EventsCard: React.FC<EventsCardProps> = ({
 
       // NOTE: Join request functionality disabled (old event system)
       // EventJoinRequestService was removed during migration to daily leaderboards
-      CustomAlert.alert(
+      Alert.alert(
         'Info',
         'Event join requests are currently unavailable. Please contact the team captain directly.',
         [{ text: 'OK' }]
@@ -412,7 +412,7 @@ export const EventsCard: React.FC<EventsCardProps> = ({
       }));
     } catch (error) {
       console.error('Failed to send join request:', error);
-      CustomAlert.alert('Error', 'Failed to send join request', [
+      Alert.alert('Error', 'Failed to send join request', [
         { text: 'OK' },
       ]);
     } finally {


### PR DESCRIPTION
## Summary
EventsCard called `CustomAlert.alert(...)` even though `CustomAlert` is a component, which caused TypeScript failures on event error paths.

## Changes
- import `Alert` from `react-native` in `EventsCard`
- replace all `CustomAlert.alert(...)` calls with `Alert.alert(...)`
- remove unused `CustomAlert` import

## Validation
- `npx eslint src/components/team/EventsCard.tsx` (passes with pre-existing warnings only)
- `npx tsc --noEmit --pretty false 2>&1 | rg "EventsCard\.tsx\(.*Property 'alert' does not exist"` (no matches)

## Risk
Low — one-file API call swap in existing error handling paths only.

## Rollback
Revert this PR to restore prior behavior.
