### PR TITLE
fix: raise journal empty-state helper text contrast to pass WCAG AA

### DIFF
--- a/src/screens/activity/JournalTrackerScreen.tsx
+++ b/src/screens/activity/JournalTrackerScreen.tsx
@@ -112,7 +112,7 @@ const styles = StyleSheet.create({
     marginTop: theme.spacing.xl,
   },
   emptyText: {
-    color: theme.colors.textDark,
+    color: theme.colors.textMuted,
     fontSize: 13,
     marginTop: theme.spacing.lg,
   },


### PR DESCRIPTION
## Summary
- switch JournalTracker empty-state helper text color from `theme.colors.textDark` to `theme.colors.textMuted`
- keep scope to a one-line style token change in `JournalTrackerScreen.tsx`

## Why
- the helper text is 13px body copy and needs stronger contrast on black background to satisfy the audit finding

## Validation
- `rg -n "emptyText:|theme.colors.text(Muted|Dark)" src/screens/activity/JournalTrackerScreen.tsx`
- `npx eslint src/screens/activity/JournalTrackerScreen.tsx` *(blocked in this environment: ESLint v10 expects `eslint.config.js` while repo uses legacy `.eslintrc` config)*

## Risk
- low: style-token swap for one empty-state text rule only
