### PR TITLE
[Meta] Tune cron agents 2026-05-17

### DIFF
--- a/.claude/cron/agents/audit.md
+++ b/.claude/cron/agents/audit.md
@@ -64,7 +64,7 @@ File **one** issue per run titled `[Audit] General sweep YYYY-MM-DD` (substitute
 - `**Why:**` one-sentence reasoning
 - `**Fix direction:**` one sentence
 
-Label: `audit`. If findings look trivially fixable (<50 line diff, single file, no design decisions), also add `auto-pr-ok`.
+Label: `audit`, `cron-run-log`. If findings look trivially fixable (<50 line diff, single file, no design decisions), also add `auto-pr-ok`.
 
 ### 5. Self-assessment
 

--- a/.claude/cron/agents/perf.md
+++ b/.claude/cron/agents/perf.md
@@ -50,7 +50,7 @@ Severity:
 - **Medium** — inefficient pattern that hurts cold start
 - **Low** — code could be tighter
 
-File one issue `[Perf] Performance sweep YYYY-MM-DD` with sections per severity. Use format from `audit.md`. Label: `perf`. Add `auto-pr-ok` if trivially fixable.
+File one issue `[Perf] Performance sweep YYYY-MM-DD` with sections per severity. Use format from `audit.md`. Label: `perf`, `cron-run-log`. Add `auto-pr-ok` if trivially fixable.
 
 ### 4. Self-assessment
 


### PR DESCRIPTION
Weekly meta-learning pass. Analyzed 8 run logs across 7 agents (audit, perf, design, simplify, docs, auto-pr, vibes).

## Per-agent summary

### audit
- Runs in window: 1 (2026-05-11, issue #331); 3 total across full history (#294, #311, #331)
- Self-score avg: 8.6 (specificity=9, actionability=9, signal_to_noise=9, false_positive_risk=8, coverage=8)
- Real-world adjustment: 0 (no merged PRs, no reactions, no closed-not-planned)
- Effective score: 8.6
- Common failure mode from notes: All three runs produce valid CRON-RUN-LOG blocks in the issue body, but the issue is never labeled `cron-run-log`. This makes audit issues invisible to `gh issue list --label cron-run-log` — the query the meta-learn agent uses to gather run logs. The prompt says `Label: \`audit\`` with no mention of `cron-run-log`.
- **Change proposed:** Add `cron-run-log` to the label list in step 4.

### perf
- Runs in window: 1 (2026-05-12, issue #334)
- Self-score avg: 8.8 (specificity=9, actionability=8, signal_to_noise=8, false_positive_risk=9, coverage=10)
- Real-world adjustment: 0
- Effective score: 8.8
- Common failure mode from notes: Same root cause as audit — issue #334 has the `perf` label but not `cron-run-log`. The prompt says `Label: \`perf\`` with no mention of `cron-run-log`.
- **Change proposed:** Add `cron-run-log` to the label list in step 3.

### design
- Runs in window: 1 (2026-05-13, issue #336)
- Self-score avg: 8.2 (specificity=9, actionability=8, signal_to_noise=8, false_positive_risk=8, coverage=8)
- Real-world adjustment: 0
- Effective score: 8.2
- Common failure mode from notes: "Three of six findings are in components with no detected import path — reachability uncertainty lowered actionability and false-positive scores; next run could grep for dynamic imports and lazy screens."
- **Change proposed:** None — single run, guardrail requires 2+ runs showing same failure mode before tuning.

### simplify
- Runs in window: 1 (2026-05-14, issue #338)
- Self-score avg: 8.4 (specificity=9, actionability=8, signal_to_noise=8, false_positive_risk=9, coverage=8)
- Real-world adjustment: 0 (PR #339 opened but not merged)
- Effective score: 8.4
- Common failure mode from notes: "Dead-code check required two grep passes to confirm zero consumers — single grep on function name was misleading."
- **Change proposed:** None — single run, operationally sound, score well above threshold.

### docs
- Runs in window: 1 (2026-05-15, issue #340)
- Self-score avg: 8.6 (specificity=9, actionability=8, signal_to_noise=9, false_positive_risk=9, coverage=8)
- Real-world adjustment: 0
- Effective score: 8.6
- Common failure mode from notes: "ARCHITECTURE.md reward-flow diagram block was missed in the 1.9.4 doc pass — cross-referencing REWARD_RULES.md made this easy to catch."
- **Change proposed:** None — performing well.

### auto-pr
- Runs in window: 1 (2026-05-12, issue #335)
- Self-score avg: 9.4 (specificity=9, actionability=9, signal_to_noise=9, false_positive_risk=10, coverage=10)
- Real-world adjustment: 0
- Effective score: 9.4
- Common failure mode from notes: "Queue is saturated — all auto-pr-ok issues already have open draft PRs." This is a human workflow issue (stale drafts not merging), not an agent prompt issue.
- **Change proposed:** None — performing excellently.

### vibes
- Runs in window: 2 (2026-05-11 #330, 2026-05-12 #333)
- Self-score avg: 8.3 (specificity=7, actionability=7, signal_to_noise=9.5, false_positive_risk=10, coverage=8)
- Real-world adjustment: 0
- Effective score: 8.3
- Common failure mode from notes: Specificity (7) and actionability (7) are structurally lower in zero-finding weeks — the agent cannot be more specific when there is nothing to report. The agent correctly verifies relay connectivity, retries at 30s, and explicitly distinguishes genuine silence from infrastructure failure. This pattern is inherent to the zero-community-signal period, not a prompt deficiency.
- **Change proposed:** None — the 7/7 on spec/action in no-finding runs is accurate self-scoring, not a problem to fix.

## Review guidance

Two files changed, one line each:

- `audit.md` step 4: `Label: \`audit\`` → `Label: \`audit\`, \`cron-run-log\``
- `perf.md` step 3: `Label: \`perf\`` → `Label: \`perf\`, \`cron-run-log\``

Both changes fix the same root cause: audit and perf issues with findings are invisible to the meta-learn agent's `label:cron-run-log` query because the prompts never instruct those agents to apply that label to their primary artifacts. The CRON-RUN-LOG blocks themselves are correctly formatted and present — this is purely a label omission.

Confirmed across 3 audit runs (#294, #311, #331) and 1 perf run (#334) with identical symptoms. All other agents (design, simplify, docs, auto-pr, vibes) correctly include `cron-run-log` in their label instructions and were found in the query.

If you disagree with either change, revert that file — the other still stands.

<!-- CRON-RUN-LOG
agent: meta-learn
run_date: 2026-05-17
findings_count: 2
severity: critical=0 high=0 medium=2 low=0
self_score:
  specificity: 9
  actionability: 9
  signal_to_noise: 9
  false_positive_risk: 9
  coverage: 8
overall: 8.8
notes: Audit issues were initially missed by the cron-run-log label query (3 consecutive runs invisible to meta-learn); found them via label:audit search and confirmed CRON-RUN-LOG blocks present in bodies — label omission, not missing blocks.
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_01WV9VmCQhsypky3U6wqpNnt)_