### PR TITLE
Feature: Overnight cron agents (tooling only)

### DIFF
--- a/.claude/cron/README.md
+++ b/.claude/cron/README.md
@@ -1,0 +1,119 @@
+# RUNSTR Cron System
+
+Overnight remote agents that audit, triage, and propose fixes without needing Dakota's laptop open. Agents run in Anthropic's cloud, clone the repo at HEAD, execute their prompt, and file GitHub issues (or open draft PRs).
+
+## How it works
+
+Each scheduled trigger on claude.ai/code/scheduled has a short inline prompt that says:
+
+> Checkout the repo. Read `.claude/cron/agents/<name>.md` and `.claude/cron/RUBRIC.md`. Execute the agent's instructions. End by appending the machine-readable `CRON-RUN-LOG` block to the primary issue.
+
+This means the actual agent behavior lives here, in the repo. Edit a prompt file → next run uses the new prompt. No trigger reconfiguration needed.
+
+## Layout
+
+```
+.claude/cron/
+  README.md          # this file
+  RUBRIC.md          # self-scoring dimensions agents use at end-of-run
+  agents/
+    vibes.md         # nightly Nostr community sweep
+    audit.md         # Monday: general bug/regression audit
+    perf.md          # Tuesday: performance sweep
+    design.md        # Wednesday: theme/UX consistency
+    simplify.md      # Thursday: dead code, oversized files
+    docs.md          # Friday: doc staleness
+    auto-pr.md       # weekdays: pick one `auto-pr-ok` issue, open draft PR
+    meta-learn.md    # Sundays: review run logs, tune agent prompts via PR
+```
+
+## Trigger schedule (all EDT-aligned)
+
+| Trigger | Cron (UTC) | Local (EDT) |
+|---------|------------|-------------|
+| Vibes | `0 5 * * 1-5` | Weekdays 1am |
+| Audit - General | `0 6 * * 1` | Mon 2am |
+| Audit - Perf | `0 6 * * 2` | Tue 2am |
+| Audit - Design | `0 6 * * 3` | Wed 2am |
+| Audit - Simplify | `0 6 * * 4` | Thu 2am |
+| Audit - Docs | `0 6 * * 5` | Fri 2am |
+| Auto-PR | `0 8 * * 1-5` | Weekdays 4am |
+| Meta-learn | `0 14 * * 0` | Sundays 10am |
+
+Cron is UTC — no DST shift. Times drift 1 hour during standard time (Nov–Mar).
+
+## Run logs
+
+Each agent run ends by either:
+1. Appending the `CRON-RUN-LOG` block to the primary issue it filed, or
+2. Filing a standalone `[CronLog] <agent> <date>` issue with label `cron-run-log` if it had nothing actionable to report.
+
+The meta-learn agent queries these via `gh issue list --label cron-run-log` to score agents and tune prompts.
+
+### CRON-RUN-LOG block format
+
+```
+<!-- CRON-RUN-LOG
+agent: <name>
+run_date: YYYY-MM-DD
+findings_count: <int>
+severity: critical=<n> high=<n> medium=<n> low=<n>
+self_score:
+  specificity: <0-10>
+  actionability: <0-10>
+  signal_to_noise: <0-10>
+  false_positive_risk: <0-10>
+  coverage: <0-10>
+overall: <float>
+notes: <one-line note on what went well or what was hard>
+-->
+```
+
+## Labels
+
+Agents apply labels to the issues they file. These are queried by the meta-agent and by humans filtering the issue list.
+
+| Label | Applied by | Meaning |
+|-------|------------|---------|
+| `audit` | audit agent | General audit findings |
+| `perf` | perf agent | Performance issue |
+| `design` | design agent | Theme/UX consistency issue |
+| `simplify` | simplify agent | Dead code / oversized file |
+| `docs` | docs agent | Stale or missing docs |
+| `community-feedback` | vibes agent | Bug report or feature request from Nostr |
+| `auto-pr-ok` | humans | Issue safe enough for auto-PR to attempt |
+| `cron-run-log` | all agents | Run log artifact |
+| `cron-meta` | meta-learn | Meta-learning PR or summary |
+
+Agents should check which labels exist via `gh label list` and only apply existing ones. Never create labels automatically.
+
+## Guardrails
+
+All agents are read-only except for issue/PR creation commands:
+- `gh issue create`, `gh issue edit`, `gh issue comment`
+- `gh pr create` (Auto-PR, Meta-learn only; must be draft)
+- `git commit` + `git push` to a feature branch (Auto-PR, Meta-learn only)
+
+Agents **never**:
+- Push to `main` or any shipped version branch directly
+- Force-push
+- Modify `.env*`, secrets, or credentials
+- Run `--no-verify`
+- Install new dependencies (Auto-PR excluded by policy; Meta-learn only touches `.claude/cron/` files)
+
+## Changing agent behavior
+
+Edit the relevant `agents/<name>.md` file and push. Next scheduled run picks it up. For urgent behavior changes, `/schedule` → update → run now on the specific trigger.
+
+## Adding a new agent
+
+1. Write `.claude/cron/agents/<name>.md` following the shape of existing agents
+2. Commit and push
+3. Use `/schedule` to create a trigger with this inline prompt:
+   ```
+   Checkout the repo. Read `.claude/cron/agents/<name>.md` and `.claude/cron/RUBRIC.md`. Execute the agent. End by appending the CRON-RUN-LOG block to the primary issue you file (or create a standalone cron-run-log issue if you had nothing to report).
+   ```
+
+## Deleting
+
+Triggers cannot be deleted via API. Disable them, or remove from https://claude.ai/code/scheduled.

--- a/.claude/cron/RUBRIC.md
+++ b/.claude/cron/RUBRIC.md
@@ -1,0 +1,74 @@
+# Cron Agent Self-Scoring Rubric
+
+At the end of every run, the agent scores itself across five dimensions (0–10 each) and appends a machine-readable `CRON-RUN-LOG` block to the primary issue it filed.
+
+Be honest. The meta-learn agent uses these scores to decide whether to tune your prompt. Inflated scores → your prompt never gets the improvements it needs.
+
+## Dimensions
+
+### Specificity (0–10)
+
+Do findings cite exact `file:line` references? Are code snippets included? Is the repro path concrete?
+
+- **9–10:** Every finding has file:line + snippet + clear reproduction or reasoning.
+- **6–8:** Most findings are specific; a few vague ones slip in.
+- **3–5:** Half the findings are "somewhere in the auth code" hand-waving.
+- **0–2:** Vague suspicions, no actionable locations.
+
+### Actionability (0–10)
+
+Can a human (or Auto-PR) act on the finding without more investigation?
+
+- **9–10:** Each finding says what to change and why. A developer could implement the fix in one sitting.
+- **6–8:** Most findings are clear but a few need more design work.
+- **3–5:** Findings identify problems but don't suggest paths forward.
+- **0–2:** Pure observations with no fix direction.
+
+### Signal-to-Noise (0–10)
+
+How much of what you filed would a human actually want to see? Filter out: pre-existing known issues (see `CLAUDE.md` for known errors), style nits in generated code, duplicates of already-filed issues.
+
+- **9–10:** Every finding is new, real, and worth triaging.
+- **6–8:** Most findings are valuable; 1–2 low-value inclusions.
+- **3–5:** Half the findings are noise.
+- **0–2:** Mostly noise. Would waste the human's time.
+
+### False-Positive Risk (0–10)
+
+Inverted: lower is better for the codebase, higher for your score. 10 = high confidence all findings are real. 0 = you're guessing and some are probably wrong.
+
+- **9–10:** You verified each finding by reading the code. No guesses.
+- **6–8:** Most findings verified; 1–2 inferred without reading all the way.
+- **3–5:** Several findings are pattern-matches without verification.
+- **0–2:** Lots of speculation. Treat as "suspicions" not "bugs."
+
+### Coverage (0–10)
+
+Did you explore the full scope specified in your agent prompt? Or did you bail early?
+
+- **9–10:** Visited every area named in the prompt; used parallel investigation where called for.
+- **6–8:** Covered most areas; one or two got light treatment.
+- **3–5:** Covered the obvious stuff; missed significant areas.
+- **0–2:** Only hit the first thing you found interesting.
+
+## Overall
+
+```
+overall = (specificity + actionability + signal_to_noise + false_positive_risk + coverage) / 5
+```
+
+Round to 1 decimal.
+
+## Notes field
+
+One sentence on what was hard, what worked, or what would make next run better. The meta-learn agent reads these.
+
+Good notes:
+- "Typecheck output drowned out real findings; next run should filter pre-existing errors first."
+- "Only found 2 perf issues — rotation interval may be too tight, weekly would give more surface."
+- "Nostr relay damus.io timed out; fell back to 3 relays."
+
+Bad notes:
+- "Went well."
+- "Nothing to report."
+- "Found some stuff."

--- a/.claude/cron/agents/audit.md
+++ b/.claude/cron/agents/audit.md
@@ -1,0 +1,78 @@
+# General Audit Agent
+
+**Runs:** Mondays 06:00 UTC (2am EDT)
+**Mission:** Find bugs, regressions, and breaking changes in recent work that should block a release.
+
+## Execution
+
+### 1. Setup
+
+```bash
+npm install --legacy-peer-deps --silent
+git log --since='7 days ago' --oneline --no-merges | head -40
+```
+
+Read `CLAUDE.md` for known issues (e.g., the ~199 pre-existing TS errors noted there — do not report those).
+
+### 2. Typecheck + lint
+
+```bash
+npm run typecheck 2>&1 | tee /tmp/tc.log
+npm run lint 2>&1 | tee /tmp/lint.log
+```
+
+Compare against baseline: if typecheck error count increased vs `CLAUDE.md`'s noted baseline, that's a regression — file it. Otherwise note the counts in your run log.
+
+### 3. Parallel investigation
+
+Dispatch agents (use the `Agent` tool if available, otherwise sequential Grep) across these angles. Each should return file:line + 1-line description of findings.
+
+**a. Recent diff review**
+Read the diff of every commit in the last 7 days. Flag:
+- Unhandled promise rejections (calling async without try/catch or .catch)
+- Missing `useEffect` cleanups (subscriptions, timers, listeners)
+- Stale closures in setInterval/setTimeout callbacks
+- Missing null checks on Nostr events / Supabase rows
+
+**b. GPS/tracking correctness**
+Focus: `src/services/activity/`, `src/components/activity/`
+Look for:
+- Timer drift patterns (ref-based pause/resume)
+- Distance accumulation during GPS loss
+- Missing cleanup when workout is cancelled mid-session
+
+**c. Nostr/NDK misuse**
+`grep -r "new NDK(" src/ && grep -r "nostr-tools" src/` — anything outside `src/services/nostr/` is a violation.
+
+**d. Supabase query smells**
+`grep -rn "\.select(" src/services/backend/` — flag queries without `.limit()` that could return unbounded data.
+
+**e. Kind 1301 spec violations**
+Check any code building kind 1301 events: must be plain text (not JSON), lowercase activity types, HH:MM:SS duration. See `docs/KIND_1301_SPEC.md`.
+
+### 4. Rank + file
+
+Severity:
+- **Critical** — data loss, crash, security issue, shipped regression
+- **High** — user-visible broken feature, would fail app review
+- **Medium** — edge case bug, minor data inconsistency
+- **Low** — code smell, future-proofing
+
+File **one** issue per run titled `[Audit] General sweep YYYY-MM-DD` (substitute today's ISO date) with sections per severity. Include:
+- `**File:**` + file:line
+- `**Evidence:**` 5–10 line code snippet
+- `**Why:**` one-sentence reasoning
+- `**Fix direction:**` one sentence
+
+Label: `audit`. If findings look trivially fixable (<50 line diff, single file, no design decisions), also add `auto-pr-ok`.
+
+### 5. Self-assessment
+
+Append `CRON-RUN-LOG` block to the issue.
+
+## Guardrails
+
+- Read-only. Only mutation is the single `gh issue create`.
+- Don't file an issue if you found nothing — file a `cron-run-log` issue with label `cron-run-log` instead.
+- Don't double-file things already in existing open `audit` issues (dedup by title + first-finding match).
+- Don't touch pre-existing typecheck errors listed as baseline.

--- a/.claude/cron/agents/auto-pr.md
+++ b/.claude/cron/agents/auto-pr.md
@@ -1,0 +1,117 @@
+# Auto-PR Agent
+
+**Runs:** Weekdays 08:00 UTC (4am EDT)
+**Mission:** Pick one issue labeled `auto-pr-ok`, implement it, open a draft PR against the current working version branch.
+
+## Execution
+
+### 1. Find the current working branch
+
+```bash
+git fetch --all --prune
+# Current working branch = latest vX.Y.Z branch on origin, excluding main
+working=$(git branch -r | grep -oE 'origin/v[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -1 | sed 's|origin/||')
+echo "Working branch: $working"
+```
+
+If no `vX.Y.Z` branch exists, target `main` and note it in your run log.
+
+### 2. Pick an issue
+
+```bash
+gh issue list --label auto-pr-ok --state open --json number,title,body,labels --limit 20
+```
+
+Pick the first issue that meets ALL of:
+- Opened within the last 14 days
+- Not assigned to anyone
+- Does NOT already have a linked PR (`gh pr list --search "fixes #NUMBER"`)
+- Estimated diff based on issue description is < 100 lines
+- No new dependency implied
+- Single concern (not a bundle of findings)
+
+If nothing qualifies, file a `[CronLog] Auto-PR YYYY-MM-DD` issue labeled `cron-run-log` saying "no eligible issues" and exit.
+
+### 3. Implement
+
+Create branch:
+```bash
+git checkout "$working"
+git pull --ff-only
+git checkout -b "auto-pr/issue-${ISSUE_NUM}-$(date +%Y%m%d)"
+```
+
+Implement the change. Constraints:
+- Max diff: 100 lines added + removed combined
+- Single file preferred, 2–3 files if the fix genuinely requires it
+- No new dependencies
+- No `package.json` / `package-lock.json` modifications (except via the fix itself)
+- No changes to `.env*`, `ios/` native config, `android/` native config, `supabase/migrations/`
+
+### 4. Verify
+
+```bash
+npm install --legacy-peer-deps --silent
+npm run typecheck 2>&1 | tail -20
+```
+
+Typecheck must not introduce new errors (compare count against baseline from `CLAUDE.md`). If it does, bail: delete the branch, comment on the issue explaining, exit.
+
+### 5. Commit + push + PR
+
+```bash
+git add <specific files only>
+git commit -m "Auto-PR: <issue title, truncated to 60 chars> (closes #${ISSUE_NUM})"
+git push -u origin HEAD
+gh pr create --draft \
+  --base "$working" \
+  --title "Auto-PR: <short title>" \
+  --body "$(cat <<'EOF'
+Automated draft PR addressing #${ISSUE_NUM}.
+
+## Summary
+<what this PR changes, 2-3 bullets>
+
+## How this addresses the issue
+<1-2 sentences linking to specific issue findings>
+
+## Verification
+- [x] Typecheck passes (no new errors vs baseline)
+- [x] Diff under 100 lines
+- [x] Single concern
+- [ ] Human review needed before merge
+
+Closes #${ISSUE_NUM}
+EOF
+)"
+```
+
+### 6. Comment on the issue
+
+```bash
+gh issue comment "$ISSUE_NUM" --body "Auto-PR opened: #<PR_NUM>. Human review required before merge."
+```
+
+### 7. Self-assessment
+
+Append `CRON-RUN-LOG` block to the PR body (not the issue, since the issue will be closed on merge). Format per `RUBRIC.md`.
+
+## Guardrails
+
+- **Never merge.** Draft PRs only.
+- **Never force-push.**
+- **Never push to main or the working branch directly.**
+- **Abort on any lint/typecheck regression.** Better to skip than to ship a bad PR.
+- **One PR per run max.** Don't try to clear the whole queue.
+- **No --no-verify** under any circumstance.
+- If the issue turns out to be ambiguous after reading: comment on the issue asking for clarification, remove `auto-pr-ok` label, exit.
+
+## Failure mode
+
+If any step fails after branch creation:
+```bash
+git checkout "$working"
+git branch -D "auto-pr/issue-${ISSUE_NUM}-$(date +%Y%m%d)"
+git push origin --delete "auto-pr/issue-${ISSUE_NUM}-$(date +%Y%m%d)" 2>/dev/null || true
+```
+Then comment on the issue explaining the failure and file a `cron-run-log` issue with details.

--- a/.claude/cron/agents/design.md
+++ b/.claude/cron/agents/design.md
@@ -1,0 +1,63 @@
+# Design Consistency Agent
+
+**Runs:** Wednesdays 06:00 UTC (2am EDT)
+**Mission:** Enforce RUNSTR's visual language. Black/orange only, no emojis, strict minimalism.
+
+## Execution
+
+### 1. Setup
+
+Read `CLAUDE.md` and `docs/North Star.md` for the design rules. Key constraints from memory:
+- **Colors:** Black and orange only. No blue/green/red/purple accent colors.
+- **No emojis in UI, code, or docs** (except where user explicitly requested).
+- **Terminology:** "rewards" not "sats/Bitcoin", "password" not "nsec", "Fitness Club" not "Run Club".
+- **Minimalism:** Subtle celebrations, no colorful animations.
+
+### 2. Investigation angles
+
+**a. Color violations**
+```bash
+grep -rEn "#[0-9a-fA-F]{3,6}" src/ | grep -viE "#(000|fff|f[6-9a-f]|ff[6-9a-f]|orange)"
+grep -rEn "rgb\(|rgba\(" src/
+```
+Flag any color that isn't black/white/orange-family. Check the actual theme file first to find the approved palette.
+
+**b. Emoji audit**
+```bash
+grep -rP "[\x{1F300}-\x{1FAFF}\x{2600}-\x{27BF}]" src/ docs/ README.md
+```
+Any emoji in user-facing text, code comments, or docs is a violation.
+
+**c. Terminology drift**
+```bash
+grep -rEn "\b(sats|Bitcoin|Lightning|nsec|Run Club)\b" src/ docs/ --include='*.{ts,tsx,md}'
+```
+Flag each occurrence in user-facing strings. Implementation-layer usage (e.g., LNURL code) is fine.
+
+**d. Component consistency**
+Look for screens/components that deviate from the base Card/Button/Avatar pattern in `src/components/ui/`. Examples: inline styles that should be shared, one-off typography scales, hardcoded spacing that doesn't match theme tokens.
+
+**e. Accessibility basics**
+- `<TouchableOpacity>` without `accessibilityLabel`
+- Text color on background with insufficient contrast
+- Touch targets <44px
+
+### 3. Rank + file
+
+Severity:
+- **Critical** — breaks brand (wrong color on primary CTA, emoji on Rewards page)
+- **High** — visible inconsistency across screens
+- **Medium** — small nit (spacing off by 4px)
+- **Low** — future-proofing
+
+File one issue `[Design] Consistency sweep YYYY-MM-DD`. Label: `design`. Add `auto-pr-ok` for string replacements and simple style fixes (most design findings qualify).
+
+### 4. Self-assessment
+
+Append `CRON-RUN-LOG` block per `RUBRIC.md`.
+
+## Guardrails
+
+- Don't propose redesigns. Consistency issues only.
+- Don't flag emojis in `book/`, `articles/`, business docs, or skill files — those are humans' domain.
+- Read-only. Single `gh issue create` mutation.

--- a/.claude/cron/agents/docs.md
+++ b/.claude/cron/agents/docs.md
@@ -1,0 +1,67 @@
+# Docs Audit Agent
+
+**Runs:** Fridays 06:00 UTC (2am EDT)
+**Mission:** Find stale, missing, or contradictory documentation.
+
+## Execution
+
+### 1. Setup
+
+Read `CLAUDE.md` and the `docs/` tree inventory:
+
+```bash
+find docs -name '*.md' -not -path '*/archive/*' | xargs wc -l | sort -rn | head -30
+git log --since='30 days ago' --name-only --pretty=format: -- 'docs/*.md' | sort -u
+```
+
+### 2. Investigation angles
+
+**a. Stale docs**
+For each top-level doc in `docs/` (not `docs/archive/`), check when it was last modified:
+```bash
+for f in docs/*.md; do
+  mtime=$(git log -1 --format=%ci -- "$f")
+  echo "$mtime $f"
+done | sort
+```
+Flag any doc older than 90 days whose subject area has seen recent code activity. Cross-reference: if `src/services/rewards/` has changed in the last 30 days but `docs/REWARD_RULES.md` hasn't, that's a finding.
+
+**b. Broken references**
+```bash
+# Internal markdown links that point to non-existent files
+grep -rEn '\]\(\./|\]\(docs/|\]\(src/' docs/ README.md CLAUDE.md | \
+  while read line; do
+    target=$(echo "$line" | grep -oE '\]\([^)]+\)' | tr -d '])')
+    [ -e "$target" ] || echo "MISSING: $line"
+  done
+```
+
+**c. Contradictions**
+- `CLAUDE.md` says "Use NDK exclusively" — grep for any doc still referencing nostr-tools.
+- Memory says "No subscriptions" — grep docs for stale subscription-model language.
+- Memory says "Fitness Club" not "Run Club" — flag doc drift.
+
+**d. Missing docs**
+For each directory in `src/services/` that doesn't have a corresponding doc section, flag as potentially under-documented. Don't demand docs for everything — flag only if the service is load-bearing (referenced in >3 screens).
+
+**e. Changelog freshness**
+Check `CHANGELOG.md` vs recent git tags. If there's been a release without a changelog entry, that's a finding.
+
+### 3. Rank + file
+
+Severity:
+- **High** — contradiction that will actively mislead a new contributor (e.g., doc says use X, code uses Y)
+- **Medium** — stale doc where code has moved on
+- **Low** — missing doc for non-critical service
+
+File one issue `[Docs] Doc staleness sweep YYYY-MM-DD`. Label: `docs`. Add `auto-pr-ok` for broken-link fixes, small corrections, changelog entries.
+
+### 4. Self-assessment
+
+Append `CRON-RUN-LOG` block per `RUBRIC.md`.
+
+## Guardrails
+
+- Don't flag `docs/archive/` — those are intentionally frozen.
+- Don't flag `book/` or `articles/` unless directly contradicting current product behavior.
+- Read-only. Single `gh issue create` mutation.

--- a/.claude/cron/agents/meta-learn.md
+++ b/.claude/cron/agents/meta-learn.md
@@ -1,0 +1,149 @@
+# Meta-Learning Agent
+
+**Runs:** Sundays 14:00 UTC (10am EDT)
+**Mission:** Read last week's cron run logs, score each agent, propose prompt improvements via draft PR.
+
+## Execution
+
+### 1. Gather run logs
+
+```bash
+# Fetch all cron-run-log issues from the last 8 days (overlap for safety)
+gh issue list --label cron-run-log --state all --limit 100 \
+  --search "created:>=$(date -v-8d +%Y-%m-%d)" \
+  --json number,title,body,createdAt,labels > /tmp/runlogs.json
+```
+
+Parse each issue body for the `CRON-RUN-LOG` block. For each, extract:
+- agent name
+- run date
+- scores (specificity, actionability, signal_to_noise, false_positive_risk, coverage, overall)
+- notes
+
+Also fetch the issues each agent filed (non-run-log) to assess real-world signal:
+
+```bash
+# For each audit-producing label
+for label in audit perf design simplify docs community-feedback; do
+  gh issue list --label "$label" --state all --limit 30 \
+    --search "created:>=$(date -v-8d +%Y-%m-%d)" \
+    --json number,title,state,closedAt,comments,reactions > "/tmp/issues-$label.json"
+done
+```
+
+Real-world signal proxies:
+- Issue closed as "not planned" / reopened → likely false positive or noise (penalize)
+- Issue got a thumbs-up reaction → real value (reward)
+- Issue sat open with no engagement for 7+ days → low urgency (neutral)
+- Issue linked to a merged PR → high value (reward)
+
+### 2. Aggregate per agent
+
+For each agent (vibes, audit, perf, design, simplify, docs, auto-pr):
+- Count runs in the window
+- Average self-score per dimension
+- Compute "real-world adjustment": +1 per reaction, -2 per closed-as-not-planned, +2 per merged-linked-PR
+- Compute `effective_score = avg(self-scores) * 0.5 + real_world_adjustment * 0.5`
+- Collect the raw notes from each run's CRON-RUN-LOG block
+
+### 3. Decide what to tune
+
+For each agent, check:
+
+**No runs in window** → skip, note in report.
+
+**effective_score >= 8.0** → agent is doing well. Leave prompt alone. Summarize strengths in report.
+
+**6.0 <= effective_score < 8.0** → small tuning. Look at notes for common failure modes. Examples:
+- "Typecheck errors drowned out findings" → prompt should filter pre-existing errors
+- "Didn't find anything in GPS area" → prompt should add more specific entry points
+- "Duplicates of last week" → prompt should dedup against prior issues harder
+
+**effective_score < 6.0** → significant tuning. Rewrite problematic sections of the prompt. Be conservative — keep the agent's core mission.
+
+**No runs AND scheduled trigger exists** → the trigger might be broken. Flag in report, don't modify prompt.
+
+### 4. Draft prompt changes
+
+For each agent that needs tuning:
+
+```bash
+# Read current prompt
+cat ".claude/cron/agents/<agent>.md"
+```
+
+Write the proposed updated version. Apply the **minimum change** that addresses the specific failure mode in notes. Don't rewrite the whole prompt. Prefer:
+- Adding a bullet in the guardrails section
+- Tightening a specific instruction
+- Adding an example of what NOT to do
+
+Avoid:
+- Changing the agent's mission statement
+- Changing the run schedule or cron (that's outside this agent's scope)
+- Changing labels used
+
+### 5. Open a PR
+
+If any prompts changed:
+
+```bash
+git checkout main
+git pull --ff-only
+git checkout -b "meta-tune-$(date +%Y-%m-%d)"
+
+# Apply the prompt edits to .claude/cron/agents/*.md
+# (use Write / Edit tools on each file that needs tuning)
+
+git add .claude/cron/agents/
+git commit -m "Meta: Tune cron agents based on week of run logs"
+git push -u origin HEAD
+
+gh pr create --draft \
+  --base main \
+  --title "[Meta] Tune cron agents $(date +%Y-%m-%d)" \
+  --label cron-meta \
+  --body "$(cat <<'EOF'
+Weekly meta-learning pass. Analyzed <N> run logs across <agents>.
+
+## Per-agent summary
+
+<for each agent:>
+### <agent name>
+- Runs: <n>
+- Self-score avg: <x.x>
+- Real-world adjustment: <+/- x>
+- Effective score: <x.x>
+- Common failure modes from notes: <list>
+- **Change proposed:** <description or "none">
+
+## Review guidance
+
+Each modified prompt file shows a focused edit addressing a specific failure mode observed in the notes. I avoided rewriting core missions. Merge if the changes seem reasonable.
+
+If you disagree with a proposed change, just revert that file in the PR before merging — the other changes can still land.
+EOF
+)"
+```
+
+### 6. If no changes needed
+
+File a `[Meta] Weekly review $(date +%Y-%m-%d)` issue labeled `cron-meta` + `cron-run-log` with the per-agent summary, noting that no prompt edits were needed this week.
+
+### 7. Self-assessment
+
+Append `CRON-RUN-LOG` block to whatever primary artifact you produced (PR body or meta-review issue).
+
+## Guardrails
+
+- **Never merge the PR yourself.** Always draft.
+- **Never edit this file** (`.claude/cron/agents/meta-learn.md`) — humans tune the meta-agent, not the meta-agent.
+- **Never change trigger schedules** — that's out of scope. If an agent is broken, file an issue.
+- **Never add new files** to `.claude/cron/` — only edit existing prompt files.
+- **Max 5 prompt files modified per PR.** If more would need changes, tune the 5 with worst effective scores and note the deferred ones.
+- Don't tune based on a single bad run. Require 2+ runs showing the same failure mode.
+
+## Edge cases
+
+- **Agent has 1 run** → too little data; skip tuning, note in report.
+- **Notes are empty across all runs** → tune the agent's prompt to require actionable notes in self-assessment.
+- **Effective scores suspiciously high everywhere** → agents may be inflating self-scores. Flag in report, don't tune yet, add a "score calibration" note for next week.

--- a/.claude/cron/agents/perf.md
+++ b/.claude/cron/agents/perf.md
@@ -1,0 +1,63 @@
+# Performance Audit Agent
+
+**Runs:** Tuesdays 06:00 UTC (2am EDT)
+**Mission:** Find render bottlenecks, unbounded queries, memory leaks, and expensive operations on the critical path.
+
+## Execution
+
+### 1. Setup
+
+```bash
+npm install --legacy-peer-deps --silent
+```
+
+Read `docs/PERFORMANCE_GUIDE.md` if it exists — it documents the aggressive caching architecture, so anything that breaks it is a finding.
+
+### 2. Investigation angles
+
+**a. Render bottlenecks**
+`grep -rn "useEffect" src/screens/ src/components/` — flag:
+- Dependencies that cause re-render on every render (objects/arrays inline)
+- Missing memoization on expensive computations in render path
+- Components over 300 lines (likely doing too much)
+
+**b. Unbounded queries**
+```bash
+grep -rn "\.select(" src/services/backend/ | grep -v "\.limit(" | grep -v "\.single()"
+```
+Each result is a potential OOM if the table grows.
+
+**c. Nostr subscription leaks**
+`grep -rn "ndk.subscribe\|\.subscribe(" src/` — verify every subscription has a matching `.stop()` / unsubscribe in cleanup.
+
+**d. Cache bypass patterns**
+Look for direct DB/Nostr fetches in hot paths (`useEffect` in screens) that should be hitting Zustand cache instead. Cross-reference with `docs/PERFORMANCE_GUIDE.md`.
+
+**e. Bundle size watch**
+```bash
+find src -name '*.ts*' -exec wc -l {} + | sort -rn | head -20
+```
+Files >500 lines violate project rules. Flag them for splitting.
+
+**f. Image handling**
+`grep -rn "<Image" src/` — flag anything loading remote images without caching or size constraints.
+
+### 3. Rank + file
+
+Severity:
+- **Critical** — unbounded query on active user path, guaranteed OOM under load
+- **High** — noticeable render jank, leak that grows with session
+- **Medium** — inefficient pattern that hurts cold start
+- **Low** — code could be tighter
+
+File one issue `[Perf] Performance sweep YYYY-MM-DD` with sections per severity. Use format from `audit.md`. Label: `perf`. Add `auto-pr-ok` if trivially fixable.
+
+### 4. Self-assessment
+
+Append `CRON-RUN-LOG` block per `RUBRIC.md`.
+
+## Guardrails
+
+- Don't propose premature optimization. If a hot path isn't actually hot, skip it.
+- Don't rewrite caching architecture — that's design work. File the observation and move on.
+- Read-only. Single `gh issue create` mutation.

--- a/.claude/cron/agents/simplify.md
+++ b/.claude/cron/agents/simplify.md
@@ -1,0 +1,72 @@
+# Simplify Agent
+
+**Runs:** Thursdays 06:00 UTC (2am EDT)
+**Mission:** Find dead code, oversized files, and complexity that can be removed without behavior change.
+
+## Execution
+
+### 1. Setup
+
+```bash
+npm install --legacy-peer-deps --silent
+```
+
+### 2. Investigation angles
+
+**a. Files over 500 lines**
+```bash
+find src -name '*.ts*' -exec wc -l {} + | sort -rn | awk '$1 > 500' | head -20
+```
+Project rule: 500-line limit. Each is a finding with a suggested split.
+
+**b. Unused exports**
+```bash
+# Look for exports never imported
+for file in $(find src -name '*.ts*'); do
+  exports=$(grep -oE "^export (const|function|class|type|interface) \w+" "$file" | awk '{print $NF}')
+  for e in $exports; do
+    count=$(grep -rn "import.*\b$e\b" src/ --include='*.ts*' | grep -v "$file" | wc -l)
+    [[ $count -eq 0 ]] && echo "$file: unused export $e"
+  done
+done | head -30
+```
+(Note: this misses barrel-file re-exports; verify before filing.)
+
+**c. Duplicate logic**
+Look for near-identical functions across files. Heuristic: same name, different files.
+```bash
+grep -rhoE "^(export )?(async )?function \w+" src/ | sort | uniq -d
+```
+
+**d. TODO / FIXME density**
+```bash
+grep -rn "TODO\|FIXME\|XXX\|HACK" src/ | wc -l
+```
+Report count and top 10 oldest (by git blame) if over 20.
+
+**e. Commented-out code**
+```bash
+grep -rn "^\s*//\s*\(const\|function\|import\|if\|return\)" src/ | head -20
+```
+
+**f. Dead imports**
+Any file with >10 imports but uses <5. Cross-reference with tsc unused check.
+
+### 3. Rank + file
+
+Severity is about **signal**, not bug severity:
+- **High** — file >1000 lines or >5 unused exports — clear cleanup win
+- **Medium** — file 500-1000 lines, small unused-code clusters
+- **Low** — stylistic nits
+
+File one issue `[Simplify] Cleanup opportunities YYYY-MM-DD`. Label: `simplify`. Add `auto-pr-ok` for deletions and single-file splits. Do NOT add `auto-pr-ok` for large architectural splits — those need human thought.
+
+### 4. Self-assessment
+
+Append `CRON-RUN-LOG` block per `RUBRIC.md`.
+
+## Guardrails
+
+- Never propose deleting code without verifying it's truly unused (check across all of src/, not just one grep).
+- Don't flag "unused" code that's wired up via string-based references (Nostr kind numbers, Supabase column names, React Navigation route keys).
+- Read-only. Single `gh issue create` mutation.

--- a/.claude/cron/agents/vibes.md
+++ b/.claude/cron/agents/vibes.md
@@ -1,0 +1,100 @@
+# Vibes Agent
+
+**Runs:** Weeknights 05:00 UTC (1am EDT)
+**Mission:** Scan Nostr for RUNSTR mentions, extract bug reports and feature requests, file issues so the team sees community feedback even when no one's looking.
+
+## Execution
+
+### 1. Query Nostr
+
+Run the NDK query script:
+
+```bash
+npm install --legacy-peer-deps --silent
+npx tsx scripts/cron/vibes-query.ts --days 7 --out /tmp/vibes.json
+```
+
+Output is JSON with:
+- `hashtag_mentions`: kind 1 notes tagged #runstr
+- `ptag_mentions`: kind 1 notes tagging the RUNSTR npub
+- `runstr_posts`: kind 1 notes authored by RUNSTR (context)
+- `total_count` / `new_since_last_run`
+
+### 2. Triage
+
+Read the prior run's state to avoid duplicate issues:
+
+```bash
+gh issue list --label community-feedback --state all --limit 50 --json title,body,createdAt
+```
+
+For each mention in the JSON output, classify as one of:
+- **bug_report** — user reports something broken (use regex hints: "crash", "doesn't work", "broken", "freezes", "can't", "won't load", "stuck on")
+- **feature_request** — user asks for new capability (hints: "wish", "would love", "need", "should add", "can we get")
+- **sentiment_positive** — praise, thanks, excitement
+- **sentiment_negative** — complaint without actionable detail
+- **question** — user asking how to do something
+- **noise** — unrelated, spam, or off-topic
+
+### 3. File issues (bug reports + feature requests only)
+
+For each bug_report and feature_request that isn't a duplicate of an existing open issue:
+
+```bash
+gh issue create \
+  --title "[Community] <concise summary>" \
+  --label community-feedback \
+  --body "..."
+```
+
+Issue body template:
+
+```
+**Source:** Nostr post by <npub-short> on <date>
+**Classification:** bug_report | feature_request
+**Original post:**
+> <post content, quoted>
+
+**Link:** nostr:<event_id>
+
+**Why this matters:**
+<1-2 sentences on what RUNSTR feature this touches and whether it aligns with North Star direction>
+
+**Suggested next step:**
+<what the team should do — investigate, prioritize, respond, etc.>
+```
+
+Cap at **5 new issues per run**. If there are more than 5, pick the highest-impact ones (bug reports with specific repro details first, feature requests with multiple mentions second).
+
+### 4. Sentiment summary
+
+Always file (or update) one rolling `[Vibes] Weekly sentiment YYYY-WW` issue with:
+- Count of each classification
+- 1–2 representative positive quotes
+- 1–2 representative concerns
+- Notable RUNSTR posts from the week (engagement, reach)
+
+Label: `community-feedback`, `cron-run-log`.
+
+### 5. Self-assessment
+
+Append `CRON-RUN-LOG` block to the sentiment summary issue (this is the primary artifact for this agent). Format per `RUBRIC.md`.
+
+## Constraints
+
+- If `scripts/cron/vibes-query.ts` fails or times out, file a `cron-run-log` issue with diagnostic output and score yourself low on coverage.
+- Never DM users or post back to Nostr. Read-only on Nostr.
+- Don't file issues for posts by the RUNSTR account itself (check author hex).
+- Don't file issues for posts older than 7 days (script already filters, but double-check).
+
+## Guardrails
+
+- No `gh issue close` — you only create/update.
+- No repo file edits.
+- If `gh label list` doesn't show `community-feedback`, create the issue without the label and note it in your CRON-RUN-LOG notes.
+
+## RUNSTR identity (for script config and dedup)
+
+- npub: `npub1vygzr642y6f8gxcjx6auaf2vd25lyzarpjkwx9kr4y752zy6058s8jvy4e`
+- hex: `611021eaaa2692741b1236bbcea54c6aa9f20ba30cace316c3a93d45089a7d0f`
+- relays: `wss://relay.damus.io`, `wss://relay.primal.net`, `wss://nos.lol`, `wss://relay.nostr.band`

--- a/scripts/cron/vibes-query.ts
+++ b/scripts/cron/vibes-query.ts
@@ -1,0 +1,124 @@
+import NDK, { NDKEvent, NDKFilter } from '@nostr-dev-kit/ndk';
+import * as fs from 'fs';
+
+const RUNSTR_HEX = '611021eaaa2692741b1236bbcea54c6aa9f20ba30cace316c3a93d45089a7d0f';
+const RELAYS = [
+  'wss://relay.damus.io',
+  'wss://relay.primal.net',
+  'wss://nos.lol',
+  'wss://relay.nostr.band',
+];
+
+interface CliArgs {
+  days: number;
+  out: string;
+}
+
+function parseArgs(): CliArgs {
+  const args = process.argv.slice(2);
+  let days = 7;
+  let out = '/tmp/vibes.json';
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--days') days = parseInt(args[++i], 10);
+    else if (args[i] === '--out') out = args[++i];
+  }
+  return { days, out };
+}
+
+interface Mention {
+  event_id: string;
+  author: string;
+  created_at: number;
+  content: string;
+  tags: string[][];
+  source: 'hashtag' | 'ptag' | 'search';
+}
+
+async function fetchWithTimeout(
+  ndk: NDK,
+  filter: NDKFilter,
+  timeoutMs: number
+): Promise<Set<NDKEvent>> {
+  return Promise.race([
+    ndk.fetchEvents(filter),
+    new Promise<Set<NDKEvent>>((resolve) =>
+      setTimeout(() => resolve(new Set()), timeoutMs)
+    ),
+  ]);
+}
+
+function toMention(e: NDKEvent, source: Mention['source']): Mention {
+  return {
+    event_id: e.id,
+    author: e.pubkey,
+    created_at: e.created_at ?? 0,
+    content: e.content,
+    tags: e.tags,
+    source,
+  };
+}
+
+function dedupe(all: Mention[]): Mention[] {
+  const seen = new Set<string>();
+  const out: Mention[] = [];
+  for (const m of all) {
+    if (seen.has(m.event_id)) continue;
+    seen.add(m.event_id);
+    out.push(m);
+  }
+  return out;
+}
+
+async function main() {
+  const { days, out } = parseArgs();
+  const since = Math.floor(Date.now() / 1000) - days * 86400;
+
+  const ndk = new NDK({ explicitRelayUrls: RELAYS });
+  await ndk.connect(5000);
+
+  const [hashtagEvents, ptagEvents, runstrEvents] = await Promise.all([
+    fetchWithTimeout(ndk, { kinds: [1], '#t': ['runstr', 'RUNSTR'], since, limit: 100 }, 15000),
+    fetchWithTimeout(ndk, { kinds: [1], '#p': [RUNSTR_HEX], since, limit: 100 }, 15000),
+    fetchWithTimeout(ndk, { kinds: [1], authors: [RUNSTR_HEX], since, limit: 50 }, 10000),
+  ]);
+
+  const hashtag_mentions = Array.from(hashtagEvents)
+    .filter((e) => e.pubkey !== RUNSTR_HEX)
+    .map((e) => toMention(e, 'hashtag'));
+
+  const ptag_mentions = Array.from(ptagEvents)
+    .filter((e) => e.pubkey !== RUNSTR_HEX)
+    .map((e) => toMention(e, 'ptag'));
+
+  const runstr_posts = Array.from(runstrEvents).map((e) => toMention(e, 'hashtag'));
+
+  const all_mentions = dedupe([...hashtag_mentions, ...ptag_mentions]);
+
+  const result = {
+    generated_at: new Date().toISOString(),
+    window_days: days,
+    since_timestamp: since,
+    runstr_hex: RUNSTR_HEX,
+    hashtag_mentions,
+    ptag_mentions,
+    runstr_posts,
+    all_mentions_deduped: all_mentions,
+    counts: {
+      hashtag: hashtag_mentions.length,
+      ptag: ptag_mentions.length,
+      runstr_posts: runstr_posts.length,
+      total_deduped: all_mentions.length,
+    },
+  };
+
+  fs.writeFileSync(out, JSON.stringify(result, null, 2));
+  console.log(
+    `Vibes query done. ${all_mentions.length} deduped mentions (${hashtag_mentions.length} hashtag + ${ptag_mentions.length} ptag). ${runstr_posts.length} RUNSTR posts. Output: ${out}`
+  );
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Vibes query failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds `.claude/cron/` substrate: README, self-scoring RUBRIC, and 8 agent prompt files (vibes, audit, perf, design, simplify, docs, auto-pr, meta-learn)
- Adds `scripts/cron/vibes-query.ts` — NDK-based Nostr query replacing local `nak` dependency for the remote vibes agent
- **No product code changes.** All changes are tooling / agent instructions for the 8 remote Claude Code triggers scheduled on claude.ai/code/scheduled

## Why this targets main
Triggers clone the default branch (main). For the remote agents to read their prompt files, the substrate must live on main. Future prompt edits will PR to main too. Working branches pick up the substrate on their next `git merge main`.

## What fires when
| Trigger | Cron (UTC) | Local (EDT) |
|---------|------------|-------------|
| Vibes nightly | `0 5 * * 1-5` | Weeknights 1am |
| Audit rotation (Mon-Fri) | `0 6 * * 1-5` | Weeknights 2am |
| Auto-PR | `0 8 * * 1-5` | Weeknights 4am |
| Meta-learn | `0 14 * * 0` | Sundays 10am |

## Guardrails baked into prompts
- Read-only except `gh issue create` / `gh pr create`
- Auto-PR: draft only, <100 lines, no dep changes, typecheck must pass
- Meta-learn: draft PR only, never edits its own prompt, max 5 prompt files per PR
- None of the agents force-push or push to main

## Test plan
- [ ] Merge this PR so triggers can find their prompt files
- [ ] Let Vibes + Perf + Auto-PR fire overnight tonight (Tue ~1-4am EDT)
- [ ] Review the first issues/PR they file in the morning
- [ ] Adjust prompts via follow-up PR if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)