### PR TITLE
docs: add contributor getting-started entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ npm install
 npm run ios
 ```
 
+For full contributor onboarding (setup + validation + troubleshooting), see [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md).
+
 ### Commands
 ```bash
 npm run start          # Development server

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,54 @@
+# Getting Started (Contributors)
+
+This guide is the fastest path to run RUNSTR locally for development.
+
+## 1) Prerequisites
+
+- Node.js 18+
+- npm
+- Xcode + iOS Simulator (for iOS)
+- Android Studio / emulator (for Android)
+
+## 2) Clone and install
+
+```bash
+git clone https://github.com/RUNSTR-LLC/RUNSTR.git
+cd RUNSTR
+npm install
+```
+
+If commands like `tsc` are missing, rerun `npm install` to ensure local dev dependencies are present.
+
+## 3) Start the app
+
+```bash
+npm run ios
+# or
+npm run android
+```
+
+You can also start the Metro server directly:
+
+```bash
+npm run start
+```
+
+## 4) Validate before opening a PR
+
+```bash
+npm run typecheck
+npm run lint
+npm test
+```
+
+## 5) Read these docs next
+
+- `docs/ENVIRONMENT_SETUP.md` (env + secrets)
+- `docs/GIT_WORKFLOW.md` (branch + PR workflow)
+- `CONTRIBUTING.md` (contribution rules)
+
+## Troubleshooting
+
+- iOS HealthKit setup: `docs/HEALTHKIT_XCODE_SETUP.md`
+- Android build/setup notes: `docs/ANDROID_BUILD.md`
+- Performance checks: `docs/PERFORMANCE_GUIDE.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Centralized documentation for the RUNSTR REWARDS project, including implementati
 **Core Documentation**: [Project Overview](#project-overview) · [Integration Guides](#integration-guides) · [Testing](#testing-documentation) · [Architecture](#architecture--planning)
 
 **Essential Files**:
+- [GETTING_STARTED.md](GETTING_STARTED.md) - Contributor onboarding quick path
 - [../README.md](../README.md) - Main project README
 - [../CLAUDE.md](../CLAUDE.md) - Claude context and instructions
 - [../CHANGELOG.md](../CHANGELOG.md) - Project changelog


### PR DESCRIPTION
## Summary
- add `docs/GETTING_STARTED.md` with a concise contributor onboarding path
- link the new guide from the root README Development section
- add the guide to `docs/README.md` essential files

## Why
Contributor setup steps were split across files with no single entrypoint. This adds one quick path to reduce onboarding friction.

## Validation
- verified new guide file exists and is linked from both README locations
- confirmed no code-path changes (docs-only patch)

## Risk
Low (documentation-only).
