### PR TITLE
fix: remove duplicate TeamMemberCache re-export blocking typecheck

### DIFF
--- a/src/services/team/TeamMemberCache.ts
+++ b/src/services/team/TeamMemberCache.ts
@@ -359,4 +359,3 @@ export class TeamMemberCache {
 // Export class as default (not instance) to prevent blocking module initialization
 // Also keep named export for compatibility
 export default TeamMemberCache;
-export { TeamMemberCache };


### PR DESCRIPTION
## Summary\n- remove redundant `export { TeamMemberCache }` re-export from `TeamMemberCache.ts`\n- keep existing `export class TeamMemberCache` and `export default TeamMemberCache` exports intact\n\n## Why\n- TypeScript raised TS2323/TS2484 due to duplicate export declarations of `TeamMemberCache` in the same file\n\n## Validation\n- npm run -s typecheck *(known repo baseline failures remain, but targeted TeamMemberCache duplicate-export errors are cleared)*