### PR TITLE
fix: track ending + weekly notification timers

### DIFF
--- a/src/services/notifications/NotificationScheduler.ts
+++ b/src/services/notifications/NotificationScheduler.ts
@@ -160,8 +160,13 @@ export class NotificationScheduler {
 
     if (reminderTime > now) {
       const delay = reminderTime.getTime() - now.getTime();
+      const timerId = `ending_reminder_${event.id}`;
 
-      setTimeout(() => {
+      if (this.activeTimers.has(timerId)) {
+        clearTimeout(this.activeTimers.get(timerId)!);
+      }
+
+      const timer = setTimeout(() => {
         this.notificationService.scheduleNotification({
           id: `ending_reminder_${event.id}`,
           type: 'competition_ending_soon',
@@ -171,7 +176,11 @@ export class NotificationScheduler {
           isRead: false,
           eventId: event.id,
         });
+
+        this.activeTimers.delete(timerId);
       }, delay);
+
+      this.activeTimers.set(timerId, timer as any);
     }
   }
 
@@ -181,8 +190,13 @@ export class NotificationScheduler {
     nextMonday.setHours(9, 0, 0, 0);
 
     const delay = nextMonday.getTime() - new Date().getTime();
+    const timerId = 'weekly_earnings_summary';
 
-    setTimeout(() => {
+    if (this.activeTimers.has(timerId)) {
+      clearTimeout(this.activeTimers.get(timerId)!);
+    }
+
+    const timer = setTimeout(() => {
       // This would calculate actual weekly earnings
       const weeklyEarnings = this.calculateWeeklyEarnings();
 
@@ -196,9 +210,13 @@ export class NotificationScheduler {
         prizeAmount: weeklyEarnings.total,
       });
 
+      this.activeTimers.delete(timerId);
+
       // Reschedule for next week
       this.scheduleWeeklyEarningsSummary();
     }, delay);
+
+    this.activeTimers.set(timerId, timer as any);
   }
 
   // Private methods


### PR DESCRIPTION
## Summary\n- track competition ending reminder timeouts in `activeTimers`\n- clear and replace existing ending reminder timer per event before scheduling\n- track weekly earnings summary timeout and remove it after firing before weekly reschedule\n\n## Why\nUntracked timers could not be cancelled by scheduler cleanup, which risks stale or duplicate notifications after lifecycle changes.\n\n## Risk\nLow — NotificationScheduler timer bookkeeping only, no API shape changes.\n\n## Validation\n- `./node_modules/.bin/eslint src/services/notifications/NotificationScheduler.ts`