### PR TITLE
Auto-PR: Fix orphaned subscriptions in ExpoNotificationProvider.cleanup()

### DIFF
--- a/src/services/notifications/ExpoNotificationProvider.ts
+++ b/src/services/notifications/ExpoNotificationProvider.ts
@@ -15,6 +15,9 @@ export class ExpoNotificationProvider {
   private static instance: ExpoNotificationProvider;
   private deviceToken: string | null = null;
   private isInitialized = false;
+  private appStateSubscription: { remove: () => void } | null = null;
+  private notifReceivedSub: { remove: () => void } | null = null;
+  private notifResponseSub: { remove: () => void } | null = null;
 
   private constructor() {}
 
@@ -52,7 +55,7 @@ export class ExpoNotificationProvider {
     this.setupNotificationListeners();
 
     // Clear badge when app comes to foreground
-    AppState.addEventListener('change', (state: AppStateStatus) => {
+    this.appStateSubscription = AppState.addEventListener('change', (state: AppStateStatus) => {
       if (state === 'active') {
         Notifications.setBadgeCountAsync(0).catch(() => {});
       }
@@ -160,7 +163,7 @@ export class ExpoNotificationProvider {
   // Setup notification event listeners
   private setupNotificationListeners(): void {
     // Handle notification received while app is in foreground
-    Notifications.addNotificationReceivedListener((notification) => {
+    this.notifReceivedSub = Notifications.addNotificationReceivedListener((notification) => {
       console.log(
         'Notification received in foreground:',
         notification.request.content
@@ -169,7 +172,7 @@ export class ExpoNotificationProvider {
     });
 
     // Handle notification tap/interaction
-    Notifications.addNotificationResponseReceivedListener((response) => {
+    this.notifResponseSub = Notifications.addNotificationResponseReceivedListener((response) => {
       const { actionIdentifier, userText } = response;
       const notificationData = response.notification.request.content.data;
 
@@ -356,8 +359,12 @@ export class ExpoNotificationProvider {
 
   // Cleanup method
   cleanup(): void {
-    // Remove notification listeners (manually tracked)
-    // Note: expo-notifications doesn't have removeAllNotificationListeners in newer versions
+    this.appStateSubscription?.remove();
+    this.appStateSubscription = null;
+    this.notifReceivedSub?.remove();
+    this.notifReceivedSub = null;
+    this.notifResponseSub?.remove();
+    this.notifResponseSub = null;
     this.isInitialized = false;
     this.deviceToken = null;
   }


### PR DESCRIPTION
Automated draft PR addressing #394 (M1 + M2).

## Summary
- Add three private subscription fields (`appStateSubscription`, `notifReceivedSub`, `notifResponseSub`) to hold listener return values
- Capture the return value of `AppState.addEventListener` and both `Notifications.add*Listener` calls
- Call `.remove()` on all three in `cleanup()` so re-initialization doesn't stack duplicate listeners

## How this addresses the issue
Fixes M1 and M2 from the 2026-06-08 audit: `ExpoNotificationProvider.initialize()` was discarding the return values of `AppState.addEventListener` and both `Notifications.add*Listener` calls. `cleanup()` reset flags but never detached the listeners, so each logout→login cycle stacked another set. The badge-clear handler would fire N times per foreground transition after N reinitializations.

## Verification
- [x] Typecheck passes (0 errors, same as baseline)
- [x] Diff under 100 lines (19 lines total: 12 added, 5 removed, 2 comment lines removed)
- [x] Single concern (orphaned subscription cleanup in one file)
- [x] No new dependencies
- [ ] Human review needed before merge

Closes #394

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-06-08
findings_count: 1
severity: critical=0 high=0 medium=2 low=0
self_score:
  specificity: 9
  actionability: 9
  signal_to_noise: 9
  false_positive_risk: 9
  coverage: 7
overall: 8.6
notes: Picked M1+M2 from #394 as a coherent single-file fix; L1 and L2 left for separate PRs since they touch different files/concerns.
-->

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXMUTnezi5oAWmzc2iWThp)_