### PR TITLE
Auto-PR: Fix off-brand activity chip colors in SavedRoutesScreen

### DIFF
--- a/src/screens/routes/SavedRoutesScreen.tsx
+++ b/src/screens/routes/SavedRoutesScreen.tsx
@@ -154,13 +154,13 @@ export const SavedRoutesScreen: React.FC = () => {
   const getActivityColor = (type: WorkoutType): string => {
     switch (type) {
       case 'running':
-        return '#FF6B00';
+        return theme.colors.accent;
       case 'walking':
-        return '#4ECDC4';
+        return theme.colors.orangeBright;
       case 'cycling':
-        return '#45B7D1';
+        return theme.colors.orangeBurnt;
       case 'hiking':
-        return '#96CEB4';
+        return theme.colors.textMuted;
       default:
         return theme.colors.accent;
     }


### PR DESCRIPTION
Automated draft PR addressing #316 (Finding #2 — Critical).

## Summary
- Replace teal `#4ECDC4` (walking), blue `#45B7D1` (cycling), and mint-green `#96CEB4` (hiking) chip colors with orange-family theme tokens in `getActivityColor()` in `SavedRoutesScreen.tsx`
- Replace hardcoded `#FF6B00` (running) with `theme.colors.accent` to keep all four cases on-token
- Single file changed, 4 lines replaced

## How this addresses the issue

Finding #2 (Critical) from [Design] Consistency sweep #316. The `getActivityColor()` helper in `SavedRoutesScreen.tsx:154-167` returned off-brand teal, blue, and mint-green values for walking, cycling, and hiking activity chips that render visibly on the Saved Routes screen. Replaced with on-brand orange-family tokens: `theme.colors.accent`, `theme.colors.orangeBright`, `theme.colors.orangeBurnt`, `theme.colors.textMuted`.

Other findings from #316 (NostrConnectionStatus, modal green-tinted boxes, debug overlay, NWC error container) are either already covered by open PR #300 or are lower severity — left for human triage.

## Verification
- [x] Typecheck passes (only pre-existing `expo/tsconfig.base` + `baseUrl` deprecation errors; no new errors)
- [x] Diff under 100 lines (8 total: 4 added + 4 removed, 1 file)
- [x] Single concern (off-brand chip colors in one component)
- [ ] Human review needed before merge

Closes #316

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-05-06
findings_count: 1
severity: critical=1 high=0 medium=0 low=0
self_score:
  specificity: 9
  actionability: 10
  signal_to_noise: 9
  false_positive_risk: 10
  coverage: 7
overall: 9.0
notes: Four issues already had existing draft PRs; picked the one unaddressed critical finding (SavedRoutesScreen chip colors) from today's sweep as the single-concern target.
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_01Li6MkQjfiCyPnnzuDd3F6F)_