### PR TITLE
Fix anonymous RewardHistoryScreen loading state

### DIFF
--- a/src/screens/RewardHistoryScreen.tsx
+++ b/src/screens/RewardHistoryScreen.tsx
@@ -149,9 +149,23 @@ export const RewardHistoryScreen: React.FC = () => {
   // Load pubkey once on mount
   useEffect(() => {
     let cancelled = false;
-    AsyncStorage.getItem('@runstr:hex_pubkey').then((value) => {
-      if (!cancelled && value) setPubkey(value);
-    });
+    AsyncStorage.getItem('@runstr:hex_pubkey')
+      .then((value) => {
+        if (cancelled) return;
+        if (value) {
+          setPubkey(value);
+        } else {
+          setPayments([]);
+          setIsLoading(false);
+        }
+      })
+      .catch((err) => {
+        console.warn('[RewardHistoryScreen] failed to load pubkey:', err);
+        if (!cancelled) {
+          setPayments([]);
+          setIsLoading(false);
+        }
+      });
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
## Summary
Fixes RUNSTR issue #331 high-severity finding: anonymous users can get stuck on a perpetual spinner in `RewardHistoryScreen`.

## Change
- Handles the `AsyncStorage.getItem('@runstr:hex_pubkey')` null path.
- Handles AsyncStorage errors with a `.catch()`.
- Clears payments and sets `isLoading(false)` when no pubkey is available or loading the pubkey fails.

## Why
`isLoading` starts as `true`. Previously, if `@runstr:hex_pubkey` was absent, `setPubkey` was skipped and `useFocusEffect` returned early, so `setIsLoading(false)` was never called.

## File
- `src/screens/RewardHistoryScreen.tsx`

Closes #331
