### PR TITLE
Auto-PR: Remove duplicate isValidLightningAddress, import from lnurl

### DIFF
--- a/src/components/club/CaptainSettingsModal.tsx
+++ b/src/components/club/CaptainSettingsModal.tsx
@@ -20,6 +20,7 @@ import { nostrProfileService } from '../../services/nostr/NostrProfileService';
 import type { NostrProfile } from '../../services/nostr/NostrProfileService';
 import { Avatar } from '../ui/Avatar';
 import type { Club, ClubMembership } from '../../types/club';
+import { isValidLightningAddress } from '../../utils/lnurl';
 
 interface CaptainSettingsModalProps {
   visible: boolean;
@@ -29,10 +30,6 @@ interface CaptainSettingsModalProps {
   onClubUpdated?: () => void;
 }
 
-function isValidLightningAddress(addr: string): boolean {
-  if (!addr) return true;
-  return /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(addr);
-}
 
 export const CaptainSettingsModal: React.FC<CaptainSettingsModalProps> = ({
   visible, onClose, club, userNpub, onClubUpdated,

--- a/src/components/creation/SimpleTeamCreationModal.tsx
+++ b/src/components/creation/SimpleTeamCreationModal.tsx
@@ -26,6 +26,7 @@ import { isSupabaseConfigured } from '../../utils/supabase';
 import { callEdgeFunction } from '../../utils/edgeFunctions';
 import { ClubWalletService } from '../../services/club/ClubWalletService';
 import { pickBannerImage, uploadBannerImage } from '../../services/club/ClubBannerStorageService';
+import { isValidLightningAddress } from '../../utils/lnurl';
 
 interface SimpleTeamCreationModalProps {
   visible: boolean;
@@ -33,10 +34,6 @@ interface SimpleTeamCreationModalProps {
   onTeamCreated?: (teamId: string) => void;
 }
 
-function isValidLightningAddress(address: string): boolean {
-  if (!address) return true; // Optional field
-  return /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(address);
-}
 
 export const SimpleTeamCreationModal: React.FC<SimpleTeamCreationModalProps> = ({
   visible,
@@ -85,7 +82,7 @@ export const SimpleTeamCreationModal: React.FC<SimpleTeamCreationModalProps> = (
 
   const isValid =
     teamName.trim().length > 0 &&
-    isValidLightningAddress(lightningAddress);
+    (!lightningAddress || isValidLightningAddress(lightningAddress));
 
   const handleCreate = useCallback(async () => {
     if (isSubmittingRef.current) return; // Synchronous check prevents double-submit


### PR DESCRIPTION
Automated draft PR addressing #424 (finding M1 — `isValidLightningAddress` duplicated in 2 components).

## Summary
- `CaptainSettingsModal.tsx`: removed local 4-line regex validator, added `import { isValidLightningAddress } from '../../utils/lnurl'`
- `SimpleTeamCreationModal.tsx`: same removal + import; preserved "empty = optional/valid" semantics at the one unguarded call site (`!lightningAddress || isValidLightningAddress(lightningAddress)`)
- All other call sites were already guarded with length checks, so behavior is identical

## How this addresses the issue
Issue #424 (finding M1) identified that both components copy-paste the same regex validator instead of importing the canonical `isValidLightningAddress` already exported at `src/utils/lnurl.ts:275`. This PR removes both copies and imports the shared utility, consolidating validation logic in one place.

## Verification
- [x] Typecheck passes (0 errors, clean `tsc --noEmit`)
- [x] Diff under 100 lines (3 insertions, 9 deletions across 2 files)
- [x] Single concern (deduplication of `isValidLightningAddress`)
- [x] No new dependencies
- [x] Empty-string behavior preserved at unguarded call site in `SimpleTeamCreationModal`
- [ ] Human review needed before merge

Closes #424

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-06-25
findings_count: 1
severity: critical=0 high=0 medium=1 low=0
self_score:
  specificity: 10
  actionability: 10
  signal_to_noise: 9
  false_positive_risk: 10
  coverage: 8
overall: 9.4
notes: Picked the isValidLightningAddress deduplication (M1) from #424 — cleanest single-concern fix under 100 lines; verified empty-string call site needed wrapping to preserve optional-field semantics before swapping the import.
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_017NMhwwNAVrhGAfux3z3rXW)_