### PR TITLE
feat: surface reward impact cards on Rewards screen

### DIFF
--- a/src/screens/RewardsScreen.tsx
+++ b/src/screens/RewardsScreen.tsx
@@ -36,6 +36,8 @@ import Toast from 'react-native-toast-message';
 import { EarningsHeroCard } from '../components/rewards/EarningsHeroCard';
 import { ImpactHeroCard } from '../components/rewards/ImpactHeroCard';
 import { TransparencyDashboardModal } from '../components/rewards/TransparencyDashboardModal';
+import { PersonalImpactSection } from '../components/rewards/PersonalImpactSection';
+import { RewardBreakdownCard } from '../components/rewards/RewardBreakdownCard';
 import { PledgeService } from '../services/pledge/PledgeService';
 import { ActivePledgeCard } from '../components/pledge/ActivePledgeCard';
 import type { Pledge } from '../types/pledge';
@@ -310,6 +312,14 @@ const RewardsScreenComponent: React.FC = () => {
         {/* Impact Hero Card - Only shown when user does NOT have Lightning address */}
         {userHexPubkey && !hasLightningAddress && (
           <ImpactHeroCard pubkey={userHexPubkey} />
+        )}
+
+        {/* Reward Impact + Breakdown cards */}
+        {userHexPubkey && (
+          <>
+            <PersonalImpactSection pubkey={userHexPubkey} />
+            <RewardBreakdownCard pubkey={userHexPubkey} />
+          </>
         )}
 
         {/* Your Team Card - Always visible */}


### PR DESCRIPTION
## Summary
Wire existing reward impact cards into RewardsScreen so users can see donation/reward breakdown details without hidden navigation.

## Changes
- import and render PersonalImpactSection when userHexPubkey is available
- import and render RewardBreakdownCard in the same conditional block
- keep patch scoped to one screen with no service/backend changes

## Validation
- rg -n "PersonalImpactSection|RewardBreakdownCard|Reward Impact \+ Breakdown cards" src/screens/RewardsScreen.tsx

## Risk
Low: reuses existing components and data services already used elsewhere; only changes screen composition.

## Rollback
Revert commit 57a928fa to remove the two card mounts.
