### PR TITLE
perf: stop forcing full 5s wait after leaderboard EOSE

### DIFF
--- a/src/services/competition/SimpleLeaderboardService.ts
+++ b/src/services/competition/SimpleLeaderboardService.ts
@@ -560,6 +560,9 @@ export class SimpleLeaderboardService {
       const subscription = ndk.subscribe(filter, {
         closeOnEose: false,
       });
+      let eoseReceived = false;
+      let eoseReceivedAt = 0;
+      let settled = false;
 
       subscription.on('event', (event: any) => {
         console.log(
@@ -569,20 +572,46 @@ export class SimpleLeaderboardService {
       });
 
       subscription.on('eose', () => {
+        eoseReceived = true;
+        eoseReceivedAt = Date.now();
         console.log(
-          '📨 NUCLEAR: EOSE received - continuing to wait for timeout...'
+          `📨 NUCLEAR: EOSE received - ${eventsArray.length} events collected, starting grace window...`
         );
       });
 
-      // ✅ GUARANTEED TIMEOUT: Always fires after 5 seconds
-      console.log('⏰ NUCLEAR: Waiting 5 seconds for all events...');
+      console.log('⏰ NUCLEAR: Waiting up to 5 seconds (early exit on EOSE)...');
       await new Promise<void>((resolve) => {
-        setTimeout(() => {
+        const finish = (reason: 'eose' | 'timeout') => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          clearInterval(checkInterval);
+          clearTimeout(hardTimeout);
+
           // ✅ MEMORY LEAK FIX: Remove listeners before stopping subscription
           subscription.removeAllListeners('event');
           subscription.removeAllListeners('eose');
           subscription.stop();
+
+          if (reason === 'eose') {
+            console.log('✅ NUCLEAR: Early exit after EOSE grace window');
+          } else {
+            console.log('⏰ NUCLEAR: Timeout hit at 5 seconds');
+          }
+
           resolve();
+        };
+
+        // Allow a short grace period after EOSE for straggler events
+        const checkInterval = setInterval(() => {
+          if (eoseReceived && Date.now() - eoseReceivedAt >= 250) {
+            finish('eose');
+          }
+        }, 100);
+
+        const hardTimeout = setTimeout(() => {
+          finish('timeout');
         }, 5000);
       });
 


### PR DESCRIPTION
## Summary
- add EOSE-aware early-exit handling to `SimpleLeaderboardService.getWorkouts()`
- keep the 5s hard timeout fallback but close subscriptions as soon as EOSE + short grace window is reached
- preserve listener cleanup before stop to avoid subscription leaks

## Validation
- `npx eslint src/services/competition/SimpleLeaderboardService.ts` (passes with pre-existing warnings only)
- `npm run -s typecheck` (fails due pre-existing repo-wide TS errors unrelated to this file; no new errors surfaced for `SimpleLeaderboardService.ts`)

## Risk
- Low: changes are localized to workout query wait-path timing and retain existing timeout fallback.
