### PR TITLE
fix: align notification modal actions with unified action types

### DIFF
--- a/src/components/profile/NotificationModal.tsx
+++ b/src/components/profile/NotificationModal.tsx
@@ -110,7 +110,8 @@ export const NotificationModal: React.FC<NotificationModalProps> = ({
       case 'view_wallet':
         handleViewWallet();
         break;
-      case 'view_captain_dashboard':
+      case 'view_join_requests':
+      case 'view_event_requests':
         handleViewCaptainDashboard(notification);
         break;
       default:
@@ -145,7 +146,11 @@ export const NotificationModal: React.FC<NotificationModalProps> = ({
   const handleViewChallenge = (notification: UnifiedNotification) => {
     onClose();
     // For now, just close the modal - challenge details screen may not exist yet
-    console.log('View challenge:', notification.metadata?.challengeId);
+    const challengeId =
+      notification.metadata && 'challengeId' in notification.metadata
+        ? notification.metadata.challengeId
+        : undefined;
+    console.log('View challenge:', challengeId ?? notification.id);
   };
 
   const handleViewCompetition = (notification: UnifiedNotification) => {

--- a/src/types/unifiedNotifications.ts
+++ b/src/types/unifiedNotifications.ts
@@ -33,6 +33,7 @@ export type NotificationActionType =
   | 'view_wallet'
   | 'approve_join_request'
   | 'deny_join_request'
+  | 'view_join_requests'
   | 'view_event_requests'
   | 'view_workout'
   | 'reply_comment';


### PR DESCRIPTION
## Summary
- add missing 'view_join_requests' action to NotificationActionType
- update NotificationModal action handler to process view_join_requests and view_event_requests
- guard challenge metadata access before logging challenge IDs

## Validation
- npx eslint src/components/profile/NotificationModal.tsx src/types/unifiedNotifications.ts
- npx tsc --noEmit --pretty false 2>&1 | rg "(NotificationModal\.tsx\(|unifiedNotifications\.ts\()" || true