### PR TITLE
perf: honor fullRefresh flag so initial cache load stays priority-only

### DIFF
--- a/src/services/cache/UnifiedWorkoutCache.ts
+++ b/src/services/cache/UnifiedWorkoutCache.ts
@@ -334,6 +334,14 @@ class UnifiedWorkoutCacheClass {
     await yieldToReact();
     console.log(`[Batched] Yielded to React after Batch 1 at T+${Date.now() - startTime}ms`);
 
+    // Initial load should return after the priority batch to keep startup snappy.
+    // Full author fetch remains available via pull-to-refresh (fullRefresh=true).
+    if (!fullRefresh) {
+      this.pruneOldWorkouts(60);
+      console.log(`[Batched] Initial load mode complete after priority batch: ${this.workouts.size} workouts in ${Date.now() - startTime}ms`);
+      return;
+    }
+
     // After priority batch, continue fetching remaining authors
     // UI already has data to show, now we progressively add more
     console.log(`[Batched] Priority batch complete (${this.workouts.size} workouts in ${Date.now() - startTime}ms), continuing with ${otherAuthors.length} remaining authors...`);


### PR DESCRIPTION
## Summary\n- return early after the priority-author batch when \ is false\n- keep full batched author fetching for pull-to-refresh paths (\)\n- prune stale workouts before early return so startup cache hygiene remains intact\n\n## Validation\n- rg -n "if \\(!fullRefresh\\)|Initial load mode complete after priority batch" src/services/cache/UnifiedWorkoutCache.ts\n- npx eslint src/services/cache/UnifiedWorkoutCache.ts *(blocked by local ESLint v10 flat-config expectation; repo currently uses legacy .eslintrc)*\n\n## Risk\n- Low: only changes the branch point between initial-load and full-refresh paths in UnifiedWorkoutCache batching.