### PR TITLE
Replace user-facing sats copy in ExternalZapModal

### DIFF
--- a/src/components/nutzap/ExternalZapModal.tsx
+++ b/src/components/nutzap/ExternalZapModal.tsx
@@ -320,7 +320,7 @@ export const ExternalZapModal: React.FC<ExternalZapModalProps> = ({
         const amountValid = validateInvoiceAmount(invoiceResult.invoice, amount);
 
         if (!amountValid) {
-          const errorMsg = `Invoice amount mismatch! Expected ${amount} sats. Please try again.`;
+          const errorMsg = `Invoice amount mismatch! Expected ${amount} rewards. Please try again.`;
           console.error('[ExternalZapModal] ❌', errorMsg);
           throw new Error(errorMsg);
         }
@@ -339,7 +339,7 @@ export const ExternalZapModal: React.FC<ExternalZapModalProps> = ({
         console.log(
           '[ExternalZapModal] 🔄 Requesting invoice for',
           amount,
-          'sats'
+          'rewards'
         );
         console.log(
           '[ExternalZapModal] Memo:',
@@ -367,7 +367,7 @@ export const ExternalZapModal: React.FC<ExternalZapModalProps> = ({
           );
 
           if (!amountValid) {
-            const errorMsg = `Invoice amount mismatch! Expected ${amount} sats. Please try again.`;
+            const errorMsg = `Invoice amount mismatch! Expected ${amount} rewards. Please try again.`;
             console.error('[ExternalZapModal] ❌', errorMsg);
             throw new Error(errorMsg);
           }
@@ -475,7 +475,7 @@ export const ExternalZapModal: React.FC<ExternalZapModalProps> = ({
           charityName: recipientName,
         });
 
-        console.log('[ExternalZapModal] ✅ Charity donation recorded:', paidAmount, 'sats to', recipientName);
+        console.log('[ExternalZapModal] ✅ Charity donation recorded:', paidAmount, 'rewards to', recipientName);
       } catch (err) {
         console.error('[ExternalZapModal] Error recording donation:', err);
         // Don't block - donation was still made to charity
@@ -484,7 +484,7 @@ export const ExternalZapModal: React.FC<ExternalZapModalProps> = ({
 
     Alert.alert(
       'Zap Sent!',
-      `Successfully sent ${paidAmount} sats to ${recipientName}`,
+      `Successfully sent ${paidAmount} rewards to ${recipientName}`,
       [
         {
           text: 'OK',
@@ -531,7 +531,7 @@ export const ExternalZapModal: React.FC<ExternalZapModalProps> = ({
               <Text style={styles.recipientLabel}>Sending to:</Text>
               <Text style={styles.recipientName}>{recipientName}</Text>
               {showInvoice && (
-                <Text style={styles.amount}>{effectiveAmount} sats</Text>
+                <Text style={styles.amount}>{effectiveAmount} rewards</Text>
               )}
             </View>
 
@@ -571,7 +571,7 @@ export const ExternalZapModal: React.FC<ExternalZapModalProps> = ({
                             styles.presetButtonTextSelected,
                         ]}
                       >
-                        sats
+                        rewards
                       </Text>
                     </TouchableOpacity>
                   ))}
@@ -592,7 +592,7 @@ export const ExternalZapModal: React.FC<ExternalZapModalProps> = ({
                       value={customAmount}
                       onChangeText={handleCustomAmountChange}
                     />
-                    <Text style={styles.satsLabel}>sats</Text>
+                    <Text style={styles.satsLabel}>rewards</Text>
                   </View>
                 </View>
 
@@ -646,7 +646,7 @@ export const ExternalZapModal: React.FC<ExternalZapModalProps> = ({
                     {effectiveAmount > 0
                       ? effectiveAmount.toLocaleString()
                       : '0'}{' '}
-                    sats
+                    rewards
                   </Text>
                   <Ionicons
                     name="arrow-forward"


### PR DESCRIPTION
## Summary
Design/terminology follow-up for #348: replace user-facing `sats` wording in `ExternalZapModal` with `rewards` language.

## Change
- Updates rendered labels, alert/toast copy, and mismatch messages in `ExternalZapModal`.
- Keeps implementation details intact; this is user-facing terminology cleanup only.

## File
- `src/components/nutzap/ExternalZapModal.tsx`

Related to #348
