### PR TITLE
Refresh reward docs terminology

### DIFF
--- a/docs/ANTICHEAT_WEBSITE_SPEC.md
+++ b/docs/ANTICHEAT_WEBSITE_SPEC.md
@@ -21,7 +21,7 @@ Payment page for the Anti-Cheat Verification Service. Users arrive here after su
 How It Works
 -------------
 1. You've submitted a verification request through the RUNSTR app
-2. Pay the 5,000 sat verification fee below
+2. Pay the 5,000 reward verification fee below
 3. Our team manually investigates within 24-48 hours
 4. Results delivered via your chosen contact method (Nostr DM or email)
 
@@ -35,12 +35,12 @@ What We Check
 
 ### Pricing Box
 ```
-Verification Fee: 5,000 sats (~$2-3 USD)
+Verification Fee: 5,000 rewards (~$2-3 USD)
 
-[Lightning Invoice QR Code]
+[Payment Invoice QR Code]
 [Copy Invoice Button]
 
-Or pay via Lightning Address: anticheat@runstr.club
+Or pay via payment address: anticheat@runstr.club
 ```
 
 ### After Investigation Section
@@ -76,17 +76,17 @@ Important Information
 ### Footer
 - Link back to RUNSTR app
 - Contact: support@runstr.club
-- "Powered by Lightning Network"
+- "Powered by RUNSTR rewards"
 
 ---
 
 ## Technical Requirements
 
 ### Payment Integration
-- Generate Lightning invoice for 5,000 sats
+- Generate payment invoice for 5,000 rewards
 - Options:
   1. **Recommended**: Use existing Alby/NWC setup to generate invoices
-  2. Alternative: Static Lightning Address (anticheat@runstr.club)
+  2. Alternative: Static payment address (anticheat@runstr.club)
   3. Alternative: BTCPay Server invoice
 
 ### Design
@@ -101,16 +101,16 @@ Important Information
 
 ---
 
-## Example Lightning Address Setup
+## Example Payment Address Setup
 
 If using Alby:
-1. Create lightning address: `anticheat@getalby.com` or custom domain
+1. Create payment address: `anticheat@getalby.com` or custom domain
 2. Set up webhook to notify when payment received
 3. Include memo field showing it's for anti-cheat service
 
 ---
 
 ## Questions for Senior Dev
-- [ ] Which Lightning payment method to use? (Alby, BTCPay, static address)
+- [ ] Which payment method to use? (Alby, BTCPay, static address)
 - [ ] Should payments trigger automatic notification to admin?
 - [ ] Need any tracking between app request and website payment?

--- a/docs/REWARD_RULES.md
+++ b/docs/REWARD_RULES.md
@@ -4,7 +4,7 @@ Single source of truth for reward logic across the app, website, and backend.
 
 ## Daily Reward
 
-- **Amount:** 100 sats per qualifying workout
+- **Amount:** 100 rewards per qualifying workout
 - **Applies to:** All users (no tiers, no subscriptions)
 - **Daily limit:** 1 reward per user per day
 
@@ -26,7 +26,7 @@ No distance minimum. No duration minimum.
 
 ## Payout Destination
 
-Rewards are sent via LNURL to the user's lightning address. There is no destination picker — no charities, no projects, no AI credits, no splits.
+Rewards are sent through the configured payout address on the user profile. There is no destination picker — no charities, no projects, no AI credits, no splits.
 
 Address resolution priority:
 1. Stored address (from Settings) if set

--- a/docs/RUNSTR_REWARDS_OVERVIEW.md
+++ b/docs/RUNSTR_REWARDS_OVERVIEW.md
@@ -1,61 +1,70 @@
-# RUNSTR REWARDS - Bitcoin-Powered Fitness Teams
+# RUNSTR REWARDS - Reward-Powered Fitness Teams
 
 ## What RUNSTR REWARDS Allows Users To Do
 
-### Transform Fitness into a Bitcoin Economy
+### Transform Fitness into a Reward Economy
 
-**RUNSTR REWARDS transforms individual fitness routines into Bitcoin-powered team competitions through Nostr's decentralized protocol.** Users begin by authenticating with their Nostr private key (nsec), which instantly imports their existing profile and workout history while automatically creating a Lightning wallet that enables peer-to-peer Bitcoin transactions. The app presents a clean two-tab interface where users can browse and join fitness teams, view their personal workout history with beautiful social sharing cards, and participate in team-based competitions where every workout contributes to collective goals while earning real satoshi rewards. Upon login, every user becomes part of a Bitcoin circular economy where fitness achievements translate directly into value exchange through instant Lightning transactions.
+RUNSTR REWARDS turns individual fitness routines into team competitions where activity can earn sponsor-funded rewards. Users authenticate with their existing profile, join teams, view workout history, share achievement cards, and participate in challenges where workouts contribute to shared goals.
+
+The product keeps payment rails and protocol details behind user-facing language. Contributors should describe the user benefit as rewards, instant payouts, and team incentives rather than exposing implementation-specific terms in broad product docs.
 
 ### Captain-Led Communities with Direct Rewards
 
-**Team captains orchestrate thriving fitness communities with powerful management tools and direct Bitcoin reward capabilities.** The captain dashboard provides complete control over team operations - approving join requests, managing members, and most importantly, instantly zapping satoshis to reward outstanding performances or motivate struggling members. The revolutionary wizard system makes competition creation intuitive, allowing captains to set up everything from daily running challenges to month-long yoga streaks, with all competitions published to Nostr where team members can track progress in real-time. Through the integrated Lightning payment system, captains can tap the lightning bolt next to any member's name to send 21 sats instantly, or long-press to send custom amounts, creating immediate positive reinforcement for fitness achievements. This direct P2P payment system transforms captains from mere administrators into active motivators who can financially reward dedication, milestone achievements, and competition victories without any intermediary or platform fees.
+Team captains manage fitness communities with tools for approving join requests, organizing members, and rewarding strong participation. The captain dashboard and competition wizard support daily running challenges, monthly consistency events, and other activity-based contests.
 
-### Intelligent Competition Tracking with Bitcoin Prizes
+Reward actions should be presented as simple appreciation or prize payouts. Users do not need to understand the underlying payment stack to understand that effort can earn value.
 
-**The competition system combines intelligent workout tracking with seamless Bitcoin prize distribution.** When users complete workouts, they post them as kind 1301 Nostr events that automatically count toward active team competitions, with the app's scoring engine processing activities based on captain-defined parameters - tracking miles for running leagues, counting sessions for meditation challenges, or measuring consistency across any activity type. As leaderboards update live with each workout posted, the integrated Lightning infrastructure enables instant prize payouts where competition winners receive satoshis directly to their auto-created wallets. The system operates entirely peer-to-peer, with every team member able to zap encouragement to others, creating micro-economies where fitness effort is immediately rewarded with real value. The auto-receiving feature checks for incoming zaps every 30 seconds, ensuring users never miss a reward while maintaining the seamless experience of traditional fitness apps enhanced with Bitcoin's monetary incentives.
+### Intelligent Competition Tracking with Prize Payouts
+
+When users complete workouts, qualifying activity automatically contributes to active team competitions. The scoring engine processes activities based on captain-defined rules such as distance, sessions, consistency, or event-specific criteria.
+
+As leaderboards update, winners and active participants can receive reward payouts. The system is designed to make incentives feel immediate while keeping payment implementation details out of contributor-facing overview docs.
 
 ### Social Recognition Meets Monetary Support
 
-**Social sharing and monetary support merge to create a unique fitness motivation ecosystem.** The app generates Instagram-worthy achievement graphics featuring gradient backgrounds, activity icons, and motivational quotes, which users can share alongside their workout data to celebrate personal records and team contributions. Beyond visual recognition, any team member can tap the lightning bolt on another's profile to send instant satoshi support - whether congratulating someone on completing their first 5K, encouraging consistency during a difficult week, or celebrating a competition victory. This dual reward system of social recognition and monetary value creates unprecedented motivation where every workout potentially earns both praise and Bitcoin. The zap interface offers both quick 21-sat appreciation taps and custom amount long-presses for more significant rewards, making it effortless to build a culture of mutual support backed by real economic value.
+RUNSTR combines social recognition with financial encouragement. Users can share achievement graphics, celebrate personal records, and receive support from teammates. Small reward sends can acknowledge consistency, milestones, and competition wins without making the interface feel like a payment app first.
+
+This dual reward system creates motivation through both community recognition and economic value.
 
 ### Complete Decentralized Fitness Economy
 
-**The architecture delivers a complete decentralized fitness economy where Bitcoin flows as freely as encouragement.** All team data, workout records, and competition parameters exist as Nostr events across multiple relays, while the Lightning wallet infrastructure handles Bitcoin transactions that provide instant, private transfers between team members. The wallet service automatically creates wallets for new users, manages payment connections, and maintains transaction histories, all while keeping the complexity invisible to users who simply see lightning bolts they can tap to send value. Future monetization features will enable captains to create exclusive paid leagues and premium events, transforming successful team leaders into fitness entrepreneurs who can monetize their coaching expertise and community-building skills. This creates a sustainable ecosystem where fitness teams become self-contained Bitcoin circular economies - members pay to join exclusive competitions, captains distribute prizes to winners, participants zap each other for motivation, and everyone benefits from a system where physical effort translates directly into economic rewards, all operating on the uncensorable, decentralized foundation of Nostr and Bitcoin.
+RUNSTR stores team, workout, and competition data through the app's decentralized identity and event model while using backend reward services for payouts. The wallet and payment services handle transaction details behind the scenes so users see a simple fitness-first experience.
+
+Future monetization features may let captains create paid leagues or premium events, turning successful team leaders into fitness entrepreneurs. The core vision remains the same: every workout can have value, every achievement can earn recognition, and every team can sustain its own incentive loop.
 
 ## Key Features
 
 ### For All Users
-- **Auto-Wallet Creation**: Lightning wallet created on login
-- **Instant Zaps**: Tap for 21 sats, long-press for custom amounts
-- **Workout Tracking**: HealthKit integration + Nostr event posting
-- **Beautiful Social Cards**: Instagram-worthy achievement graphics
-- **Team Discovery**: Browse and join fitness teams
-- **Competition Participation**: Automatic scoring from workout posts
+- Reward wallet setup handled by the app
+- Quick reward sends and custom reward amounts
+- Workout tracking and event posting
+- Beautiful social cards for achievements
+- Team discovery and membership
+- Competition participation with automatic scoring
 
 ### For Team Captains
-- **Captain Dashboard**: Complete team management interface
-- **Competition Wizards**: Intuitive 4-step competition creation
-- **Member Rewards**: Direct P2P Bitcoin payments to team members
-- **Join Request Management**: Approve/deny team membership
-- **Prize Distribution**: Instant satoshi payouts to winners
-- **Future: Paid Events**: Create exclusive monetized competitions
+- Captain dashboard for team management
+- Competition wizard for event creation
+- Member rewards for motivation and recognition
+- Join request management
+- Prize distribution for winners
+- Future paid events and premium competitions
 
 ### Technical Architecture
-- **Pure Nostr**: All data stored as Nostr events (no central database)
-- **Lightning Network**: Complete wallet implementation
-- **Bitcoin Integration**: Instant Bitcoin transactions
-- **Client-Side Processing**: Leaderboards calculated locally
-- **Multi-Relay Support**: Damus, Primal, nos.lol
-- **Offline Support**: AsyncStorage caching for performance
+- Decentralized identity and event model
+- Reward payment services abstracted behind app flows
+- Client-side leaderboard processing where appropriate
+- Multi-relay support for social and workout events
+- Offline-friendly local caching for performance
 
-### Bitcoin Circular Economy
-- **Entry Fees**: Captains can charge sats for exclusive competitions
-- **Prize Pools**: Automated distribution to competition winners
-- **Peer Support**: Members zap each other for motivation
-- **Achievement Rewards**: Instant payments for milestones
-- **No Platform Fees**: Direct P2P Lightning transactions
-- **Future Monetization**: Captains as fitness entrepreneurs
+### Reward Economy
+- Entry fees for exclusive competitions where enabled
+- Prize pools for competition winners
+- Peer support through direct reward sends
+- Achievement rewards for milestones
+- Low-friction payouts without exposing payment complexity
+- Future monetization for captains and teams
 
 ## The RUNSTR REWARDS Vision
 
-RUNSTR REWARDS is building the world's first decentralized fitness economy where every workout has value, every achievement earns recognition, and every team operates as a self-contained Bitcoin circular economy. By combining the social motivation of team fitness with the economic incentives of Bitcoin micropayments, we're creating a new paradigm where getting fit literally pays.
+RUNSTR REWARDS is building a decentralized fitness economy where every workout has value, every achievement earns recognition, and every team can operate a self-contained reward loop. By combining social motivation with economic incentives, RUNSTR creates a fitness experience where getting active can literally pay.


### PR DESCRIPTION
## Summary

Addresses the terminology drift called out in #306 for the reward-facing docs.

## Changes

- `docs/REWARD_RULES.md`
  - changes the daily amount from `sats` language to `rewards`
  - describes payout destination in product-facing terms while preserving the existing implementation notes
- `docs/ANTICHEAT_WEBSITE_SPEC.md`
  - changes verification fee and invoice copy to reward/payment-address language
  - removes Lightning-branded footer/spec wording from the user-facing page copy
- `docs/RUNSTR_REWARDS_OVERVIEW.md`
  - rewrites the overview around reward-first language
  - avoids exposing payment-rail specifics in the broad product overview
  - keeps the app value proposition focused on team incentives, prize payouts, and reward loops

## Validation

Docs-only change. I checked the touched docs for remaining `Bitcoin`, `sats`, `satoshi`, and user-facing `Lightning` terminology. The only remaining Lightning mention in these files is an implementation class name in `REWARD_RULES.md`.

BTC fallback address for bounty payout: `1BL4eV82zZ64Dp4cj3s9EgJ3ae8xPx5ZuJ`
