### PR TITLE
Auto-PR: replace "sats" with "rewards" in RewardEarnedModal

### DIFF
--- a/src/components/rewards/RewardEarnedModal.tsx
+++ b/src/components/rewards/RewardEarnedModal.tsx
@@ -88,18 +88,18 @@ export const RewardEarnedModal: React.FC<RewardEarnedModalProps> = ({
       return (
         <>
           <Text style={styles.title}>Reward Queued</Text>
-          <Text style={styles.message}>{amount} sats queued for payout!</Text>
+          <Text style={styles.message}>{amount} rewards queued for payout!</Text>
           <View style={styles.splitContainer}>
             <View style={styles.splitRow}>
               <Text style={styles.splitLine}>{'├─'}</Text>
               <Text style={styles.splitText}>
-                {donationSplit.userAmount} sats to your wallet
+                {donationSplit.userAmount} to your wallet
               </Text>
             </View>
             <View style={styles.splitRow}>
               <Text style={styles.splitLine}>{'└─'}</Text>
               <Text style={styles.splitText}>
-                {donationSplit.charityAmount} sats to {donationSplit.charityName}
+                {donationSplit.charityAmount} to {donationSplit.charityName}
               </Text>
             </View>
           </View>
@@ -112,7 +112,7 @@ export const RewardEarnedModal: React.FC<RewardEarnedModalProps> = ({
     return (
       <>
         <Text style={styles.title}>Reward Queued</Text>
-        <Text style={styles.message}>{amount} sats queued for payout!</Text>
+        <Text style={styles.message}>{amount} rewards queued for payout!</Text>
         <Text style={styles.deliveryInfo}>Rewards sent daily ~10pm EST</Text>
       </>
     );


### PR DESCRIPTION
Automated draft PR addressing #437 (Finding 3 — High).

## Summary
- Replaced `{amount} sats queued for payout!` → `{amount} rewards queued for payout!` (appears in both the split-reward and no-split render paths)
- Replaced `{donationSplit.userAmount} sats to your wallet` → `{donationSplit.userAmount} to your wallet`
- Replaced `{donationSplit.charityAmount} sats to {charityName}` → `{donationSplit.charityAmount} to {charityName}`

## How this addresses the issue

Finding 3 from the 2026-07-01 design sweep flags `RewardEarnedModal` as the highest-visibility terminology violation in the app — it is shown after **every** qualifying workout, so non-Bitcoin users seeing "sats" with no context is the worst-case UX. All four occurrences at lines 91, 96, 102, and 115 are replaced with CLAUDE.md-compliant "rewards" language.

## Verification
- [x] Typecheck passes (0 errors — same as baseline)
- [x] Diff under 100 lines (4 lines changed, 1 file)
- [x] Single concern (terminology fix in one component)
- [x] No new dependencies
- [ ] Human review needed before merge

Closes #437

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-07-01
findings_count: 1
severity: critical=0 high=1 medium=0 low=0
self_score:
  specificity: 9
  actionability: 10
  signal_to_noise: 9
  false_positive_risk: 10
  coverage: 7
overall: 9.0
notes: Addressed highest-visibility single finding (RewardEarnedModal "sats") from a 13-finding design sweep; remaining findings left for human triage or future runs per single-concern rule.
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_01F9L7CrD3zSCPz5CPFuKdF1)_