### PR TITLE
Auto-PR: correct stale kind 1301 "NOT published" in ARCHITECTURE.md

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -391,7 +391,7 @@ This is the most important data flow in the app.
      +-- Upload card to Blossom
      +-- Publish to relays via GlobalNDKService
 
-7. KIND 1301 EVENT STRUCTURE (created locally, submitted to Supabase)
+7. KIND 1301 EVENT STRUCTURE (saved to Supabase + published to relays by default)
    {
      kind: 1301,
      content: "Running workout - 5.2 km in 30:45",
@@ -537,8 +537,8 @@ Restore to local storage (workouts, habits, journal, preferences)
 |  | Event Kinds:                                                |  |
 |  |   kind 0     - Profile metadata (read + write)             |  |
 |  |   kind 1     - Social posts for workout shares (write)     |  |
-|  |   kind 1301  - Workout structure (local only, NOT          |  |
-|  |                published to relays; submitted to Supabase)  |  |
+|  |   kind 1301  - Workout records (write, default) — saved to |  |
+|  |                Supabase AND published to relays for interop |  |
 |  |   kind 30078 - Encrypted backup (write, NIP-44)            |  |
 |  +------------------------------------------------------------+  |
 |                                                                   |


### PR DESCRIPTION
Automated draft PR addressing #427 (HIGH finding 1 — kind 1301 contradicts reality in ARCHITECTURE.md).

## Summary
- Updated lines 540–541 in the External Dependencies ASCII diagram: replaced `"Workout structure (local only, NOT published to relays; submitted to Supabase)"` with `"Workout records (write, default) — saved to Supabase AND published to relays for interop"`
- Updated the section 7 header at line 394: replaced `"KIND 1301 EVENT STRUCTURE (created locally, submitted to Supabase)"` with `"KIND 1301 EVENT STRUCTURE (saved to Supabase + published to relays by default)"`

## How this addresses the issue
Fixes HIGH finding 1 from the 2026-06-26 docs staleness sweep (#427): two places in ARCHITECTURE.md contradicted each other — lines 540–541 said kind 1301 was "local only, NOT published to relays" while line 656 (same file) and CLAUDE.md correctly stated it is published by default for cross-app interop (Amethyst/POWR/Chachi). The stale text was a leftover from before `docs/plans/2026-06-16-reenable-1301-publishing.md` was implemented. Finding 2 (Social feed stale refs across multiple files) is left for a separate PR as it touches more surfaces.

## Verification
- [x] Typecheck passes (pre-existing env errors only — no new errors; doc-only change has no TS impact)
- [x] Diff under 100 lines (3 insertions, 3 deletions — 1 file)
- [x] Single concern (kind 1301 publishing status in ARCHITECTURE.md)
- [x] No new dependencies
- [ ] Human review needed before merge

Closes #427

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-07-06
findings_count: 1
severity: critical=0 high=1 medium=0 low=0
self_score:
  specificity: 9
  actionability: 10
  signal_to_noise: 9
  false_positive_risk: 10
  coverage: 7
overall: 9.0
notes: Issues #440, #437, #431, #421 all had existing open PRs; #427 finding 1 (kind 1301 NOT-published contradiction) was the cleanest unaddressed single-concern fix — finding 2 (Social feed stale refs) requires multi-file edits and was left for a future run.
-->

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqfZDLQeXngiibU4Cvcb1M)_