### PR TITLE
Auto-PR: Fix stale reward flow diagram in ARCHITECTURE.md

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -355,7 +355,6 @@ This is the most important data flow in the app.
      +-- Server validates: distance, duration, anti-cheat flags
      +-- Stored in Supabase workouts table
      +-- Leaderboard rankings update automatically
-     +-- Database trigger fires claim-reward Edge Function
 
    Kind 1301 event is created locally for tag structure and signing,
    but is NOT published to Nostr relays. Supabase is the single
@@ -364,12 +363,14 @@ This is the most important data flow in the app.
 4. REWARD AUTO-TRIGGERED
      |
      v
-   Database trigger on workout_submissions INSERT:
-     +-- Reads reward destination tag (user, charity, project, or service)
-     +-- Reads Lightning address from tags
-     +-- Calls claim-reward Edge Function
-     +-- Sends reward via LNURL to destination's address
+   runstr-zapper (external service, separate repo) polls Supabase:
+     +-- Detects new workout_submission rows
+     +-- Validates workout (distance, duration, anti-cheat flags)
+     +-- Reads user's lightning address (Nostr lud16 or Settings)
+     +-- Sends reward via LNURL to user's lightning address
      +-- Records payment in reward_payments table
+   App reads payment status via SupabaseRewardService (read-only).
+   The in-repo claim-reward Edge Function is vestigial for this path.
 
 5. BACKGROUND SYNC PATH (No App Interaction Required)
      |
@@ -380,7 +381,7 @@ This is the most important data flow in the app.
      +-- Fetch recent workouts from health platform
      +-- Auto-submit to Supabase
      +-- Auto-join matching competitions
-     +-- Reward auto-triggered via same database trigger
+     +-- Reward auto-triggered via runstr-zapper polling
 
 6. OPTIONAL: SHARE AS SOCIAL POST
      |


### PR DESCRIPTION
Automated draft PR addressing #380 (Findings H1 and H2).

## Summary
- Remove stale `+-- Database trigger fires claim-reward Edge Function` bullet from the workout-submit flow (section 3)
- Replace the section 4 "REWARD AUTO-TRIGGERED" block — the old description showed DB trigger → claim-reward Edge Function with destination-picker routing; the correct model is runstr-zapper (external service) polling Supabase and sending to the user's lightning address
- Update section 5 background-sync path: replace "Reward auto-triggered via same database trigger" with "Reward auto-triggered via runstr-zapper polling"

## How this addresses the issue
H1 and H2 in #380 both point at `docs/ARCHITECTURE.md` lines 355–372: the reward flow diagram described the vestigial in-repo `claim-reward` Edge Function as the live payment sender, and referenced a destination picker (`user, charity, project, or service`) that was removed in v1.9.4. A new contributor reading that section would build the wrong mental model. This PR replaces the stale block with the actual flow: runstr-zapper (external service, separate repo) polls `workout_submissions`, validates, sends LNURL payment to the user's lightning address, and records the result in `reward_payments`. The app only reads payment status via `SupabaseRewardService`.

H3 (CLAUDE.md + USER_FLOW.md tab navigation) is left for a separate PR — PR #355 is already in progress on that surface.

## Verification
- [x] Typecheck passes (only the 2 pre-existing `tsconfig.json` errors, no regressions)
- [x] Diff under 100 lines (8 insertions + 7 deletions = 15 lines)
- [x] Single concern (reward flow docs correction in one file)
- [ ] Human review needed before merge

Closes #380

---

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-05-29
findings_count: 2
severity: critical=0 high=2 medium=0 low=0
self_score:
  specificity: 9
  actionability: 9
  signal_to_noise: 8
  false_positive_risk: 9
  coverage: 8
overall: 8.6
notes: All 14 auto-pr-ok issues scanned; #376 and #348 had open PRs already; #380 (today's docs sweep) was the only uncontested eligible issue — H1+H2 addressed in one file, H3 deferred to open PR #355.
-->