### PR TITLE
Stabilize dynamic event club info effect dependencies

### DIFF
--- a/src/screens/events/DynamicEventDetailScreen.tsx
+++ b/src/screens/events/DynamicEventDetailScreen.tsx
@@ -193,7 +193,7 @@ export const DynamicEventDetailScreen: React.FC<DynamicEventDetailScreenProps> =
       }
     };
     fetchClubInfo();
-  }, [competition]);
+  }, [competition?.club_id]);
 
   useEffect(() => {
     if (!isCharityEvent || !competition) return;


### PR DESCRIPTION
## Summary
Performance follow-up for #346: avoid re-running the club-info Supabase lookups when the `competition` object reference changes but the club id does not.

## Change
- Narrowed the club-info `useEffect` dependency from `[competition]` to `[competition?.club_id]`.

## Why
React compares object dependencies by reference. A refreshed competition object can re-fire the effect and repeat club/member lookups even when the target club is unchanged.

## File
- `src/screens/events/DynamicEventDetailScreen.tsx`

Related to #346
