### PR TITLE
Use brand colors for Nostr connection status

### DIFF
--- a/src/components/ui/NostrConnectionStatus.tsx
+++ b/src/components/ui/NostrConnectionStatus.tsx
@@ -54,9 +54,9 @@ export const NostrConnectionStatus: React.FC<NostrConnectionStatusProps> = ({
     const { connected, total, error } = connectionStatus;
 
     if (connected === 0) return theme.colors.textMuted; // No connections
-    if (error > 0) return '#FF6B00'; // Has errors
-    if (connected === total) return '#51cf66'; // All connected
-    return '#ffd43b'; // Partial connection
+    if (error > 0) return theme.colors.accent; // Has errors
+    if (connected === total) return theme.colors.accent; // All connected
+    return theme.colors.orangeBright; // Partial connection
   };
 
   const getStatusText = () => {
@@ -130,11 +130,11 @@ export const NostrConnectionStatus: React.FC<NostrConnectionStatusProps> = ({
   const getRelayStatusColor = (status: string) => {
     switch (status) {
       case 'connected':
-        return '#51cf66';
+        return theme.colors.accent;
       case 'connecting':
-        return '#ffd43b';
+        return theme.colors.orangeBright;
       case 'error':
-        return '#FF6B00';
+        return theme.colors.accent;
       case 'disconnected':
         return theme.colors.textMuted;
       default:


### PR DESCRIPTION
## Summary
Addresses the #348 design consistency finding for off-brand relay status colors in `NostrConnectionStatus`.

## Change
- Replaced hardcoded green/yellow status colors with RUNSTR orange theme tokens.
- Uses `theme.colors.accent` for connected/error emphasis and `theme.colors.orangeBright` for connecting/partial states.

## File
- `src/components/ui/NostrConnectionStatus.tsx`

Related to #348
