### PR TITLE
docs: add env setup step to README quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,11 @@ Earn satoshis for staying active:
 git clone https://github.com/RUNSTR-LLC/RUNSTR.git
 cd RUNSTR
 npm install
+cp .env.example .env
 npm run ios
 ```
+
+Before sending rewards or using Lightning features, complete the environment setup: [docs/ENVIRONMENT_SETUP.md](docs/ENVIRONMENT_SETUP.md).
 
 ### Commands
 ```bash


### PR DESCRIPTION
## Summary
- add `cp .env.example .env` to README Quick Start so first-run setup includes env file creation
- add a direct link to `docs/ENVIRONMENT_SETUP.md` for Lightning/rewards configuration

## Why
Quick Start previously skipped env bootstrap, which can delay first successful local setup for reward-related flows.

## Validation
- verified README Quick Start now includes `cp .env.example .env`
- verified README links to `docs/ENVIRONMENT_SETUP.md`
