### PR TITLE
Guard unread chat count timestamp parsing

### DIFF
--- a/src/services/backend/ClubChatService.ts
+++ b/src/services/backend/ClubChatService.ts
@@ -423,7 +423,8 @@ export class ClubChatService {
       const cached = await ClubChatService.getCachedMessages(clubId);
       let count = 0;
       for (const msg of cached) {
-        const createdMs = new Date(msg.created_at).getTime();
+        const createdMs = msg.created_at ? new Date(msg.created_at).getTime() : 0;
+        if (!Number.isFinite(createdMs)) continue;
         if (createdMs > lastSeenMs) {
           count += 1;
           if (count > 99) return 100;


### PR DESCRIPTION
## Summary
Fixes the #331 low finding where `ClubChatService.getUnreadCount()` silently undercounted or behaved inconsistently when cached messages had missing/invalid `created_at` values.

## Change
- Guard `msg.created_at` before parsing.
- Skip invalid timestamps instead of comparing `NaN` against `lastSeenMs`.

## File
- `src/services/backend/ClubChatService.ts`

Related to #331
