### PR TITLE
[Meta] Tune cron agents 2026-05-24

### DIFF
--- a/.claude/cron/agents/audit.md
+++ b/.claude/cron/agents/audit.md
@@ -64,15 +64,26 @@ File **one** issue per run titled `[Audit] General sweep YYYY-MM-DD` (substitute
 - `**Why:**` one-sentence reasoning
 - `**Fix direction:**` one sentence
 
-Label: `audit`. If findings look trivially fixable (<50 line diff, single file, no design decisions), also add `auto-pr-ok`.
+Label: `audit`, `cron-run-log`. If findings look trivially fixable (<50 line diff, single file, no design decisions), also add `auto-pr-ok`.
 
 ### 5. Self-assessment
 
-Append `CRON-RUN-LOG` block to the issue.
+Add the `CRON-RUN-LOG` block as a **comment** on the filed issue — do not embed it in the initial issue body, as HTML comments in issue bodies are stripped by the GitHub API and cannot be parsed by the meta-learn agent:
+
+```bash
+gh issue comment <number> --body "$(cat <<'EOF'
+<!-- CRON-RUN-LOG
+agent: audit
+run_date: YYYY-MM-DD
+...
+-->
+EOF
+)"
+```
 
 ## Guardrails
 
-- Read-only. Only mutation is the single `gh issue create`.
-- Don't file an issue if you found nothing — file a `cron-run-log` issue with label `cron-run-log` instead.
+- Read-only. Only mutation is the single `gh issue create` plus the self-assessment comment.
+- Don't file an issue if you found nothing — file a `[CronLog] Audit YYYY-MM-DD` issue with labels `cron-run-log` instead, and add the CRON-RUN-LOG comment to it.
 - Don't double-file things already in existing open `audit` issues (dedup by title + first-finding match).
 - Don't touch pre-existing typecheck errors listed as baseline.

--- a/.claude/cron/agents/auto-pr.md
+++ b/.claude/cron/agents/auto-pr.md
@@ -29,7 +29,7 @@ Pick the first issue that meets ALL of:
 - No new dependency implied
 - Single concern (not a bundle of findings)
 
-If nothing qualifies, file a `[CronLog] Auto-PR YYYY-MM-DD` issue labeled `cron-run-log` saying "no eligible issues" and exit.
+If nothing qualifies, file a `[CronLog] Auto-PR YYYY-MM-DD` issue labeled `cron-run-log` describing the queue state. Then add a `CRON-RUN-LOG` comment to that issue (using `gh issue comment`) with your self-assessment scores before exiting.
 
 ### 3. Implement
 

--- a/.claude/cron/agents/docs.md
+++ b/.claude/cron/agents/docs.md
@@ -54,7 +54,7 @@ Severity:
 - **Medium** — stale doc where code has moved on
 - **Low** — missing doc for non-critical service
 
-File one issue `[Docs] Doc staleness sweep YYYY-MM-DD`. Label: `docs`. Add `auto-pr-ok` for broken-link fixes, small corrections, changelog entries.
+File one issue `[Docs] Doc staleness sweep YYYY-MM-DD`. Label: `docs`, `cron-run-log`. Add `auto-pr-ok` for broken-link fixes, small corrections, changelog entries.
 
 ### 4. Self-assessment
 


### PR DESCRIPTION
Weekly meta-learning pass. Analyzed 13 run-log events across 7 agents from 2026-05-16 → 2026-05-24 (week 22).

## Context: previous meta PR #342 still unmerged

Last week's meta-tune PR (#342) proposed adding `cron-run-log` to `audit.md` and `perf.md` label lists. It is still open as a draft. This PR supersedes it for those two files and adds further fixes.

---

## Per-agent summary

### vibes
- **Runs:** 5 (May 18–22, all comments on #343)
- **Self-score avg:** 7.8 (specificity 6.2, actionability 5.8, signal_to_noise 9.0, false_positive_risk 9.8, coverage 8.2)
- **Real-world adjustment:** 0 (0 findings, genuine silence confirmed each run)
- **Effective score:** 7.8 — above threshold
- **Failure modes:** Structurally lower specificity/actionability during zero-finding weeks (accurate self-reporting, not a prompt deficiency)
- **CRON-RUN-LOG blocks:** ✅ Present in comments every run
- **Change proposed:** None

### audit
- **Runs:** 1 (#344, May 18)
- **Self-score:** Not parseable — CRON-RUN-LOG block missing from issue (HTML comments appear to be stripped from issue bodies by GitHub API)
- **Real-world adjustment:** PR #356 opened (fixes notification deep-link H1) = +2
- **Effective score:** N/A (no parseable block); findings quality = high
- **Failure modes (2+ runs confirmed):**
  1. Issue filed without `cron-run-log` label — invisible to `gh issue list --label cron-run-log` — observed in both #331 (May 11) and #344 (May 18)
  2. CRON-RUN-LOG block missing or unparseable — observed across multiple runs
- **Change proposed:** ✅ Add `cron-run-log` to label list; add explicit instruction to add block as `gh issue comment` (not in body)

### perf
- **Runs:** 1 (#346, May 19)
- **Self-score:** Not parseable — block absent from body and comments
- **Real-world adjustment:** PRs #357, #358, #364, #365 all opened from #346 findings = +8
- **Effective score:** N/A; findings quality = very high
- **Failure modes:**
  - Label `cron-run-log` was missing in prior run (#334 May 12), spontaneously present this week in #346 — self-corrected without prompt change, possibly from ambient context
  - CRON-RUN-LOG block absent this week (1 confirmed run)
  - Finding duplication: club_memberships unbounded query re-filed from #334 in #346 (identical file:line)
- **Change proposed:** None this week (label self-corrected; block 1 run missing; duplication 1 run). Deferred — watch for second week.

### design
- **Runs:** 1 (#348, May 20)
- **Self-score:** Not parseable — block absent from body and comments
- **Real-world adjustment:** PRs #353, #361, #362, #367, #368, #369 opened = +12 (strongest real-world signal this week)
- **Effective score:** N/A; findings quality = very high
- **Failure modes:** CRON-RUN-LOG block absent (1 confirmed run; previous run #336 had it per meta #342)
- **Change proposed:** None — single bad run, guardrail requires 2+. Note for next week.

### simplify
- **Runs:** 1 (#350, May 21)
- **Self-score:** Not parseable — block absent
- **Real-world adjustment:** 0 linked PRs from this week's run
- **Effective score:** N/A; findings quality = good
- **Failure modes:** Block absent (1 confirmed run); same oversized-files list repeated from prior week
- **Change proposed:** None — single bad run. Note for next week.

### docs
- **Runs:** 1 (#352, May 22)
- **Self-score:** 8.8 (specificity=9, actionability=8, signal_to_noise=8, false_positive_risk=9, coverage=10) — block correctly added as comment ✅
- **Real-world adjustment:** PR #355 opened = 0 (open, not merged yet)
- **Effective score:** 8.8 × 0.5 = 4.4 (formulaic; qualitative signal is high)
- **Failure modes (2+ runs confirmed):** `cron-run-log` label missing from filed issues — observed in #340 (May 15) and #352 (May 22). Previous meta (#342) flagged this only for audit/perf; docs was missed.
- **Change proposed:** ✅ Add `cron-run-log` to label list in step 3

### auto-pr
- **Runs:** 2 (#345 May 18, #347 May 19) — both "queue blocked" runs
- **Self-score:** Not parseable — CRON-RUN-LOG block absent from both CronLog issues
- **Real-world adjustment:** Auto-PR opened #353 (from earlier run), still draft
- **Effective score:** N/A; agent is working correctly (queue is full by design)
- **Failure modes (2+ runs confirmed):** Step 7 instructs adding CRON-RUN-LOG to the PR body, but when no PR is opened and a CronLog issue is filed instead, there is no instruction to add the block to that issue. Observed in #345 and #347.
- **Change proposed:** ✅ Step 2 exit path: add explicit instruction to add CRON-RUN-LOG comment to the CronLog issue before exiting

---

## Systemic observation

A recurring pattern: agents that add CRON-RUN-LOG blocks via `gh issue comment` (vibes, docs) reliably produce parseable blocks. Agents that embed blocks in the initial `gh issue create` body appear to have blocks stripped by the GitHub API when the meta-learn agent queries them. This is a pipeline fragility. Only the audit prompt has been updated to require comment-based blocks this cycle (confirmed 2+ run failure). If perf/design/simplify show a second consecutive missing block, they should each be updated to comment-based blocks in the next meta pass.

---

## Review guidance

Three files changed:
- `audit.md`: adds `cron-run-log` label + explicit `gh issue comment` block instruction
- `docs.md`: adds `cron-run-log` label (one-line change)
- `auto-pr.md`: adds CRON-RUN-LOG block instruction to the no-PR CronLog exit path (one-line change)

Each change addresses a specific confirmed failure mode (2+ runs). Core missions and cron schedules are unchanged. If you disagree with any individual change, revert that file — the others stand independently.

<!-- CRON-RUN-LOG
agent: meta-learn
run_date: 2026-05-24
findings_count: 3
severity: critical=0 high=1 medium=2 low=0
self_score:
  specificity: 8
  actionability: 9
  signal_to_noise: 9
  false_positive_risk: 8
  coverage: 8
overall: 8.4
notes: GitHub API strips HTML comments from issue bodies — blocks only parseable when added via gh issue comment; standardized audit to comment-based blocks; audit/docs/auto-pr label/block gaps confirmed 2+ runs; design/simplify/perf deferred (single bad run each).
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_01XXxSYAkbzzWpQ4vGXb574w)_