### PR TITLE
cleanup: remove unused theme import in SettingsAccordion

### DIFF
--- a/src/components/ui/SettingsAccordion.tsx
+++ b/src/components/ui/SettingsAccordion.tsx
@@ -9,7 +9,6 @@ import {
   UIManager,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { theme } from '../../styles/theme';
 
 // Enable LayoutAnimation on Android
 if (


### PR DESCRIPTION
## Summary\n- remove unused `theme` import from `SettingsAccordion`\n- keep component behavior unchanged\n\n## Validation\n- verified focused diff: 1 file changed, 1 deletion\n- confirmed `theme` identifier is no longer imported in `src/components/ui/SettingsAccordion.tsx`\n\n## Risk\n- low (import cleanup only)