### PR TITLE
fix: wire WeatherService OpenWeather key to env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,11 @@ EXPO_PUBLIC_COINOS_API_BASE=https://coinos.io/api
 EXPO_PUBLIC_RUNSTR_LIGHTNING_ADDRESS=your-address@coinos.io
 
 # ==============================================================================
+# Weather API (optional - enables workout weather badges)
+# ==============================================================================
+EXPO_PUBLIC_OPENWEATHER_API_KEY=your-openweather-api-key
+
+# ==============================================================================
 # OAuth Configuration (Client IDs only - secrets go in Supabase Secrets)
 # ==============================================================================
 # Apple OAuth (optional)

--- a/docs/ENVIRONMENT_SETUP.md
+++ b/docs/ENVIRONMENT_SETUP.md
@@ -49,6 +49,9 @@ CoinOS Lightning API base URL (legacy, may not be needed)
 ### EXPO_PUBLIC_RUNSTR_LIGHTNING_ADDRESS
 Lightning address for RUNSTR operations
 
+### EXPO_PUBLIC_OPENWEATHER_API_KEY
+OpenWeather API key for workout weather badges (`WeatherService`)
+
 ### OAuth Configuration (Future Use)
 - `EXPO_PUBLIC_APPLE_CLIENT_ID`
 - `EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS`

--- a/src/services/activity/WeatherService.ts
+++ b/src/services/activity/WeatherService.ts
@@ -15,9 +15,11 @@ export interface WeatherConditions {
 class WeatherService {
   private static instance: WeatherService;
 
-  // OpenWeather API key - should be in environment variables
-  // For MVP, using a placeholder - replace with actual key
-  private readonly API_KEY = 'YOUR_OPENWEATHER_API_KEY'; // TODO: Move to env
+  // OpenWeather API key - configured via Expo env (preferred) with legacy fallback
+  private readonly API_KEY =
+    process.env.EXPO_PUBLIC_OPENWEATHER_API_KEY ||
+    process.env.OPENWEATHER_API_KEY ||
+    'YOUR_OPENWEATHER_API_KEY';
   private readonly BASE_URL = 'https://api.openweathermap.org/data/2.5/weather';
 
   private constructor() {}


### PR DESCRIPTION
## Summary
- load `WeatherService` OpenWeather API key from Expo env (`EXPO_PUBLIC_OPENWEATHER_API_KEY`) with legacy fallback support
- add `EXPO_PUBLIC_OPENWEATHER_API_KEY` to `.env.example`
- document the new optional weather env var in `docs/ENVIRONMENT_SETUP.md`

## Validation
- `rg -n "EXPO_PUBLIC_OPENWEATHER_API_KEY|YOUR_OPENWEATHER_API_KEY" src/services/activity/WeatherService.ts .env.example docs/ENVIRONMENT_SETUP.md`
- Typecheck could not be executed in this environment (`tsc: command not found`)
