### PR TITLE
Auto-PR: Remove duplicate isValidLightningAddress validators, import from canonical lnurl.ts

### DIFF
--- a/src/components/club/CaptainSettingsModal.tsx
+++ b/src/components/club/CaptainSettingsModal.tsx
@@ -20,6 +20,7 @@ import { nostrProfileService } from '../../services/nostr/NostrProfileService';
 import type { NostrProfile } from '../../services/nostr/NostrProfileService';
 import { Avatar } from '../ui/Avatar';
 import type { Club, ClubMembership } from '../../types/club';
+import { isValidLightningAddress } from '../../utils/lnurl';
 
 interface CaptainSettingsModalProps {
   visible: boolean;
@@ -27,11 +28,6 @@ interface CaptainSettingsModalProps {
   club: Club;
   userNpub: string;
   onClubUpdated?: () => void;
-}
-
-function isValidLightningAddress(addr: string): boolean {
-  if (!addr) return true;
-  return /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(addr);
 }
 
 export const CaptainSettingsModal: React.FC<CaptainSettingsModalProps> = ({

--- a/src/components/creation/SimpleTeamCreationModal.tsx
+++ b/src/components/creation/SimpleTeamCreationModal.tsx
@@ -26,16 +26,12 @@ import { isSupabaseConfigured } from '../../utils/supabase';
 import { callEdgeFunction } from '../../utils/edgeFunctions';
 import { ClubWalletService } from '../../services/club/ClubWalletService';
 import { pickBannerImage, uploadBannerImage } from '../../services/club/ClubBannerStorageService';
+import { isValidLightningAddress } from '../../utils/lnurl';
 
 interface SimpleTeamCreationModalProps {
   visible: boolean;
   onClose: () => void;
   onTeamCreated?: (teamId: string) => void;
-}
-
-function isValidLightningAddress(address: string): boolean {
-  if (!address) return true; // Optional field
-  return /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(address);
 }
 
 export const SimpleTeamCreationModal: React.FC<SimpleTeamCreationModalProps> = ({
@@ -85,7 +81,7 @@ export const SimpleTeamCreationModal: React.FC<SimpleTeamCreationModalProps> = (
 
   const isValid =
     teamName.trim().length > 0 &&
-    isValidLightningAddress(lightningAddress);
+    (lightningAddress.length === 0 || isValidLightningAddress(lightningAddress));
 
   const handleCreate = useCallback(async () => {
     if (isSubmittingRef.current) return; // Synchronous check prevents double-submit


### PR DESCRIPTION
Automated draft PR addressing #424 (MEDIUM — `isValidLightningAddress` duplicated in 2 components).

## Summary
- `CaptainSettingsModal.tsx`: remove local 4-line regex validator, import `isValidLightningAddress` from `src/utils/lnurl.ts`
- `SimpleTeamCreationModal.tsx`: same removal + import; also update the `isValid` expression to preserve "optional field" behavior (`lightningAddress.length === 0 || isValidLightningAddress(...)`) since the canonical function returns `false` for empty strings whereas the local one returned `true`

## How this addresses the issue
Both components duplicated a simpler email-regex validator instead of using the canonical `isValidLightningAddress` exported from `src/utils/lnurl.ts:275`. This PR eliminates the duplication and points both files at the single source of truth. The one behavior difference (empty string handling) is handled explicitly at the call site in `SimpleTeamCreationModal` where lightning address is optional.

## Verification
- [x] Typecheck passes (0 errors — same as baseline)
- [x] Diff under 100 lines (14 lines: 3 added, 11 removed, 2 files)
- [x] Single concern (deduplicate isValidLightningAddress)
- [x] No new dependencies
- [ ] Human review needed before merge

Closes #424

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-06-29
findings_count: 1
severity: critical=0 high=0 medium=1 low=0
self_score:
  specificity: 9
  actionability: 10
  signal_to_noise: 9
  false_positive_risk: 9
  coverage: 7
overall: 8.8
notes: All issues within 14-day window were multi-finding sweeps; picked the explicit auto-pr-ok sub-finding from #424; caught empty-string behavior difference between local and canonical functions that issue body missed.
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_01EqtmZ7BHnNWx5mMwqLiEbK)_