### PR TITLE
Bound club member fetch in ClubMembershipService

### DIFF
--- a/src/services/backend/ClubMembershipService.ts
+++ b/src/services/backend/ClubMembershipService.ts
@@ -341,7 +341,8 @@ export class ClubMembershipService {
         .from('club_memberships')
         .select('*')
         .eq('club_id', clubId)
-        .order('joined_at', { ascending: true });
+        .order('joined_at', { ascending: true })
+        .limit(500);
 
       if (error) {
         console.error(`${TAG} getClubMembers error for ${clubId}:`, error);


### PR DESCRIPTION
## Summary
Addresses RUNSTR issue #346 critical finding: `getClubMembers()` fetched unbounded rows from `club_memberships`.

## Change
- Added `.limit(500)` to the `getClubMembers` Supabase query:
  - `src/services/backend/ClubMembershipService.ts`

## Why
Without a limit, large clubs can force huge client payloads and memory pressure on mobile. This puts a safe upper bound on per-request transfer while preserving current ordering/caching logic.

## Note
If maintainers prefer full pagination support, I can follow up with cursor/page params in a separate PR.

Closes #346
