### PR TITLE
Auto-PR: Replace nsec/sats with password/rewards in Help screen

### DIFF
--- a/src/screens/HelpSupportScreen.tsx
+++ b/src/screens/HelpSupportScreen.tsx
@@ -69,9 +69,9 @@ export const HelpSupportScreen: React.FC<{ navigation: any }> = ({
       title: 'Getting Started',
       content: `Welcome to RUNSTR! Here's how to get started:
 
-• Nostr Login: Use your nsec (private key) to sign in. Your nsec starts with "nsec1" and should be kept private.
+• Sign in with your password. Your password starts with "nsec1" and should be kept private.
 • Profile Import: Your profile and workout history automatically import from Nostr events.
-• Understanding Keys: Your npub (public key) is like your username - safe to share. Your nsec is your password - never share it!
+• Your public key is like your username — safe to share. Your password is private — never share it!
 • First Steps: Join a team from the Teams tab to start competing and earning Bitcoin.`,
     },
     {
@@ -100,13 +100,13 @@ export const HelpSupportScreen: React.FC<{ navigation: any }> = ({
     },
     {
       id: 'rewards',
-      title: 'Sats & Rewards',
-      content: `Earn sats through fitness:
+      title: 'Rewards',
+      content: `Earn rewards through fitness:
 
 • NutZap Wallet: Your built-in Lightning wallet for instant transactions.
-• Prize Pools: Competition winners receive automatic sats distributions.
-• Entry Fees: Some competitions require small satoshi entry fees.
-• Sending/Receiving: Use the wallet buttons in your Profile to send or receive sats.
+• Prize Pools: Competition winners receive automatic reward distributions.
+• Entry Fees: Some competitions require small entry fees.
+• Sending/Receiving: Use the wallet buttons in your Profile to send or receive rewards.
 • Balance: Your current balance shows in the Profile wallet section.
 • Withdrawals: Transfer to external Lightning wallets anytime.`,
     },
@@ -140,7 +140,7 @@ export const HelpSupportScreen: React.FC<{ navigation: any }> = ({
       title: 'Troubleshooting',
       content: `Common issues and solutions:
 
-• Login Issues: Ensure your nsec starts with "nsec1" and has no spaces.
+• Login Issues: Ensure your password starts with "nsec1" and has no spaces.
 • Team Not Loading: Pull down to refresh in the Teams tab.
 • Workout Not Syncing: Check Profile > Workouts and tap sync button.
 • Can't Join Team: Ensure you're not already in another team.


### PR DESCRIPTION
Automated draft PR addressing #387 (findings C1 and H1).

## Summary
- Replace all user-visible `nsec` references in `HelpSupportScreen.tsx` with `password` (C1: lines 72, 74, 143)
- Replace all user-visible `sats`/`satoshi` references with `rewards` and update section title from `Sats & Rewards` to `Rewards` (H1: lines 103, 104, 107, 108, 109)
- Single file changed: `src/screens/HelpSupportScreen.tsx`

## How this addresses the issue
Finding C1 identified three user-facing `nsec` strings in the Getting Started and Troubleshooting sections — violating the CLAUDE.md rule that users see "password" not "nsec". Finding H1 identified the "Sats & Rewards" section title and body using "sats"/"satoshi" directly — violating the "rewards" terminology policy. Both findings are in the same file, and all fixes are pure string replacements with no logic changes.

## Verification
- [x] Typecheck passes (no errors vs baseline — `tsc --noEmit` exits clean)
- [x] Diff under 100 lines (8 insertions + 8 deletions, single file)
- [x] Single concern (terminology compliance in HelpSupportScreen)
- [ ] Human review needed before merge

Closes #387

---

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-06-03
findings_count: 1
severity: critical=1 high=1 medium=0 low=0
self_score:
  specificity: 9
  actionability: 10
  signal_to_noise: 10
  false_positive_risk: 10
  coverage: 8
overall: 9.4
notes: Picked C1+H1 from #387 (same file, pure string replacements); #383 and #380 already had open draft PRs so were skipped; M1 in #387 flagged as possibly dead code so excluded.
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_01AuogMphaKATidgcRJ64Nxo)_