### PR TITLE
Auto-PR: Fix RewardHistoryScreen perpetual spinner for anonymous users

### DIFF
--- a/src/screens/RewardHistoryScreen.tsx
+++ b/src/screens/RewardHistoryScreen.tsx
@@ -149,9 +149,14 @@ export const RewardHistoryScreen: React.FC = () => {
   // Load pubkey once on mount
   useEffect(() => {
     let cancelled = false;
-    AsyncStorage.getItem('@runstr:hex_pubkey').then((value) => {
-      if (!cancelled && value) setPubkey(value);
-    });
+    AsyncStorage.getItem('@runstr:hex_pubkey')
+      .then((value) => {
+        if (!cancelled && value) setPubkey(value);
+        else if (!cancelled) setIsLoading(false);
+      })
+      .catch(() => {
+        if (!cancelled) setIsLoading(false);
+      });
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
Automated draft PR addressing #331.

## Summary

- Anonymous users (no pubkey in AsyncStorage) were stuck on a loading spinner indefinitely in `RewardHistoryScreen`
- Added `else if (!cancelled) setIsLoading(false)` branch so the spinner clears when no pubkey is found
- Added `.catch(() => { if (!cancelled) setIsLoading(false) })` to handle AsyncStorage errors gracefully

## How this addresses the issue

Finding H1 from #331: `isLoading` initialises `true`, but for anonymous users the `AsyncStorage.getItem` `.then()` returns `null`, the `if (value)` guard skips `setPubkey`, `useFocusEffect` exits early on `!pubkey`, and `setIsLoading(false)` is never reached. The fix adds the missing else-branch and catch-handler so the spinner resolves in both the no-pubkey and error cases.

## Verification

- [x] Typecheck passes (0 errors — clean baseline)
- [x] Diff under 100 lines (8 insertions, 3 deletions — 11 lines total)
- [x] Single concern (one bug, one file)
- [ ] Human review needed before merge

Closes #331

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-05-20
findings_count: 1
severity: critical=0 high=1 medium=0 low=0
self_score:
  specificity: 9
  actionability: 10
  signal_to_noise: 10
  false_positive_risk: 10
  coverage: 7
overall: 9.2
notes: Eligible issue pool was all audit/design/simplify sweep bundles; picked H1 from #331 as cleanest single-concern fix — a real bug with a verified 2-line root cause.
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_017jfYpQ4VdqZhHJw63LARfc)_