### PR TITLE
fix: prevent duplicate streak reminders from stacked timers

### DIFF
--- a/src/services/notifications/NotificationScheduler.ts
+++ b/src/services/notifications/NotificationScheduler.ts
@@ -141,13 +141,23 @@ export class NotificationScheduler {
     }
 
     const delay = reminderTime.getTime() - new Date().getTime();
+    const timerId = 'streak_reminder';
 
-    setTimeout(() => {
+    // Clear existing streak reminder timer before rescheduling
+    if (this.activeTimers.has(timerId)) {
+      clearTimeout(this.activeTimers.get(timerId)!);
+    }
+
+    const timer = setTimeout(() => {
       this.notificationService.sendStreakReminder({
         streakDays,
         timeRemaining: '6 hours',
       });
+
+      this.activeTimers.delete(timerId);
     }, delay);
+
+    this.activeTimers.set(timerId, timer as any);
   }
 
   // Schedule competition ending reminders


### PR DESCRIPTION
## Summary
- track the streak reminder timeout in NotificationScheduler.activeTimers
- clear any previously scheduled streak reminder before creating a new one
- remove the timer handle after it fires so cleanup state stays accurate

## Why
Repeated calls to scheduleStreakReminder could stack duplicate timers, causing duplicate streak reminders and preventing cleanup() from canceling the latest pending streak reminder reliably.

## Validation
- eslint src/services/notifications/NotificationScheduler.ts
