### PR TITLE
[Docs] Align navigation/data architecture docs with current app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,9 @@ Never use "cryptocurrency", "blockchain", or "decentralized" in user-facing cont
 
 ## Product Structure
 
-**Three-Tab Navigation:** Profile (workouts, history, settings) · Social (feed, Fitness Clubs) · Events (daily leaderboard, club events)
+**Three-Tab Navigation:** Home (workouts, history, settings) · Social (feed, Fitness Clubs) · History (reward transaction history)
 
-**Social Pillar:** Three surfaces — the Nostr feed (workout posts, zaps, likes, reposts), Fitness Clubs (captain-run groups with chat + events), and Events (daily leaderboard + club events). The pillar spans both the Social tab and the Events tab.
+**Social Pillar:** Two surfaces — the Nostr feed (workout posts, zaps, likes, reposts) and Fitness Clubs (captain-run groups with chat + events). Event discovery now lives inside Social/competition surfaces rather than a bottom Events tab.
 
 **Activities:** Cardio only — Run, Walk, Cycle, Hike with GPS tracking.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -81,15 +81,15 @@ App.tsx
                                 |    |
                                 |    +-- BottomTabNavigator
                                 |         |
-                                |         +-- Profile Tab (eager load)
+                                |         +-- Home Tab    (eager load)
                                 |         +-- Social Tab  (React.lazy)
-                                |         +-- Events Tab  (React.lazy)
+                                |         +-- History Tab (React.lazy; RewardHistoryScreen)
                                 |
                                 +-- Modal Screens (~21 reachable)
                                      |
                                      +-- Activity Tracking
                                      |    +-- ActivityTrackerScreen (SwipeGridNavigator
-                                     |    |     for cardio/strength/wellness/mindfulness)
+                                     |    |     for cardio only: Run/Walk/Cycle/Hike)
                                      |    +-- StepsDisplayScreen
                                      |    +-- ManualEntryScreen
                                      |
@@ -329,7 +329,7 @@ This is the most important data flow in the app.
    ProfileScreen -> "Start Workout" button
      |
      v
-   ActivityTrackerScreen (SwipeGridNavigator: cardio/strength/wellness/mindfulness)
+   ActivityTrackerScreen (SwipeGridNavigator: cardio only — Run/Walk/Cycle/Hike)
      |
      v
    SimpleRunTracker.startTracking() [for cardio]
@@ -587,8 +587,7 @@ Restore to local storage (workouts, habits, journal, preferences)
 // Core workout type (src/types/workout.ts)
 interface Workout {
   id: string;
-  type: 'running' | 'walking' | 'cycling' | 'hiking' |
-        'strength' | 'meditation' | 'diet' | 'other';
+  type: 'running' | 'walking' | 'cycling' | 'hiking';
   source: 'gps_tracker' | 'imported_healthkit' | 'imported_health_connect' |
           'imported_garmin' | 'manual_entry' | 'nostr';
   distance?: number;      // meters

--- a/docs/DATA_ARCHITECTURE_AND_CACHING_STRATEGY.md
+++ b/docs/DATA_ARCHITECTURE_AND_CACHING_STRATEGY.md
@@ -8,16 +8,16 @@
 
 ## Executive Summary
 
-**App Type**: Decentralized fitness social app powered by Nostr protocol
-**Data Sources**: 100% Nostr relays (no traditional backend/database)
+**App Type**: Fitness social app with Nostr identity/social data and Supabase-backed workouts, teams, events, leaderboards, and rewards
+**Data Sources**: Hybrid: Nostr relays for identity/social events; Supabase for workout submissions, user-created teams, dynamic competitions, leaderboards, and reward/payment state
 **Screens**: 32 screens total
 **Active Relays**: 3 relays (Damus, nos.lol, Nostr.band)
-**Current Cache**: Custom UnifiedNostrCache with AsyncStorage persistence
+**Current Cache**: UnifiedNostrCache/AsyncStorage for relay data plus service-level Supabase caches for teams, competitions, leaderboards, and reward summaries
 
 **Key Challenges**:
-- All data fetched via WebSocket subscriptions from distributed relays
-- No centralized server to invalidate caches or push updates
-- Relay response times vary (200ms-5s depending on query complexity)
+- Nostr identity/social data still depends on distributed relay subscriptions
+- Supabase-backed product surfaces need freshness rules separate from relay cache invalidation
+- Relay response times vary (200ms-5s depending on query complexity), while Supabase-backed leaderboards target faster reads
 - Mobile network constraints (battery, data usage, offline scenarios)
 
 ---

--- a/docs/USER_FLOW.md
+++ b/docs/USER_FLOW.md
@@ -21,22 +21,22 @@
 3. On success: nsec stored in SecureStore, npub + hex pubkey in AsyncStorage
 
 ### First-Time Setup
-1. **WelcomePermissionModal** appears after first entry
-2. Requests location permission (required for GPS workout tracking)
-3. On grant → navigates to Profile tab (home screen)
+1. After authentication, the app enters the main Home tab without the deleted WelcomePermissionModal flow
+2. Location permission is requested from workout/GPS surfaces when needed
+3. The Home tab is the default authenticated landing screen
 
 ### Session Persistence
 - On subsequent launches, app checks AsyncStorage for `@runstr:npub`
-- If found → skip login, go straight to Profile tab
+- If found → skip login, go straight to the Home tab
 - If not found → show LoginScreen with "Start" button
 
 ---
 
 ## 2. Three-Tab Navigation
 
-The app uses a bottom tab bar with three tabs. Profile is the default/home tab.
+The app uses a bottom tab bar with three tabs. Home is the default tab.
 
-### Profile Tab (Default)
+### Home Tab (Default)
 - **Profile card** at top: avatar, display name, npub, bio (tap → ProfileEditScreen)
 - **Three action buttons**:
   - **Start Workout** → ActivityTrackerScreen (GPS tracking)
@@ -50,16 +50,16 @@ The app uses a bottom tab bar with three tabs. Profile is the default/home tab.
 - **Clubs row**: Horizontal list of Fitness Clubs. Tap to browse, join, or view club pages.
 - **Tap a club** → ClubPageScreen (member leaderboard, chat, events)
 
-### Events Tab
-- **Daily Leaderboards**: 5K, 10K, Half Marathon, Marathon, Steps — always active
-- **Club Events**: Captain-created events; all club members auto-entered
+### History Tab
+- **Reward transaction history**: reward payment activity and historical reward state
+- Loaded lazily via RewardHistoryScreen
 
 ---
 
 ## 3. Workout Flow (GPS Tracking)
 
 ### Starting a Workout
-1. Tap **Start Workout** on Profile tab → ActivityTrackerScreen
+1. Tap **Start Workout** on the Home tab → ActivityTrackerScreen
 2. **SwipeGridNavigator** presents the four cardio activities (swipe to navigate):
 
 | Col 0 | Col 1 | Col 2 | Col 3 |

--- a/src/components/onboarding/README.md
+++ b/src/components/onboarding/README.md
@@ -4,26 +4,21 @@ Simplified onboarding components for new user experience.
 
 ## Files
 
-**WelcomePermissionModal.tsx** - Single welcome modal shown on first app launch with location permission request and app introduction
-
 **ProfileSetupStep.tsx** - (UNUSED) Optional profile customization component
 
 **WalletSetupStep.tsx** - (UNUSED) Optional wallet setup component
 
 ## Onboarding Flow
 
-The onboarding flow has been simplified to a single modal approach:
+The onboarding flow has been simplified and the former welcome-permission modal has been removed:
 
 1. **User clicks "Start" or "Login"** → Authentication happens
-2. **First launch only** → WelcomePermissionModal appears with:
-   - Brief app description
-   - Location permission request
-   - Single "Get Started" button
-3. **Main App** → User enters authenticated app immediately
+2. **Main App** → User enters authenticated app immediately
+3. Location permission is requested from workout/GPS flows when needed
 
 **Key Changes:**
 - No multi-step wizard
 - No splash screens
 - Password saved silently (accessible in Settings → Backup Password)
 - Background data loading (non-blocking)
-- Single modal shown only on first launch
+- No first-launch WelcomePermissionModal


### PR DESCRIPTION
## Summary
Follow-up docs staleness sweep for #352 to align key docs with current app structure.

## What this fixes
- Aligns tab/navigation wording with current implementation:
  - `Home · Social · History` (not Profile/Social/Events)
- Updates architecture tree to reflect lazy-loaded `History` tab and current Home naming.
- Removes stale activity-grid wording (`cardio/strength/wellness/mindfulness`) and documents cardio-only tracker flow.
- Corrects outdated “100% Nostr / no backend” claim to hybrid reality:
  - Nostr for identity/social events
  - Supabase for workouts, teams, competitions, leaderboards, rewards/payment state
- Removes stale onboarding reference to `WelcomePermissionModal` from onboarding docs.

## Files changed
- `CLAUDE.md`
- `docs/ARCHITECTURE.md`
- `docs/DATA_ARCHITECTURE_AND_CACHING_STRATEGY.md`
- `docs/USER_FLOW.md`
- `src/components/onboarding/README.md`

## Validation
- Markdown/docs consistency sweep done against current code paths:
  - `src/navigation/BottomTabNavigator.tsx`
  - Supabase usage across app services/components (`utils/supabase`, leaderboard/reward/team/event services)

If helpful, I can run one more pass for additional stale “Events tab” references in older planning docs as a separate PR.
