### PR TITLE
Auto-PR: Fix off-palette green colors and Bitcoin label in wallet modals

### DIFF
--- a/src/components/ai/PPQAccountSetupModal.tsx
+++ b/src/components/ai/PPQAccountSetupModal.tsx
@@ -362,12 +362,12 @@ const styles = StyleSheet.create({
   existingAccountBox: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: '#0a1a0a',
+    backgroundColor: theme.colors.cardBackground,
     padding: 16,
     borderRadius: 10,
     marginBottom: 16,
     borderWidth: 1,
-    borderColor: '#1a3a1a',
+    borderColor: theme.colors.border,
   },
   existingAccountContent: {
     marginLeft: 12,

--- a/src/components/wallet/CoinOSAccountSetupModal.tsx
+++ b/src/components/wallet/CoinOSAccountSetupModal.tsx
@@ -153,7 +153,7 @@ export const CoinOSAccountSetupModal: React.FC<CoinOSAccountSetupModalProps> = (
             <View style={styles.headerIcon}>
               <Ionicons name="wallet-outline" size={24} color={theme.colors.text} />
             </View>
-            <Text style={styles.title}>Bitcoin Wallet</Text>
+            <Text style={styles.title}>Wallet</Text>
             <TouchableOpacity
               onPress={handleClose}
               style={styles.closeButton}
@@ -347,12 +347,12 @@ const styles = StyleSheet.create({
   existingAccountBox: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: '#0a1a0a',
+    backgroundColor: theme.colors.cardBackground,
     padding: 16,
     borderRadius: 10,
     marginBottom: 16,
     borderWidth: 1,
-    borderColor: '#1a3a1a',
+    borderColor: theme.colors.border,
   },
   existingAccountContent: {
     marginLeft: 12,


### PR DESCRIPTION
Automated draft PR addressing #437 (Critical findings 1 & 2).

## Summary
- Replaced off-palette green `#0a1a0a` / `#1a3a1a` backgrounds in `existingAccountBox` styles with `theme.colors.cardBackground` and `theme.colors.border` in both `CoinOSAccountSetupModal.tsx` and `PPQAccountSetupModal.tsx`
- Changed modal heading from `Bitcoin Wallet` → `Wallet` in `CoinOSAccountSetupModal.tsx` to comply with in-app terminology rules

## How this addresses the issue
Fixes Critical #1 and Critical #2 from the 2026-07-01 design sweep: the green-tinted near-blacks (`#0a1a0a`, `#1a3a1a`) violate the black/orange-only palette rule and the visible "Bitcoin Wallet" title violates the in-app terminology firewall per CLAUDE.md. Both are now consistent with the existing theme tokens.

## Verification
- [x] Typecheck passes (0 errors, same as baseline)
- [x] Diff under 100 lines (5 lines added, 5 removed across 2 files)
- [x] Single concern (design palette + terminology in wallet setup modals)
- [x] No new dependencies
- [ ] Human review needed before merge

Closes #437

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-07-02
findings_count: 2
severity: critical=2 high=0 medium=0 low=0
self_score:
  specificity: 10
  actionability: 10
  signal_to_noise: 10
  false_positive_risk: 10
  coverage: 7
overall: 9.4
notes: Picked Critical #1+#2 from #437 (green palette + Bitcoin label) — both verified by reading exact lines; skipped High #3-#7 (sats/Lightning) as they would require more files and push past the single-concern guardrail for one run.
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_01NytAVAwr7WWiEEUkH3f3Qt)_