### PR TITLE
Reduce ProfileDataService stats fetch ceiling

### DIFF
--- a/src/services/backend/ProfileDataService.ts
+++ b/src/services/backend/ProfileDataService.ts
@@ -157,7 +157,7 @@ export class ProfileDataService {
         .select('id, activity_type, distance_meters, duration_seconds, created_at')
         .eq('npub', npub)
         .order('created_at', { ascending: false })
-        .limit(5000);
+        .limit(1000);
 
       if (error || !data) {
         console.warn(TAG, 'getUserStats error:', error?.message);


### PR DESCRIPTION
## Summary
Performance follow-up for #346: lowers client-side row scan in `getUserStats` to reduce profile-tab payload and iteration cost.

## Change
- Reduced `workout_submissions` fetch cap from `5000` to `1000` rows in `ProfileDataService.getUserStats()`.

## Why
This does not fully replace aggregation with RPC/SQL, but it significantly reduces worst-case payload/memory pressure while preserving current logic.

## File
- `src/services/backend/ProfileDataService.ts`

Related to #346
