### PR TITLE
chore: remove unused Platform import in navigation data context

### DIFF
--- a/src/contexts/NavigationDataContext.tsx
+++ b/src/contexts/NavigationDataContext.tsx
@@ -12,7 +12,7 @@ import React, {
   useMemo,
   ReactNode,
 } from 'react';
-import { InteractionManager, Platform } from 'react-native';
+import { InteractionManager } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { AuthService } from '../services/auth/authService';
 import { getNostrTeamService } from '../services/nostr/NostrTeamService';


### PR DESCRIPTION
## Summary
- remove unused \ import from \
- keep runtime behavior unchanged (import-only cleanup)

## Why
This reduces lint/type noise and keeps the module clean with no functional impact.

## Validation
- \ (no matches)
- \ shows only \

## Risk
Low — import-only change.
