### PR TITLE
Auto-PR: Extract duplicate deriveStatus into shared utility

### DIFF
--- a/src/components/club/ClubEventsSection.tsx
+++ b/src/components/club/ClubEventsSection.tsx
@@ -21,8 +21,8 @@ import { theme } from '../../styles/theme';
 import { SupabaseCompetitionService } from '../../services/backend/SupabaseCompetitionService';
 import { SimpleEventCreationModal } from '../creation/SimpleEventCreationModal';
 import { CustomAlert } from '../ui/CustomAlert';
-import type { Competition } from '../../utils/supabase';
 import type { CompetitionStatus, DynamicCompetition } from '../../hooks/useDynamicCompetitions';
+import { deriveStatus } from '../../utils/competitionStatus';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -46,17 +46,6 @@ const CACHE_TTL = 3 * 60 * 1000;
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function deriveStatus(comp: Competition): CompetitionStatus {
-  const now = Date.now();
-  const start = new Date(comp.start_date).getTime();
-  const endDate = new Date(comp.end_date);
-  endDate.setUTCHours(23, 59, 59, 999);
-  const end = endDate.getTime();
-  if (now < start) return 'upcoming';
-  if (now > end) return 'ended';
-  return 'active';
-}
 
 const STATUS_ORDER: Record<CompetitionStatus, number> = {
   active: 0,

--- a/src/hooks/useDynamicCompetitions.ts
+++ b/src/hooks/useDynamicCompetitions.ts
@@ -8,25 +8,15 @@
 import { useState, useEffect, useCallback } from 'react';
 import { SupabaseCompetitionService } from '../services/backend/SupabaseCompetitionService';
 import type { Competition } from '../utils/supabase';
+import { deriveStatus, type CompetitionStatus } from '../utils/competitionStatus';
 
-export type CompetitionStatus = 'active' | 'upcoming' | 'ended';
+export type { CompetitionStatus };
 
 export interface DynamicCompetition extends Competition {
   status: CompetitionStatus;
 }
 
 const ENDED_GRACE_MS = 24 * 60 * 60 * 1000; // 24 hours
-
-function deriveStatus(comp: Competition): CompetitionStatus {
-  const now = Date.now();
-  const start = new Date(comp.start_date).getTime();
-  const endDate = new Date(comp.end_date);
-  endDate.setUTCHours(23, 59, 59, 999);
-  const end = endDate.getTime();
-  if (now < start) return 'upcoming';
-  if (now > end) return 'ended';
-  return 'active';
-}
 
 /** Ended events stay visible for 24h so users can view final leaderboards */
 function isWithinGracePeriod(comp: Competition): boolean {

--- a/src/screens/events/DynamicEventDetailScreen.tsx
+++ b/src/screens/events/DynamicEventDetailScreen.tsx
@@ -35,6 +35,7 @@ import { callEdgeFunction } from '../../utils/edgeFunctions';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Avatar } from '../../components/ui/Avatar';
 import type { Competition, CompetitionConfig } from '../../utils/supabase';
+import { deriveStatus } from '../../utils/competitionStatus';
 import { getCharityById } from '../../constants/charities';
 
 const RUNSTR_LOGO = require('../../../assets/images/icon.png');
@@ -44,19 +45,6 @@ const BATCH_SIZE = 21;
 interface DynamicEventDetailScreenProps {
   navigation: any;
   route: { params: { eventId: string } };
-}
-
-type EventStatus = 'active' | 'upcoming' | 'ended';
-
-function deriveStatus(comp: Competition): EventStatus {
-  const now = Date.now();
-  const start = new Date(comp.start_date).getTime();
-  const endDate = new Date(comp.end_date);
-  endDate.setUTCHours(23, 59, 59, 999);
-  const end = endDate.getTime();
-  if (now < start) return 'upcoming';
-  if (now > end) return 'ended';
-  return 'active';
 }
 
 const ACTIVITY_ICONS: Record<string, keyof typeof Ionicons.glyphMap> = {

--- a/src/utils/competitionStatus.ts
+++ b/src/utils/competitionStatus.ts
@@ -1,0 +1,14 @@
+import type { Competition } from './supabase';
+
+export type CompetitionStatus = 'active' | 'upcoming' | 'ended';
+
+export function deriveStatus(comp: Competition): CompetitionStatus {
+  const now = Date.now();
+  const start = new Date(comp.start_date).getTime();
+  const endDate = new Date(comp.end_date);
+  endDate.setUTCHours(23, 59, 59, 999);
+  const end = endDate.getTime();
+  if (now < start) return 'upcoming';
+  if (now > end) return 'ended';
+  return 'active';
+}


### PR DESCRIPTION
Automated draft PR addressing #318 (MEDIUM finding — identical `deriveStatus` in 2 files, near-identical in a third).

## Summary
- Create `src/utils/competitionStatus.ts` exporting `CompetitionStatus` type and canonical `deriveStatus` function
- Remove the byte-for-byte duplicate `deriveStatus` from `src/hooks/useDynamicCompetitions.ts`; import from utility; re-export `CompetitionStatus` for backward compatibility
- Remove the byte-for-byte duplicate `deriveStatus` from `src/components/club/ClubEventsSection.tsx`; import from utility; drop now-unused `Competition` import
- Remove the near-identical `deriveStatus` + local `EventStatus` type from `src/screens/events/DynamicEventDetailScreen.tsx`; import from utility (types are structurally identical)

## How this addresses the issue

Issue #318 (MEDIUM finding 1) identified a byte-for-byte identical 9-line `deriveStatus` function in `ClubEventsSection.tsx:50` and `useDynamicCompetitions.ts:20`, with a near-identical third copy at `DynamicEventDetailScreen.tsx:51`. The issue tagged this "auto-pr-ok — deletion + two-file update, no behavior change." This PR consolidates all three into `src/utils/competitionStatus.ts` with no logic changes.

## Verification
- [x] Typecheck passes (no new errors vs baseline — only pre-existing `expo/tsconfig.base` + `baseUrl` deprecation)
- [x] Diff under 100 lines (18 added + 37 removed across 4 files)
- [x] Single concern (deduplication of `deriveStatus`)
- [ ] Human review needed before merge

Closes #318

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-05-07
findings_count: 1
severity: critical=0 high=0 medium=1 low=0
self_score:
  specificity: 9
  actionability: 9
  signal_to_noise: 9
  false_positive_risk: 9
  coverage: 7
overall: 8.6
notes: Issue #318 had multiple findings but only one was auto-pr-ok; the remaining 4 eligible issues (282, 299, 303, 306, 316) all had existing open draft PRs so the pool was narrow.
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_012Rrm4iBtRyVfzJ9xoMTdFm)_