### PR TITLE
fix: dedupe streak reminder timers in NotificationScheduler

### DIFF
--- a/src/services/notifications/NotificationScheduler.ts
+++ b/src/services/notifications/NotificationScheduler.ts
@@ -141,13 +141,24 @@ export class NotificationScheduler {
     }
 
     const delay = reminderTime.getTime() - new Date().getTime();
+    const timerId = 'streak_reminder';
 
-    setTimeout(() => {
+    // Clear existing streak reminder to avoid duplicate notifications
+    if (this.activeTimers.has(timerId)) {
+      clearTimeout(this.activeTimers.get(timerId)!);
+    }
+
+    const timer = setTimeout(() => {
       this.notificationService.sendStreakReminder({
         streakDays,
         timeRemaining: '6 hours',
       });
+
+      // Timer has fired; remove it from active tracking
+      this.activeTimers.delete(timerId);
     }, delay);
+
+    this.activeTimers.set(timerId, timer as any);
   }
 
   // Schedule competition ending reminders


### PR DESCRIPTION
## Summary
- track `scheduleStreakReminder` timeout in `activeTimers`
- clear the previous streak reminder before scheduling a new one
- remove the timer from tracking after it fires

## Why
Repeated calls to `scheduleStreakReminder` could create duplicate pending timers and trigger duplicate reminders.

## Validation
- `ln -s /Users/larry/RUNSTR/node_modules node_modules && ./node_modules/.bin/eslint src/services/notifications/NotificationScheduler.ts`
