### PR TITLE
Auto-PR: extract formatDistanceKm to shared utility

### DIFF
--- a/src/components/season2/CharityRankings.tsx
+++ b/src/components/season2/CharityRankings.tsx
@@ -15,6 +15,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { theme } from '../../styles/theme';
+import { formatDistanceKm } from '../../utils/distanceFormatter';
 import type { CharityRanking } from '../../types/season2';
 
 // Enable LayoutAnimation on Android
@@ -89,7 +90,7 @@ export const CharityRankings: React.FC<CharityRankingsProps> = ({
 
               {/* Distance - already in km from backend */}
               <Text style={styles.distanceText}>
-                {formatDistance(charity.totalDistance)}
+                {formatDistanceKm(charity.totalDistance)}
               </Text>
             </View>
           ))}
@@ -98,19 +99,6 @@ export const CharityRankings: React.FC<CharityRankingsProps> = ({
     </View>
   );
 };
-
-/**
- * Format distance in km for display
- */
-function formatDistance(km: number): string {
-  if (km >= 1000) {
-    return `${(km / 1000).toFixed(1)}k km`;
-  }
-  if (km >= 100) {
-    return `${km.toFixed(0)} km`;
-  }
-  return `${km.toFixed(1)} km`;
-}
 
 const styles = StyleSheet.create({
   container: {

--- a/src/components/season2/Season2Leaderboard.tsx
+++ b/src/components/season2/Season2Leaderboard.tsx
@@ -10,24 +10,12 @@ import React, { memo, useEffect, useRef, useState } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator, TouchableOpacity } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { theme } from '../../styles/theme';
+import { formatDistanceKm } from '../../utils/distanceFormatter';
 import { ZappableUserRow } from '../ui/ZappableUserRow';
 import { getSeason2Avatar } from '../../../assets/images/season2';
 import type { Season2Participant } from '../../types/season2';
 
 const BATCH_SIZE = 21; // Show 21 participants at a time
-
-/**
- * Format distance in km for display
- */
-function formatDistance(km: number): string {
-  if (km >= 1000) {
-    return `${(km / 1000).toFixed(1)}k km`;
-  }
-  if (km >= 100) {
-    return `${km.toFixed(0)} km`;
-  }
-  return `${km.toFixed(1)} km`;
-}
 
 /**
  * Format workout count with activity-specific label
@@ -58,7 +46,7 @@ interface LeaderboardRowProps {
 const LeaderboardRow = memo(
   ({ item, index, activityType }: LeaderboardRowProps) => {
     const rank = index + 1;
-    const formattedDistance = formatDistance(item.totalDistance);
+    const formattedDistance = formatDistanceKm(item.totalDistance);
     const bundledAvatar = getSeason2Avatar(item.pubkey);
 
     return (

--- a/src/utils/distanceFormatter.ts
+++ b/src/utils/distanceFormatter.ts
@@ -77,3 +77,17 @@ export const convertDistance = (
 export const getDistanceUnit = (unitSystem: UnitSystem = 'metric'): string => {
   return unitSystem === 'imperial' ? 'mi' : 'km';
 };
+
+/**
+ * Formats a km distance for leaderboard/ranking display (input is already in km)
+ * 1000+ km → "1.0k km", 100+ km → "123 km", else → "4.5 km"
+ */
+export function formatDistanceKm(km: number): string {
+  if (km >= 1000) {
+    return `${(km / 1000).toFixed(1)}k km`;
+  }
+  if (km >= 100) {
+    return `${km.toFixed(0)} km`;
+  }
+  return `${km.toFixed(1)} km`;
+}


### PR DESCRIPTION
Automated draft PR addressing #424 (MEDIUM finding — `formatDistance` duplicated in two season components).

## Summary
- Added `formatDistanceKm(km: number): string` to `src/utils/distanceFormatter.ts` — the existing canonical home for distance formatting
- Removed the byte-for-byte identical local `formatDistance` from `src/components/season2/CharityRankings.tsx` (was lines 102–113) and imported the shared utility
- Removed the byte-for-byte identical local `formatDistance` from `src/components/season2/Season2Leaderboard.tsx` (was lines 19–30) and imported the shared utility

## How this addresses the issue
Fixes the MEDIUM finding from the 2026-06-25 simplify sweep (#424): both season components independently defined the same km-based `formatDistance(km: number): string` with identical logic (1000+ km → "1.0k km", 100+ km → "123 km", else → "4.5 km"). The function is named `formatDistanceKm` in the utility to avoid collision with the existing `formatDistance(meters, unitSystem)` export in the same file, which takes meters and a unit-system parameter.

## Verification
- [x] Typecheck passes (0 errors — `tsc --noEmit` clean)
- [x] Diff under 100 lines (18 added, 28 removed across 3 files — 46 total)
- [x] Single concern (deduplicate km-based distance formatter for season leaderboards)
- [x] No new dependencies
- [ ] Human review needed before merge

Closes #424

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-07-07
findings_count: 1
severity: critical=0 high=0 medium=1 low=0
self_score:
  specificity: 10
  actionability: 10
  signal_to_noise: 9
  false_positive_risk: 10
  coverage: 7
overall: 9.2
notes: Issues #440, #437, #431, #421, #427 all had existing open PRs; #424 MEDIUM finding (formatDistance dedup across two season components) was the cleanest unaddressed fix — named the extracted function formatDistanceKm to avoid shadowing the existing meters-based formatDistance export in the same utility file.
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_01XkxWMwv9e2HvzqFxHtN8sd)_