### PR TITLE
fix: remove duplicate modalInput style key in captain dashboard

### DIFF
--- a/src/screens/CaptainDashboardScreen.tsx
+++ b/src/screens/CaptainDashboardScreen.tsx
@@ -1816,17 +1816,6 @@ const styles = StyleSheet.create({
     marginBottom: 20,
   },
 
-  modalInput: {
-    backgroundColor: theme.colors.background,
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-    borderRadius: 8,
-    padding: 12,
-    fontSize: 16,
-    color: theme.colors.text,
-    marginBottom: 20,
-  },
-
   textAreaInput: {
     minHeight: 100,
     textAlignVertical: 'top',


### PR DESCRIPTION
## Summary
- remove the duplicate `modalInput` style key in `CaptainDashboardScreen`
- keep a single `modalInput` definition to eliminate TS1117 duplicate-property failure
- no logic changes; style object hygiene only

## Validation
- `rg -n "^[[:space:]]*modalInput:" src/screens/CaptainDashboardScreen.tsx` now returns one key
- duplicate key error source at `CaptainDashboardScreen.tsx(1958,3)` is removed in this file

## Risk
- Low: removes duplicate style declaration only; no behavior or data-path changes
