### PR TITLE
cleanup: remove unused Platform import from BackgroundSyncService

### DIFF
--- a/src/services/fitness/backgroundSyncService.ts
+++ b/src/services/fitness/backgroundSyncService.ts
@@ -9,7 +9,7 @@
  * See AuthContext.tsx lines 629-650 for where this was disabled.
  */
 
-import { AppState, Platform } from 'react-native';
+import { AppState } from 'react-native';
 import healthKitService from './healthKitService';
 // import workoutDataProcessor from './workoutDataProcessor';  // REMOVED: Pure Nostr - workouts processed via kind 1301 events
 // import teamLeaderboardService from './teamLeaderboardService';  // REMOVED: Pure Nostr - leaderboards query kind 1301 events directly


### PR DESCRIPTION
## Summary\n- remove unused `Platform` import from `backgroundSyncService.ts`\n- keep runtime behavior unchanged (import-only cleanup)\n\n## Validation\n- `rg -n \"\bPlatform\b\" src/services/fitness/backgroundSyncService.ts` returns no matches\n- react-native import now only includes `AppState`\n\n## Risk\n- low (no logic changes)