### PR TITLE
fix: improve workout source label contrast for dark theme accessibility

### DIFF
--- a/src/components/profile/shared/WorkoutCard.tsx
+++ b/src/components/profile/shared/WorkoutCard.tsx
@@ -290,7 +290,7 @@ const styles = StyleSheet.create({
     fontWeight: '500',
   },
   sourceType: {
-    color: theme.colors.textDark,
+    color: theme.colors.textMuted,
     fontSize: 10,
     fontWeight: '500',
     textTransform: 'uppercase',


### PR DESCRIPTION
## Summary
Improve WorkoutCard source metadata legibility on dark backgrounds by using the existing textMuted token for the small uppercase source type label.

## Changes
- change styles.sourceType.color from theme.colors.textDark to theme.colors.textMuted

## Validation
- rg -n "sourceType:|textMuted|textDark" src/components/profile/shared/WorkoutCard.tsx

## Risk
Low: single style-token swap in one component; no logic changes.