### PR TITLE
refactor: remove caller npub plumbing from supabase competition join/leave

### DIFF
--- a/src/hooks/useSupabaseLeaderboard.ts
+++ b/src/hooks/useSupabaseLeaderboard.ts
@@ -657,8 +657,7 @@ export function useCompetitionParticipation(competitionId: string) {
 
     // Fire-and-forget: Service handles local + Supabase sync
     const result = await SupabaseCompetitionService.joinCompetition(
-      competitionId,
-      npub
+      competitionId
     );
 
     // Service always returns success (optimistic pattern), but handle edge case
@@ -677,8 +676,7 @@ export function useCompetitionParticipation(competitionId: string) {
     setIsParticipating(false);
 
     const result = await SupabaseCompetitionService.leaveCompetition(
-      competitionId,
-      npub
+      competitionId
     );
 
     if (!result.success) {

--- a/src/services/backend/SupabaseCompetitionService.ts
+++ b/src/services/backend/SupabaseCompetitionService.ts
@@ -121,23 +121,20 @@ export class SupabaseCompetitionService {
   }
 
   /**
-   * Join a competition - adds user's npub to participant list
-   * Uses optimistic pattern: save locally first for instant UI, then sync to Supabase
+   * Join a competition - adds authenticated user's npub to participant list
+   * Uses optimistic pattern: save locally first for instant UI, then sync to Supabase.
    *
-   * SECURITY: The authenticated npub is derived from local auth storage.
-   * Any caller-provided npub is treated as untrusted and only used for mismatch diagnostics.
+   * SECURITY: Authenticated npub is always derived from local auth storage.
    *
    * @param competitionId - The competition UUID or external_id
-   * @param npub - Caller-provided npub (untrusted; service resolves authenticated npub)
    * @param profile - Optional profile data (name, picture) to store for leaderboard display
    * @returns Success status
    */
   static async joinCompetition(
     competitionId: string,
-    npub: string,
     profile?: { name?: string; picture?: string }
   ): Promise<{ success: boolean; error?: string }> {
-    const authenticatedNpub = await this.resolveAuthenticatedNpub(npub);
+    const authenticatedNpub = await this.resolveAuthenticatedNpub();
     if (!authenticatedNpub) {
       console.warn('[SupabaseCompetitionService] joinCompetition blocked: no authenticated npub in local storage');
       return { success: false, error: 'Not authenticated' };
@@ -202,20 +199,17 @@ export class SupabaseCompetitionService {
   }
 
   /**
-   * Leave a competition - removes user's npub from participant list
+   * Leave a competition - removes authenticated user's npub from participant list
    *
-   * SECURITY: The authenticated npub is derived from local auth storage.
-   * Any caller-provided npub is treated as untrusted and only used for mismatch diagnostics.
+   * SECURITY: Authenticated npub is always derived from local auth storage.
    *
    * @param competitionId - The competition UUID or external_id
-   * @param npub - Caller-provided npub (untrusted; service resolves authenticated npub)
    * @returns Success status
    */
   static async leaveCompetition(
-    competitionId: string,
-    npub: string
+    competitionId: string
   ): Promise<{ success: boolean; error?: string }> {
-    const authenticatedNpub = await this.resolveAuthenticatedNpub(npub);
+    const authenticatedNpub = await this.resolveAuthenticatedNpub();
     if (!authenticatedNpub) {
       return { success: false, error: 'Not authenticated' };
     }

--- a/src/services/challenge/EinundzwanzigService.ts
+++ b/src/services/challenge/EinundzwanzigService.ts
@@ -405,7 +405,6 @@ class EinundzwanzigServiceClass {
       // Register for the combined einundzwanzig competition
       const result = await SupabaseCompetitionService.joinCompetition(
         EINUNDZWANZIG_COMPETITION_ID,
-        npub,
         profileData
       );
 

--- a/src/services/challenge/JanuaryWalkingService.ts
+++ b/src/services/challenge/JanuaryWalkingService.ts
@@ -326,7 +326,6 @@ class JanuaryWalkingServiceClass {
 
       const result = await SupabaseCompetitionService.joinCompetition(
         'january-walking',
-        npub,
         profileData
       );
 

--- a/src/services/challenge/RunningBitcoinService.ts
+++ b/src/services/challenge/RunningBitcoinService.ts
@@ -659,7 +659,7 @@ class RunningBitcoinServiceClass {
       } catch {
         console.warn('[RunningBitcoin] Could not decode npub for profile lookup');
         // Still register without profile data
-        const result = await SupabaseCompetitionService.joinCompetition('running-bitcoin', npub);
+        const result = await SupabaseCompetitionService.joinCompetition('running-bitcoin');
         return result.success;
       }
 
@@ -683,7 +683,6 @@ class RunningBitcoinServiceClass {
       // Register in Supabase with profile data
       const result = await SupabaseCompetitionService.joinCompetition(
         'running-bitcoin',
-        npub,
         profileData
       );
 


### PR DESCRIPTION
## Summary
- remove caller `npub` from `SupabaseCompetitionService.joinCompetition` and `.leaveCompetition` public APIs
- always derive authenticated npub from local auth storage inside the service
- update challenge services and leaderboard hook call sites to use the simplified signatures

## Validation
- `rg -n "static async joinCompetition\(|static async leaveCompetition\(" src/services/backend/SupabaseCompetitionService.ts`
- `rg -n "SupabaseCompetitionService\.(joinCompetition|leaveCompetition)\(" src/services/challenge/RunningBitcoinService.ts src/services/challenge/EinundzwanzigService.ts src/services/challenge/JanuaryWalkingService.ts src/hooks/useSupabaseLeaderboard.ts`
- `npx eslint src/services/backend/SupabaseCompetitionService.ts src/services/challenge/RunningBitcoinService.ts src/services/challenge/EinundzwanzigService.ts src/services/challenge/JanuaryWalkingService.ts src/hooks/useSupabaseLeaderboard.ts` *(blocked locally: ESLint v10 flat-config expectation in this environment)*

## Risk
- low: signature simplification only; runtime auth source remains unchanged

## Rollback
- revert commit `cc89d2d6`
