### PR TITLE
Auto-PR: Deduplicate formatDistanceKm into shared util

### DIFF
--- a/src/components/season2/CharityRankings.tsx
+++ b/src/components/season2/CharityRankings.tsx
@@ -15,6 +15,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { theme } from '../../styles/theme';
+import { formatDistanceKm } from '../../utils/distanceFormatter';
 import type { CharityRanking } from '../../types/season2';
 
 // Enable LayoutAnimation on Android
@@ -89,7 +90,7 @@ export const CharityRankings: React.FC<CharityRankingsProps> = ({
 
               {/* Distance - already in km from backend */}
               <Text style={styles.distanceText}>
-                {formatDistance(charity.totalDistance)}
+                {formatDistanceKm(charity.totalDistance)}
               </Text>
             </View>
           ))}
@@ -98,19 +99,6 @@ export const CharityRankings: React.FC<CharityRankingsProps> = ({
     </View>
   );
 };
-
-/**
- * Format distance in km for display
- */
-function formatDistance(km: number): string {
-  if (km >= 1000) {
-    return `${(km / 1000).toFixed(1)}k km`;
-  }
-  if (km >= 100) {
-    return `${km.toFixed(0)} km`;
-  }
-  return `${km.toFixed(1)} km`;
-}
 
 const styles = StyleSheet.create({
   container: {

--- a/src/components/season2/Season2Leaderboard.tsx
+++ b/src/components/season2/Season2Leaderboard.tsx
@@ -10,24 +10,12 @@ import React, { memo, useEffect, useRef, useState } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator, TouchableOpacity } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { theme } from '../../styles/theme';
+import { formatDistanceKm } from '../../utils/distanceFormatter';
 import { ZappableUserRow } from '../ui/ZappableUserRow';
 import { getSeason2Avatar } from '../../../assets/images/season2';
 import type { Season2Participant } from '../../types/season2';
 
 const BATCH_SIZE = 21; // Show 21 participants at a time
-
-/**
- * Format distance in km for display
- */
-function formatDistance(km: number): string {
-  if (km >= 1000) {
-    return `${(km / 1000).toFixed(1)}k km`;
-  }
-  if (km >= 100) {
-    return `${km.toFixed(0)} km`;
-  }
-  return `${km.toFixed(1)} km`;
-}
 
 /**
  * Format workout count with activity-specific label
@@ -58,7 +46,7 @@ interface LeaderboardRowProps {
 const LeaderboardRow = memo(
   ({ item, index, activityType }: LeaderboardRowProps) => {
     const rank = index + 1;
-    const formattedDistance = formatDistance(item.totalDistance);
+    const formattedDistance = formatDistanceKm(item.totalDistance);
     const bundledAvatar = getSeason2Avatar(item.pubkey);
 
     return (

--- a/src/utils/distanceFormatter.ts
+++ b/src/utils/distanceFormatter.ts
@@ -77,3 +77,13 @@ export const convertDistance = (
 export const getDistanceUnit = (unitSystem: UnitSystem = 'metric'): string => {
   return unitSystem === 'imperial' ? 'mi' : 'km';
 };
+
+/**
+ * Formats a distance value already in km for display (e.g. leaderboard totals).
+ * Use formatDistance() for raw meter values.
+ */
+export function formatDistanceKm(km: number): string {
+  if (km >= 1000) return `${(km / 1000).toFixed(1)}k km`;
+  if (km >= 100) return `${km.toFixed(0)} km`;
+  return `${km.toFixed(1)} km`;
+}


### PR DESCRIPTION
Automated draft PR addressing #400 (finding 8).

## Summary
- Add `formatDistanceKm(km: number): string` to `src/utils/distanceFormatter.ts` — the canonical shared implementation
- Remove the identical local `formatDistance(km)` from `CharityRankings.tsx` (was lines 102–113) and import the shared util
- Remove the identical local `formatDistance(km)` from `Season2Leaderboard.tsx` (was lines 19–30) and import the shared util

## How this addresses the issue
Fixes finding 8 from the 2026-06-11 simplify sweep (#400): `CharityRankings.tsx` and `Season2Leaderboard.tsx` both defined a byte-for-byte identical 3-branch km-formatting function. Neither imported the existing `distanceFormatter.ts` (which only handled meter inputs). This PR adds the km-based variant to the shared module and eliminates both duplicates, reducing the two components by 11 lines each.

## Verification
- [x] Typecheck passes (1 pre-existing error in SocialScreen.tsx — unchanged vs. baseline)
- [x] Diff under 100 lines (42 lines: 14 added, 28 removed, 3 files)
- [x] Single concern (utility deduplication — identical function extracted to shared module)
- [x] No new dependencies
- [ ] Human review needed before merge

Partially addresses #400

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-06-22
findings_count: 1
severity: critical=0 high=0 medium=1 low=0
self_score:
  specificity: 10
  actionability: 10
  signal_to_noise: 9
  false_positive_risk: 10
  coverage: 6
overall: 9.0
notes: All 14-day auto-pr-ok issues already had prior PR attempts; picked finding 8 from #400 as the cleanest unaddressed auto-pr-ok candidate — two byte-for-byte identical km-formatters extracted to a shared util; coverage capped at 6 because the primary eligible findings were already addressed by earlier runs.
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_012CCFP7WLHsq7bXPM93CNAi)_