### PR TITLE
fix(wallet): add missing Alert import in ReceiveBitcoinForm

### DIFF
--- a/src/components/wallet/ReceiveBitcoinForm.tsx
+++ b/src/components/wallet/ReceiveBitcoinForm.tsx
@@ -10,6 +10,7 @@ import {
   TextInput,
   TouchableOpacity,
   StyleSheet,
+  Alert,
 } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { theme } from '../../styles/theme';


### PR DESCRIPTION
## Summary\n- add missing `Alert` import from `react-native` in `ReceiveBitcoinForm`\n- fixes TypeScript compile errors where `Alert.alert(...)` is used\n\n## Validation\n- `npx eslint src/components/wallet/ReceiveBitcoinForm.tsx` (warning only: existing unused `handleSubmit`)\n- `npx tsc --noEmit --pretty false 2>&1 | rg "ReceiveBitcoinForm\.tsx\(" || true` (no matches)\n\n## Risk\n- low (single import addition, no runtime behavior changes)\n