### PR TITLE
Remove raw_event from leaderboard query

### DIFF
--- a/src/services/backend/SupabaseCompetitionService.ts
+++ b/src/services/backend/SupabaseCompetitionService.ts
@@ -674,7 +674,7 @@ export class SupabaseCompetitionService {
       // DATA QUALITY FIX: Use validNpubs (banned users filtered)
       let workoutQuery = supabase!
         .from('workout_submissions')
-        .select('npub, distance_meters, activity_type, created_at, duration_seconds, raw_event, event_id, time_5k_seconds, time_10k_seconds, time_half_seconds, time_marathon_seconds')
+        .select('npub, distance_meters, activity_type, created_at, duration_seconds, event_id, time_5k_seconds, time_10k_seconds, time_half_seconds, time_marathon_seconds')
         .in('npub', validNpubs)
         .gte('created_at', startDate)
         .lte('created_at', endDate);


### PR DESCRIPTION
## Summary
Addresses RUNSTR issue #346 high-severity finding: leaderboard query selects `raw_event` for up to 2,000 rows.

## Change
- Removed `raw_event` from the leaderboard workout select list in `SupabaseCompetitionService.ts`.
- All 9 scoring columns retained; only the unused display blob is dropped.

## Why
`raw_event` is the full JSON workout payload. It is not used for ranking or scoring; it was only fetched as a side effect of a broader select. Removing it roughly halves the leaderboard payload on mobile.

Closes #346
