### PR TITLE
Fix reward notification deep-link routing

### DIFF
--- a/src/services/notifications/ExpoNotificationProvider.ts
+++ b/src/services/notifications/ExpoNotificationProvider.ts
@@ -195,7 +195,7 @@ export class ExpoNotificationProvider {
       switch (data?.type) {
         case 'reward_earned':
         case 'step_reward_earned':
-          navigate('MainTabs', { screen: 'Rewards' });
+          navigate('Rewards');
           break;
         case 'auto_joined':
         case 'leaderboard_change':


### PR DESCRIPTION
## Summary
Fixes RUNSTR issue #344 high-severity finding: reward notification taps attempted to route to a non-existent tab (`MainTabs` -> `Rewards`).

## Change
- Updated notification action routing for:
  - `reward_earned`
  - `step_reward_earned`
- from:
  - `navigate('MainTabs', { screen: 'Rewards' })`
- to:
  - `navigate('Rewards')`

## Why
`Rewards` is registered as a root stack screen, not a bottom-tab screen. The previous route silently no-op'd on notification taps.

## File
- `src/services/notifications/ExpoNotificationProvider.ts`

Closes #344
