### PR TITLE
Auto-PR: Fix terminology in LightningAddressSetupModal ("sats" → "rewards", "Lightning wallet" → "wallet")

### DIFF
--- a/src/components/wallet/LightningAddressSetupModal.tsx
+++ b/src/components/wallet/LightningAddressSetupModal.tsx
@@ -157,7 +157,7 @@ export const LightningAddressSetupModal: React.FC<LightningAddressSetupModalProp
           ) : (
             <>
               <Text style={styles.description}>
-                Enter your Lightning address to receive workout rewards directly in sats.
+                Enter your lightning address to receive your workout rewards.
               </Text>
 
               {/* Lightning Address Input */}
@@ -196,7 +196,7 @@ export const LightningAddressSetupModal: React.FC<LightningAddressSetupModalProp
               <View style={styles.infoBox}>
                 <Ionicons name="information-circle-outline" size={18} color={theme.colors.textMuted} />
                 <Text style={styles.infoText}>
-                  Get a free Lightning address from Wallet of Satoshi, Strike, Alby, or any Lightning wallet.
+                  Get a free lightning address from Wallet of Satoshi, Strike, Alby, or any compatible wallet.
                 </Text>
               </View>
             </>


### PR DESCRIPTION
Automated draft PR addressing #410 (H1 + H2).

## Summary
- Line 160: Remove "in sats" from description — "...rewards directly in sats" → "...your workout rewards"
- Line 199: "Lightning wallet" → "wallet" in hint text ("...or any Lightning wallet" → "...or any compatible wallet")

## How this addresses the issue
Fixes both High findings from the 2026-06-17 design sweep: `LightningAddressSetupModal.tsx` used "in sats" (violates the "rewards" terminology rule) and "Lightning wallet" (should be "wallet" per CLAUDE.md terminology table) in user-visible strings on the reward destination setup screen.

## Verification
- [x] Typecheck passes (0 errors, same as baseline)
- [x] Diff under 100 lines (4 lines total: 2 added, 2 removed, 1 file)
- [x] Single concern (terminology fixes in one file)
- [x] No new dependencies
- [ ] Human review needed before merge

Closes #410

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-06-17
findings_count: 2
severity: critical=0 high=2 medium=0 low=0
self_score:
  specificity: 10
  actionability: 10
  signal_to_noise: 10
  false_positive_risk: 10
  coverage: 8
overall: 9.6
notes: All prior auto-pr-ok issues had linked PRs; #410 (filed same day) was the only fresh candidate — 2 clean string replacements in one file, typecheck clean.
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_016AUDj6ZaqJG3zia5qnwLkP)_