### PR TITLE
fix: improve workout source label contrast for dark theme accessibility

### DIFF
--- a/src/components/profile/shared/WorkoutCard.tsx
+++ b/src/components/profile/shared/WorkoutCard.tsx
@@ -290,7 +290,7 @@ const styles = StyleSheet.create({
     fontWeight: '500',
   },
   sourceType: {
-    color: theme.colors.textDark,
+    color: theme.colors.textMuted,
     fontSize: 10,
     fontWeight: '500',
     textTransform: 'uppercase',


### PR DESCRIPTION
## Summary\n- switch WorkoutCard source label color from `textDark` to `textMuted`\n- preserve existing source label sizing/layout while raising contrast on dark cards\n\n## Why\nThe source metadata label rendered with insufficient normal-text contrast on dark cards.\n\n## Validation\n- npx eslint src/components/profile/shared/WorkoutCard.tsx ✅\n- npm run -s typecheck ❌ (pre-existing repository-wide TypeScript errors unrelated to this one-line style change)\n\n## Risk\nLow: single style-token update in one component.