### PR TITLE
cleanup: remove unused React Native imports in background sync service

### DIFF
--- a/src/services/fitness/backgroundSyncService.ts
+++ b/src/services/fitness/backgroundSyncService.ts
@@ -9,7 +9,6 @@
  * See AuthContext.tsx lines 629-650 for where this was disabled.
  */
 
-import { AppState, Platform } from 'react-native';
 import healthKitService from './healthKitService';
 // import workoutDataProcessor from './workoutDataProcessor';  // REMOVED: Pure Nostr - workouts processed via kind 1301 events
 // import teamLeaderboardService from './teamLeaderboardService';  // REMOVED: Pure Nostr - leaderboards query kind 1301 events directly


### PR DESCRIPTION
## Summary
Removes an unused React Native import line from `BackgroundSyncService` now that app state listener logic is fully disabled.

## Changes
- Deleted `AppState` and `Platform` import from `src/services/fitness/backgroundSyncService.ts`

## Why
- Reduces lint noise and keeps the deactivated background-sync module tidy while preserving behavior.

## Risk
- Low (import-only cleanup; no runtime logic changes)

## Validation
- Verified focused one-line diff (`1 file changed, 1 deletion`)
- Ran file-level lint after linking workspace dependencies: `./node_modules/.bin/eslint src/services/fitness/backgroundSyncService.ts` (no findings)

## Rollback
- Revert this PR commit to restore previous import line.
