### PR TITLE
Guard RewardHistoryScreen date parsing

### DIFF
--- a/src/screens/RewardHistoryScreen.tsx
+++ b/src/screens/RewardHistoryScreen.tsx
@@ -62,12 +62,18 @@ const startOfCurrentMonth = (): number => {
   return d.getTime();
 };
 
+const parseValidDate = (iso?: string | null): Date | null => {
+  if (!iso) return null;
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
 const groupByDate = (payments: PaymentRecord[]): RewardSection[] => {
   const today = new Date();
   const sections = new Map<string, PaymentRecord[]>();
   for (const p of payments) {
-    const d = new Date(p.paid_at);
-    const key = formatDateHeader(d, today);
+    const d = parseValidDate(p.paid_at);
+    const key = d ? formatDateHeader(d, today) : 'UNKNOWN DATE';
     const arr = sections.get(key) ?? [];
     arr.push(p);
     sections.set(key, arr);
@@ -75,8 +81,9 @@ const groupByDate = (payments: PaymentRecord[]): RewardSection[] => {
   return Array.from(sections.entries()).map(([title, data]) => ({ title, data }));
 };
 
-const formatTime = (iso: string): string => {
-  const d = new Date(iso);
+const formatTime = (iso?: string | null): string => {
+  const d = parseValidDate(iso);
+  if (!d) return 'unknown time';
   let hours = d.getHours();
   const minutes = d.getMinutes().toString().padStart(2, '0');
   const ampm = hours >= 12 ? 'pm' : 'am';
@@ -201,7 +208,10 @@ export const RewardHistoryScreen: React.FC = () => {
   const monthlyTotal = useMemo(() => {
     const start = startOfCurrentMonth();
     return payments
-      .filter((p) => new Date(p.paid_at).getTime() >= start)
+      .filter((p) => {
+        const paidAt = parseValidDate(p.paid_at);
+        return paidAt ? paidAt.getTime() >= start : false;
+      })
       .reduce((sum, p) => sum + p.amount_sats, 0);
   }, [payments]);
 


### PR DESCRIPTION
## Summary
Fixes the #331 medium finding where `RewardHistoryScreen` passed unguarded `paid_at` values to `new Date()`.

## Changes
- Added `parseValidDate()` helper for nullable/invalid ISO values.
- `groupByDate()` now groups malformed/missing dates under `UNKNOWN DATE` instead of formatting `Invalid Date`.
- `formatTime()` now returns `unknown time` for missing/invalid timestamps.
- Monthly total calculation now ignores payments with invalid `paid_at` instead of comparing `NaN`.

## Why
Reward/payment data should not be able to produce invalid section labels or unstable date calculations if a backend row is malformed or missing `paid_at`.

## File
- `src/screens/RewardHistoryScreen.tsx`

Related to #331
