### PR TITLE
Auto-PR: Replace duplicate isValidLightningAddress with shared lnurl export

### DIFF
--- a/src/components/club/CaptainSettingsModal.tsx
+++ b/src/components/club/CaptainSettingsModal.tsx
@@ -20,6 +20,7 @@ import { nostrProfileService } from '../../services/nostr/NostrProfileService';
 import type { NostrProfile } from '../../services/nostr/NostrProfileService';
 import { Avatar } from '../ui/Avatar';
 import type { Club, ClubMembership } from '../../types/club';
+import { isValidLightningAddress } from '../../utils/lnurl';
 
 interface CaptainSettingsModalProps {
   visible: boolean;
@@ -29,10 +30,6 @@ interface CaptainSettingsModalProps {
   onClubUpdated?: () => void;
 }
 
-function isValidLightningAddress(addr: string): boolean {
-  if (!addr) return true;
-  return /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(addr);
-}
 
 export const CaptainSettingsModal: React.FC<CaptainSettingsModalProps> = ({
   visible, onClose, club, userNpub, onClubUpdated,

--- a/src/components/creation/SimpleTeamCreationModal.tsx
+++ b/src/components/creation/SimpleTeamCreationModal.tsx
@@ -26,6 +26,7 @@ import { isSupabaseConfigured } from '../../utils/supabase';
 import { callEdgeFunction } from '../../utils/edgeFunctions';
 import { ClubWalletService } from '../../services/club/ClubWalletService';
 import { pickBannerImage, uploadBannerImage } from '../../services/club/ClubBannerStorageService';
+import { isValidLightningAddress } from '../../utils/lnurl';
 
 interface SimpleTeamCreationModalProps {
   visible: boolean;
@@ -33,10 +34,6 @@ interface SimpleTeamCreationModalProps {
   onTeamCreated?: (teamId: string) => void;
 }
 
-function isValidLightningAddress(address: string): boolean {
-  if (!address) return true; // Optional field
-  return /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(address);
-}
 
 export const SimpleTeamCreationModal: React.FC<SimpleTeamCreationModalProps> = ({
   visible,
@@ -85,7 +82,7 @@ export const SimpleTeamCreationModal: React.FC<SimpleTeamCreationModalProps> = (
 
   const isValid =
     teamName.trim().length > 0 &&
-    isValidLightningAddress(lightningAddress);
+    (!lightningAddress.trim() || isValidLightningAddress(lightningAddress));
 
   const handleCreate = useCallback(async () => {
     if (isSubmittingRef.current) return; // Synchronous check prevents double-submit


### PR DESCRIPTION
Automated draft PR addressing #400 (finding #9).

## Summary
- Delete the local `isValidLightningAddress` function defined in `CaptainSettingsModal.tsx` and `SimpleTeamCreationModal.tsx`
- Import the shared `isValidLightningAddress` from `src/utils/lnurl.ts` in both files
- Fix the unguarded `isValid` expression in `SimpleTeamCreationModal` (`!lightningAddress.trim() || isValidLightningAddress(...)`) to preserve the optional-field semantics — the shared function returns `false` for empty string, but both local copies returned `true`, so the call site needed a guard

## How this addresses the issue
Implements finding #9 from the 2026-06-11 simplify sweep: two components defined identical local copies of `isValidLightningAddress` that never imported the already-exported version from `src/utils/lnurl.ts`. All call sites that passed non-empty strings were already behaviorally compatible with the shared function; only the unguarded `isValid` expression in `SimpleTeamCreationModal` required a small call-site fix to preserve the optional-field semantics.

## Verification
- [x] Typecheck passes (0 errors, same as baseline)
- [x] Diff under 100 lines (55 lines total: 3 added, 9 deleted)
- [x] Single concern (deduplication of one utility function across 2 files)
- [x] No new dependencies
- [ ] Human review needed before merge

Closes #400

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-06-12
findings_count: 1
severity: critical=0 high=0 medium=1 low=0
self_score:
  specificity: 9
  actionability: 9
  signal_to_noise: 9
  false_positive_risk: 9
  coverage: 8
overall: 8.8
notes: Issue #396/398 already had PRs; picked #400 finding #9; shared function had empty-string behavioral difference requiring one call-site fix that the issue description missed — verified by reading all usages before committing.
-->
