### PR TITLE
fix: remove duplicate modalInput style key in captain dashboard

### DIFF
--- a/src/screens/CaptainDashboardScreen.tsx
+++ b/src/screens/CaptainDashboardScreen.tsx
@@ -1816,17 +1816,6 @@ const styles = StyleSheet.create({
     marginBottom: 20,
   },
 
-  modalInput: {
-    backgroundColor: theme.colors.background,
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-    borderRadius: 8,
-    padding: 12,
-    fontSize: 16,
-    color: theme.colors.text,
-    marginBottom: 20,
-  },
-
   textAreaInput: {
     minHeight: 100,
     textAlignVertical: 'top',


### PR DESCRIPTION
## Summary
- remove the duplicate `modalInput` style declaration in `CaptainDashboardScreen`
- keep the currently active modal input style object to preserve runtime UI behavior
- clear the TS1117 duplicate-key compile error for this screen

## Validation
- `npm run -s typecheck` (fails repo-wide on pre-existing TypeScript issues)
- confirmed no `TS1117` diagnostics remain in typecheck output

## Risk
- Low: style-object dedup only; no logic changes
