### PR TITLE
docs: add canonical quickstart and refresh docs index

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,72 @@
+# RUNSTR Quickstart
+
+Use this checklist for a clean first run on a local machine.
+
+## Prerequisites
+
+- Node.js 18+
+- npm 9+
+- Xcode + iOS Simulator (for iOS)
+- CocoaPods (`pod --version`)
+- Android Studio (for Android)
+
+## 1) Clone + install
+
+```bash
+git clone https://github.com/RUNSTR-LLC/RUNSTR.git
+cd RUNSTR
+npm install
+```
+
+## 2) Configure environment
+
+```bash
+cp .env.example .env
+```
+
+Then set required values in `.env` (especially `REWARD_SENDER_NWC`).
+
+Reference: [`docs/ENVIRONMENT_SETUP.md`](./ENVIRONMENT_SETUP.md)
+
+## 3) Install iOS pods
+
+```bash
+cd ios
+pod install
+cd ..
+```
+
+## 4) Run the app
+
+### iOS
+
+```bash
+npm run ios
+```
+
+### Android
+
+```bash
+npm run android
+```
+
+## 5) Baseline validation
+
+```bash
+npm run typecheck
+npm run lint
+npm test
+```
+
+## Common troubleshooting
+
+- Clear Metro cache: `npx expo start --clear`
+- Reinstall dependencies: remove `node_modules` then `npm install`
+- iOS pod drift: re-run `cd ios && pod install`
+
+## Next reads
+
+- [`../README.md`](../README.md)
+- [`../CLAUDE.md`](../CLAUDE.md)
+- [`docs/ENVIRONMENT_SETUP.md`](./ENVIRONMENT_SETUP.md)
+- [`docs/HEALTHKIT_XCODE_SETUP.md`](./HEALTHKIT_XCODE_SETUP.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,105 +1,41 @@
-# Documentation Directory
+# RUNSTR Docs Index
 
-Centralized documentation for the RUNSTR REWARDS project, including implementation guides, architecture decisions, testing documentation, and development history.
+This folder contains implementation guides, architecture notes, and operational references.
 
-## Quick Navigation
+## Start Here
 
-**Core Documentation**: [Project Overview](#project-overview) · [Integration Guides](#integration-guides) · [Testing](#testing-documentation) · [Architecture](#architecture--planning)
+1. [`../README.md`](../README.md) — product overview + developer commands
+2. [`QUICKSTART.md`](./QUICKSTART.md) — canonical first-run checklist (`prereqs -> env -> pod install -> run`)
+3. [`ENVIRONMENT_SETUP.md`](./ENVIRONMENT_SETUP.md) — `.env` requirements and secrets handling
+4. [`HEALTHKIT_XCODE_SETUP.md`](./HEALTHKIT_XCODE_SETUP.md) — iOS capability setup details
 
-**Essential Files**:
-- [../README.md](../README.md) - Main project README
-- [../CLAUDE.md](../CLAUDE.md) - Claude context and instructions
-- [../CHANGELOG.md](../CHANGELOG.md) - Project changelog
+## Core Technical References
 
-## Documentation Categories
+- [`WORKOUT_ARCHITECTURE.md`](./WORKOUT_ARCHITECTURE.md)
+- [`DATA_ARCHITECTURE_AND_CACHING_STRATEGY.md`](./DATA_ARCHITECTURE_AND_CACHING_STRATEGY.md)
+- [`PERFORMANCE_GUIDE.md`](./PERFORMANCE_GUIDE.md)
+- [`KIND_1301_SPEC.md`](./KIND_1301_SPEC.md)
 
-### Project Overview
-- **ROADMAP.md** - Project roadmap and future plans
+## Integration Guides
 
-### Integration Guides
-- **AMBER_INTEGRATION.md** - Amber signer integration guide
-- **HEALTHKIT_IMPLEMENTATION_GUIDE.md** - HealthKit integration
-- **HEALTHKIT_XCODE_SETUP.md** - Xcode HealthKit setup instructions
-- **KIND_1301_SPEC.md** - Nostr kind 1301 workout event specification
-- **ENVIRONMENT_SETUP.md** - Environment variables and secrets setup
+- [`AMBER_INTEGRATION.md`](./AMBER_INTEGRATION.md)
+- [`HEALTHKIT_IMPLEMENTATION_GUIDE.md`](./HEALTHKIT_IMPLEMENTATION_GUIDE.md)
+- [`HEALTHKIT_XCODE_SETUP.md`](./HEALTHKIT_XCODE_SETUP.md)
+- [`events-and-leagues.md`](./events-and-leagues.md)
 
-### Testing Documentation
-- **PHASE_1_2_TESTING_GUIDE.md** - Complete testing guide for Phase 1 & 2
-- **PRE_LAUNCH_REVIEW_GUIDE.md** - Pre-launch review workflow
-- **PRE_LAUNCH_REVIEW_SCRIPT.md** - Claude's manual review script
-- **CLAUDE_REVIEW_PROMPT.md** - Ready-to-paste Claude review prompt
-- **AMBER_TEST_SUITE.md** - Amber integration test suite
-- **AUDIT_REPORT.md** - Automated audit results
-- **TEST_SCRIPTS_SUMMARY.md** - Test scripts documentation
-- **NOTIFICATION_TESTING.md** - Notification testing guide
-- **PHASE1_TESTING_GUIDE.md** - Phase 1 specific testing
+## Quality + Release
 
-### Deployment & Publishing
-- **ZAPSTORE_PUBLISHING.md** - ZapStore publishing guide
-- **APP_STORE_RESPONSE.md** - App Store submission responses
+- [`PRE_LAUNCH_REVIEW_GUIDE.md`](./PRE_LAUNCH_REVIEW_GUIDE.md)
+- [`CLAUDE_REVIEW_PROMPT.md`](./CLAUDE_REVIEW_PROMPT.md)
+- [`release-notes/`](./release-notes)
 
-### Architecture & Planning
-- **DATA_ARCHITECTURE_AND_CACHING_STRATEGY.md** - Data architecture and caching design
-- **CACHING_MIGRATION_GUIDE.md** - Cache migration from legacy to unified system
-- **DATABASE_IMPLEMENTATION_PLAN.md** - Database architecture strategy (deprecated)
-- **NOSTR_FITNESS_ECOSYSTEM_VISION.md** - Vision for Nostr fitness ecosystem
-- **NOSTR_MVP_STRATEGY.md** - MVP strategy for Nostr implementation
-- **Decentralized-Fitness.md** - Decentralized fitness platform concepts
-- **ZAP_ARENA_VISION.md** - Zap Arena competition system vision
-- **WORKOUT_ARCHITECTURE.md** - Workout data architecture
-- **TEAM_MANAGEMENT_SYSTEM.md** - Team management system design
+## Historical Material
 
-### Implementation Guides
-- **PHASE_2_IMPLEMENTATION_GUIDE.md** - Phase 2 development guide
-- **PHASE2_IMPLEMENTATION.md** - Phase 2 implementation details
-- **COMPETITION_REWARDS_IMPLEMENTATION.md** - Competition rewards system
-- **COMPETITION_SIMPLIFICATION.md** - Competition system simplification
-- **WALLET_PERSISTENCE_IMPROVEMENTS.md** - Wallet persistence improvements
-- **ACTIVITY_TRACKING_SIMPLIFICATION.md** - Activity tracking simplification
-- **nutzap-plan.md** - NutZap integration planning
-- **events-and-leagues.md** - Events and leagues system
+Older planning, deprecated docs, and one-off investigations live in [`archive/`](./archive).
 
-### Setup & Configuration
-- **SETUP_INSTRUCTIONS.md** - Project setup and configuration
-- **METRO_XCODE_DEBUGGING_GUIDE.md** - Metro bundler and Xcode debugging
-- **APPLY_MIGRATION_INSTRUCTIONS.md** - Database migration instructions
+## Maintenance Rule
 
-### Problem Solving & Fixes
-- **1301_FITNESS_NOTES_BREAKTHROUGH.md** - Kind 1301 event breakthrough
-- **1301-PROBLEM-SOLVING.md** - Kind 1301 problem solving
-- **ACTIVITY_FILTERING_FIX_SUMMARY.md** - Activity filtering fixes
-- **CAPTAIN_DETECTION_FIX_ATTEMPTS.md** - Captain detection fix attempts
-- **CAPTAIN_DETECTION_INVESTIGATION.md** - Captain detection investigation
-- **TEAM_CREATION_ISSUE_SUMMARY.md** - Team creation issues
-- **TEAM_CREATION_RESOLUTION_SUMMARY.md** - Team creation resolution
-- **SUPABASE_FIX.md** - Supabase-related fixes (deprecated)
-- **PERFORMANCE_FIX_40S_FREEZE.md** - 40-second freeze performance fix
-
-### Issue Tracking & Bug Reports
-- **GITHUB_ISSUE_CAPTAIN_NOTIFICATIONS.md** - Captain notification issue
-- **github-issue-wallet-duplication.md** - Wallet duplication issue
-- **FITNESS_TRACKER_MEMORY.md** - Fitness tracker memory management
-
-### Development History & Progress
-- **LESSONS_LEARNED.md** - Lessons learned during development
-- **LESSONS_FROM_REFERENCE_IMPLEMENTATION.md** - Lessons from reference apps
-- **ENHANCED_TEAM_DISCOVERY_SUMMARY.md** - Team discovery implementation
-- **RUNSTR_PROGRESS_REPORT.md** - Project progress reports
-- **MVP Plan.md** - Original MVP planning
-- **september-to-do-list.md** - September development todos
-- **NOSTR_AGENT_MEMORY.md** - Nostr agent development memory
-
-## File Statistics
-
-**Total Documentation Files**: 61 MD files
-**Categories**: 9 major categories
-**Last Updated**: 2025-01-13
-
-## Contributing to Documentation
-
-When adding new documentation:
-1. Place in appropriate category folder (or root docs/ if general)
-2. Update this README with file entry in correct category
-3. Use clear, descriptive file names (SCREAMING_SNAKE_CASE or kebab-case)
-4. Include date updated in file footer
-5. Link to related documentation where relevant
+When adding or renaming docs:
+- keep this index focused on high-signal entry points
+- link new canonical guides from **Start Here** or the most relevant section
+- move stale/obsolete material to `archive/` instead of deleting history


### PR DESCRIPTION
## Summary
- add `docs/QUICKSTART.md` as a canonical first-run checklist (`prereqs -> env -> pod install -> run`)
- replace stale `docs/README.md` entries with a curated, current index and explicit archive guidance

## Why
`docs/README.md` referenced files that no longer exist, and onboarding lacked a single copy-paste quickstart path.

## Validation
- `rg -n "QUICKSTART|prereqs -> env -> pod install -> run|REWARD_SENDER_NWC|npm run ios|archive/" docs/README.md docs/QUICKSTART.md`
- verified referenced paths in the new index exist

## Risk
Low — documentation-only changes; no runtime or build behavior modified.
