### PR TITLE
Ignore GPS cache updates while paused

### DIFF
--- a/src/services/activity/SimpleRunTracker.ts
+++ b/src/services/activity/SimpleRunTracker.ts
@@ -737,6 +737,11 @@ export class SimpleRunTracker {
    * Timer → Pure JS stopwatch → Counts 1, 2, 3, 4, 5...
    */
   appendGpsPointsToCache(points: GPSPoint[]): void {
+    if (this.isPaused) {
+      console.log('[SimpleRunTracker] Ignoring GPS points while paused');
+      return;
+    }
+
     if (points.length === 0) {
       // No points received - check for GPS failure
       const now = Date.now();


### PR DESCRIPTION
## Summary
Fixes the #344 medium finding where GPS points could still be appended during the short async pause-state persistence window.

## Change
- Adds an in-memory `this.isPaused` guard at the start of `appendGpsPointsToCache()`.
- Incoming GPS point batches are ignored immediately after `pauseTracking()` sets the synchronous in-memory pause flag.

## Why
The background task reads pause state from AsyncStorage, which can lag behind the in-memory pause flag. Guarding the append path prevents phantom distance from being accumulated while the persisted pause state catches up.

## File
- `src/services/activity/SimpleRunTracker.ts`

Related to #344
