### PR TITLE
refactor: remove duplicate npub gate from competition join/leave

### DIFF
--- a/src/hooks/useSupabaseLeaderboard.ts
+++ b/src/hooks/useSupabaseLeaderboard.ts
@@ -649,13 +649,10 @@ export function useCompetitionParticipation(competitionId: string) {
   }, [competitionId]);
 
   const join = useCallback(async () => {
-    const npub = await AsyncStorage.getItem('@runstr:npub');
-    if (!npub) return false;
-
     // OPTIMISTIC: Set participating state immediately for instant UI feedback
     setIsParticipating(true);
 
-    // Fire-and-forget: Service handles local + Supabase sync
+    // Service resolves authenticated identity from secure local auth storage.
     const result = await SupabaseCompetitionService.joinCompetition(
       competitionId
     );
@@ -669,12 +666,10 @@ export function useCompetitionParticipation(competitionId: string) {
   }, [competitionId]);
 
   const leave = useCallback(async () => {
-    const npub = await AsyncStorage.getItem('@runstr:npub');
-    if (!npub) return false;
-
     // OPTIMISTIC: Set non-participating state immediately for instant UI feedback
     setIsParticipating(false);
 
+    // Service resolves authenticated identity from secure local auth storage.
     const result = await SupabaseCompetitionService.leaveCompetition(
       competitionId
     );


### PR DESCRIPTION
## Summary
- remove redundant '@runstr:npub' AsyncStorage gate from `useCompetitionParticipation.join()`
- remove redundant '@runstr:npub' AsyncStorage gate from `useCompetitionParticipation.leave()`
- rely on `SupabaseCompetitionService` as the single auth-source for competition join/leave identity checks

## Why
`joinCompetition()` and `leaveCompetition()` already resolve authenticated identity from secure local auth storage. The extra hook-level gate duplicated that check and could return false before the service-level auth path runs.

## Validation
- `rg -n "join = useCallback|leave = useCallback|joinCompetition\\(|leaveCompetition\\(" src/hooks/useSupabaseLeaderboard.ts`
- `npm run -s typecheck` *(fails in this runtime: `tsc: command not found`)*

## Risk
Low: behavior is unchanged for authenticated users; unauthenticated paths are still blocked by service-level checks.
