### PR TITLE
fix: improve journal selector pill text contrast in dark theme

### DIFF
--- a/src/components/journal/EnergySelector.tsx
+++ b/src/components/journal/EnergySelector.tsx
@@ -78,7 +78,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#1a1a1a',
   },
   pillText: {
-    color: theme.colors.textDark,
+    color: theme.colors.textMuted,
     fontSize: 13,
     fontWeight: theme.typography.weights.medium,
   },

--- a/src/components/journal/MoodSelector.tsx
+++ b/src/components/journal/MoodSelector.tsx
@@ -87,7 +87,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#1a1a1a',
   },
   pillText: {
-    color: theme.colors.textDark,
+    color: theme.colors.textMuted,
     fontSize: 13,
     fontWeight: theme.typography.weights.medium,
   },


### PR DESCRIPTION
## Summary
This PR applies the H01 audit smallest-safe patch to improve dark-theme readability in journal selectors.

## Changes
- Switch `pillText` color from `theme.colors.textDark` to `theme.colors.textMuted` in `MoodSelector`.
- Switch `pillText` color from `theme.colors.textDark` to `theme.colors.textMuted` in `EnergySelector`.

## Validation
- Confirmed both selectors now use `textMuted` for unselected pill labels (static source verification).
- `npm run typecheck` could not run in isolated worktree because project dependencies are not installed (`tsc: command not found`).

## Risk
Low — style-token swap only; no logic or navigation changes.

## Rollback
Revert this PR commit to restore previous `textDark` token usage.
