### PR TITLE
Fix: Guard charity lightning address with user-facing alert

### DIFF
--- a/src/components/team/CharitySection.tsx
+++ b/src/components/team/CharitySection.tsx
@@ -179,6 +179,15 @@ export const CharitySection: React.FC<CharitySectionProps> = ({
       return;
     }
 
+    // Guard: charity must have a lightning address configured
+    if (!charity.lightningAddress) {
+      Alert.alert(
+        'Charity Payment Unavailable',
+        'This charity does not currently have a Lightning address configured.'
+      );
+      return;
+    }
+
     // Quick zap with default amount - routes through RUNSTR for tracking
     setIsZapping(true);
     try {
@@ -226,7 +235,7 @@ export const CharitySection: React.FC<CharitySectionProps> = ({
 
       // Step 3: Record donation and forward to charity
       console.log('[CharitySection] Recording and forwarding donation...');
-      const donorName = currentUser?.name || currentUser?.displayName;
+      const donorName = currentUser?.name || currentUser?.displayName || 'Anonymous';
 
       // Get hex pubkey from cached storage (reliable source set at login)
       const storedPubkey = await AsyncStorage.getItem('@runstr:hex_pubkey');
@@ -351,10 +360,10 @@ export const CharitySection: React.FC<CharitySectionProps> = ({
 
       {/* External Zap Modal with charity donation verification
           v3: Modal disabled - NWC moved to external service */}
-      {IN_APP_ZAPS_ENABLED && (
+      {IN_APP_ZAPS_ENABLED && charity.lightningAddress && (
         <ExternalZapModal
           visible={showPaymentModal}
-          recipientNpub={charity.lightningAddress || ''}
+          recipientNpub={charity.lightningAddress}
           recipientName={charity.name}
           memo={`Donation to ${charity.name}`}
           onClose={() => setShowPaymentModal(false)}


### PR DESCRIPTION
## Summary
- Show a user-facing alert ("Charity Payment Unavailable") when a charity has no Lightning address configured, instead of silently failing.
- Default donor name to `'Anonymous'` instead of `undefined` when `currentUser` has no name/displayName.
- Gate the `ExternalZapModal` render on the lightning address being present (belt-and-suspenders for when `IN_APP_ZAPS_ENABLED` is re-enabled).

Supersedes #210 — the core defensive guards already landed inline on `main`; this PR captures the remaining user-facing improvements cleanly against current head.

## Test plan
- [ ] Select a charity with no Lightning address → long-press → alert appears, no crash.
- [ ] Select a charity with Lightning address → long-press → normal zap flow.
- [ ] Anonymous user (no name/displayName) donates → donation is recorded with donorName `'Anonymous'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)