### PR TITLE
cleanup: remove unused Platform import in TTS announcement service

### DIFF
--- a/src/services/activity/TTSAnnouncementService.ts
+++ b/src/services/activity/TTSAnnouncementService.ts
@@ -5,7 +5,6 @@
 
 import * as Speech from 'expo-speech';
 import { Audio, InterruptionModeIOS, InterruptionModeAndroid } from 'expo-av';
-import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { TTSPreferencesService } from './TTSPreferencesService';
 import { AppStateManager } from '../core/AppStateManager';


### PR DESCRIPTION
## Summary
Remove an unused `Platform` import from `TTSAnnouncementService` to reduce lint noise without changing runtime behavior.

## Changes
- deleted unused `Platform` import from `src/services/activity/TTSAnnouncementService.ts`

## Validation
- `rg -n "from 'react-native'" src/services/activity/TTSAnnouncementService.ts` (no matches)
- `rg -n "\bPlatform\b" src/services/activity/TTSAnnouncementService.ts` (no matches)

## Risk
Low — import-only cleanup, no logic changes.

## Rollback
Revert commit `8c09db91` if needed.
