### PR TITLE
fix: rename app init completion flag to avoid TS2300 duplicate identifier

### DIFF
--- a/src/services/core/AppInitializationService.ts
+++ b/src/services/core/AppInitializationService.ts
@@ -18,7 +18,7 @@ class AppInitializationService {
   private isInitializing = false;
   private abortController: AbortController | null = null;
   private timeoutId: NodeJS.Timeout | null = null;
-  private hasCompleted = false;
+  private hasCompletedFlag = false;
 
   private constructor() {}
 
@@ -41,7 +41,7 @@ class AppInitializationService {
     }
 
     this.isInitializing = true;
-    this.hasCompleted = false; // Reset completion flag
+    this.hasCompletedFlag = false; // Reset completion flag
     const MAX_INIT_TIME = 12000; // 12 second timeout (increased for first launch)
 
     // Create AbortController for proper cancellation
@@ -164,8 +164,8 @@ class AppInitializationService {
         }
 
         // CRITICAL FIX: Only set flags if not aborted and not already completed
-        if (!signal.aborted && !this.hasCompleted) {
-          this.hasCompleted = true; // Mark as completed to prevent timeout from running
+        if (!signal.aborted && !this.hasCompletedFlag) {
+          this.hasCompletedFlag = true; // Mark as completed to prevent timeout from running
           this.isInitialized = true;
 
           // Cancel the timeout since we succeeded
@@ -196,9 +196,9 @@ class AppInitializationService {
     const timeoutPromise = new Promise<void>((resolve) => {
       this.timeoutId = setTimeout(() => {
         // Only execute timeout if initialization hasn't completed
-        if (!this.hasCompleted) {
+        if (!this.hasCompletedFlag) {
           console.warn('⚠️ AppInit: Timeout reached - partial data loaded');
-          this.hasCompleted = true; // Prevent success path from running
+          this.hasCompletedFlag = true; // Prevent success path from running
 
           // CRITICAL: Abort the initialization to prevent orphaned promises
           if (this.abortController) {


### PR DESCRIPTION
## Summary\n- rename the internal completion boolean in AppInitializationService from `hasCompleted` to `hasCompletedFlag`\n- keep the public `hasCompleted()` async accessor unchanged\n- update all internal guard/timeout references to the renamed flag\n\n## Why\nTypeScript reported duplicate identifier errors in `AppInitializationService.ts` because the class had both a property and method named `hasCompleted`. This blocks typecheck signal quality for this module.\n\n## Validation\n- npm -s run typecheck | rg "AppInitializationService.ts\((21,11|233,9)\): error TS2300" (no matches)\n