### PR TITLE
Use brand colors for saved route activity labels

### DIFF
--- a/src/screens/routes/SavedRoutesScreen.tsx
+++ b/src/screens/routes/SavedRoutesScreen.tsx
@@ -154,13 +154,13 @@ export const SavedRoutesScreen: React.FC = () => {
   const getActivityColor = (type: WorkoutType): string => {
     switch (type) {
       case 'running':
-        return '#FF6B00';
+        return theme.colors.accent;
       case 'walking':
-        return '#4ECDC4';
+        return theme.colors.orangeBright;
       case 'cycling':
-        return '#45B7D1';
+        return theme.colors.orangeDeep;
       case 'hiking':
-        return '#96CEB4';
+        return theme.colors.orangeBurnt;
       default:
         return theme.colors.accent;
     }


### PR DESCRIPTION
## Summary
Addresses the #348 design consistency finding for off-brand activity colors in `SavedRoutesScreen`.

## Change
- Replaced hardcoded teal/blue/mint activity colors with existing RUNSTR orange theme tokens:
  - running → `theme.colors.accent`
  - walking → `theme.colors.orangeBright`
  - cycling → `theme.colors.orangeDeep`
  - hiking → `theme.colors.orangeBurnt`

## Why
The previous walking/cycling/hiking route label colors came from a teal/blue/green palette that does not match the RUNSTR brand system. This keeps activity labels visually distinct while staying inside the orange brand palette.

## File
- `src/screens/routes/SavedRoutesScreen.tsx`

Related to #348
