### PR TITLE
perf: bound leaderboard workout query to reduce over-fetch risk

### DIFF
--- a/src/services/backend/SupabaseCompetitionService.ts
+++ b/src/services/backend/SupabaseCompetitionService.ts
@@ -671,7 +671,9 @@ export class SupabaseCompetitionService {
         workoutQuery = workoutQuery.eq('source', 'app');
       }
 
-      const { data: rawWorkouts } = await workoutQuery.order('created_at', { ascending: false }); // Most recent first
+      const { data: rawWorkouts } = await workoutQuery
+        .order('created_at', { ascending: false }) // Most recent first
+        .limit(5000); // Bound leaderboard fetch to protect query latency on large seasons
 
       // CRITICAL: Deduplicate workouts by (npub, distance, date) to prevent double-counting
       // Same workout can be submitted multiple times from different sources (GPS, HealthKit, Health Connect)


### PR DESCRIPTION
## Summary
Adds a bounded cap to leaderboard workout fetches so large seasons don't over-fetch and spike query latency.

## Changes
- add `.limit(5000)` to leaderboard `workout_submissions` query in `SupabaseCompetitionService.getLeaderboard`
- keep existing sort and filtering behavior unchanged

## Validation
- Verified focused one-file diff
- Attempted `npm run -s typecheck` in isolated worktree (blocked: `tsc: command not found` in this environment)

## Risk
Low — query behavior is unchanged except for a protective upper bound.

## Rollback
Revert this PR to remove the row cap and restore previous unbounded fetch behavior.
