### PR TITLE
Auto-PR: Replace "sats" with "rewards" in RewardEarnedModal

### DIFF
--- a/src/components/rewards/RewardEarnedModal.tsx
+++ b/src/components/rewards/RewardEarnedModal.tsx
@@ -69,7 +69,7 @@ export const RewardEarnedModal: React.FC<RewardEarnedModalProps> = ({
             {pledgeInfo.isComplete ? 'Commitment Complete!' : 'Daily Reward Committed'}
           </Text>
           <Text style={styles.message}>
-            {amount} sats sent to {pledgeInfo.recipientName}
+            {amount} rewards sent to {pledgeInfo.recipientName}
           </Text>
           <Text style={styles.eventName}>{pledgeInfo.eventName}</Text>
           <View style={styles.progressRow}>
@@ -88,18 +88,18 @@ export const RewardEarnedModal: React.FC<RewardEarnedModalProps> = ({
       return (
         <>
           <Text style={styles.title}>Reward Queued</Text>
-          <Text style={styles.message}>{amount} sats queued for payout!</Text>
+          <Text style={styles.message}>{amount} rewards queued for payout!</Text>
           <View style={styles.splitContainer}>
             <View style={styles.splitRow}>
               <Text style={styles.splitLine}>{'├─'}</Text>
               <Text style={styles.splitText}>
-                {donationSplit.userAmount} sats to your wallet
+                {donationSplit.userAmount} rewards to your wallet
               </Text>
             </View>
             <View style={styles.splitRow}>
               <Text style={styles.splitLine}>{'└─'}</Text>
               <Text style={styles.splitText}>
-                {donationSplit.charityAmount} sats to {donationSplit.charityName}
+                {donationSplit.charityAmount} rewards to {donationSplit.charityName}
               </Text>
             </View>
           </View>
@@ -112,7 +112,7 @@ export const RewardEarnedModal: React.FC<RewardEarnedModalProps> = ({
     return (
       <>
         <Text style={styles.title}>Reward Queued</Text>
-        <Text style={styles.message}>{amount} sats queued for payout!</Text>
+        <Text style={styles.message}>{amount} rewards queued for payout!</Text>
         <Text style={styles.deliveryInfo}>Rewards sent daily ~10pm EST</Text>
       </>
     );


### PR DESCRIPTION
Automated draft PR addressing #376 (Finding C1 — Critical).

## Summary
- Replace all 5 user-visible `sats` strings in `src/components/rewards/RewardEarnedModal.tsx` with `rewards`
- Covers: pledge reward path (line 72), charity-split path (lines 91, 96, 102), and no-split path (line 115)
- Zero logic changes — string-only substitution

## How this addresses the issue
Issue #376 Finding C1 flags "sats" appearing in the primary reward confirmation modal — the single most prominent moment in the reward UX. This PR eliminates all 5 occurrences in the file, including one (line 72) not explicitly called out in the issue but present in the pledge-reward branch.

## Verification
- [x] Typecheck passes (zero errors — clean output)
- [x] Diff under 100 lines (10 lines: 5 added + 5 removed)
- [x] Single concern (terminology fix in one file)
- [x] No new dependencies
- [ ] Human review needed before merge

Related to #376

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-05-27
findings_count: 1
severity: critical=1 high=0 medium=0 low=0
self_score:
  specificity: 10
  actionability: 10
  signal_to_noise: 10
  false_positive_risk: 10
  coverage: 7
overall: 9.4
notes: Issue #376 is a multi-finding bundle; picked C1 (highest priority, single file) per <100 line constraint — remaining findings left for future runs.
-->

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6TxA8C7xu3viWP3gAox8v)_