### PR TITLE
cleanup: remove dead react-native import from background sync service

### DIFF
--- a/src/services/fitness/backgroundSyncService.ts
+++ b/src/services/fitness/backgroundSyncService.ts
@@ -9,7 +9,6 @@
  * See AuthContext.tsx lines 629-650 for where this was disabled.
  */
 
-import { AppState, Platform } from 'react-native';
 import healthKitService from './healthKitService';
 // import workoutDataProcessor from './workoutDataProcessor';  // REMOVED: Pure Nostr - workouts processed via kind 1301 events
 // import teamLeaderboardService from './teamLeaderboardService';  // REMOVED: Pure Nostr - leaderboards query kind 1301 events directly


### PR DESCRIPTION
## Summary\n- remove unused / import from \n- keep behavior unchanged while reducing lint noise in a deprecated service\n\n## Validation\n-  (no matches)\n- 176:    // DISABLED: AppState listener causing background crashes
179:    this.appStateListener = AppState.addEventListener(
486:    /* DISABLED: AppState listener removed to prevent crashes (comment-only references)\n\n## Risk\n- Low: import-only cleanup, no runtime logic changes