### PR TITLE
Auto-PR: cap getCountsForEvents IN-clause queries to finite row limit

### DIFF
--- a/src/services/social/WorkoutInteractionService.ts
+++ b/src/services/social/WorkoutInteractionService.ts
@@ -54,10 +54,11 @@ export class WorkoutInteractionService {
     if (!isSupabaseConfigured()) return result;
 
     try {
+      const rowCap = eventIds.length * 500;
       const [likesRes, commentsRes, zapsRes] = await Promise.all([
-        supabase!.from('workout_likes').select('event_id, npub').in('event_id', eventIds),
-        supabase!.from('workout_comments').select('event_id').in('event_id', eventIds),
-        supabase!.from('workout_zaps').select('event_id, amount').in('event_id', eventIds),
+        supabase!.from('workout_likes').select('event_id, npub').in('event_id', eventIds).limit(rowCap),
+        supabase!.from('workout_comments').select('event_id').in('event_id', eventIds).limit(rowCap),
+        supabase!.from('workout_zaps').select('event_id, amount').in('event_id', eventIds).limit(rowCap),
       ]);
 
       if (likesRes.error) console.error('[WorkoutInteraction] likes fetch:', likesRes.error.message);


### PR DESCRIPTION
Automated draft PR addressing #431 (H2).

## Summary
- Added `rowCap = eventIds.length * 500` before the three parallel Supabase queries in `getCountsForEvents`
- Applied `.limit(rowCap)` to all three queries: `workout_likes`, `workout_comments`, `workout_zaps`
- Cap scales with page size (default 20 eventIds → 10,000 row cap per table) — generous-but-finite, prevents OOM on viral posts

## How this addresses the issue
Fixes H2 from the 2026-06-29 general audit: `WorkoutInteractionService.getCountsForEvents` fired three unbounded `.in()` queries per feed page load. A popular workout with 1,000+ likes could return tens of thousands of rows across all three tables into device memory on every scroll. The cap is `eventIds.length * 500` as recommended in the issue.

## Verification
- [x] Typecheck passes (0 errors, same as baseline)
- [x] Diff under 100 lines (7 lines: 4 added, 3 removed, 1 file)
- [x] Single concern (row limit on three sibling queries in one function)
- [x] No new dependencies
- [ ] Human review needed before merge

Closes #431

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-06-30
findings_count: 1
severity: critical=0 high=1 medium=0 low=0
self_score:
  specificity: 9
  actionability: 10
  signal_to_noise: 9
  false_positive_risk: 10
  coverage: 7
overall: 9.0
notes: H1 (isSending stuck) exceeded 100-line diff limit due to try/finally re-indentation; pivoted to H2 which was a clean 7-line change. H1 remains open for human implementation.
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_0121pLTc2bVdZ8yo3YDNvk5G)_