### PR TITLE
Auto-PR: extract formatElapsedTime to shared utility

### DIFF
--- a/src/screens/activity/CyclingTrackerScreen.tsx
+++ b/src/screens/activity/CyclingTrackerScreen.tsx
@@ -45,6 +45,7 @@ import { CountdownOverlay } from '../../components/activity/CountdownOverlay';
 import { ControlBar } from '../../components/activity/ControlBar';
 import { HoldToStartButton } from '../../components/activity/HoldToStartButton';
 import { StepDebugOverlay } from '../../components/debug/StepDebugOverlay';
+import { formatElapsedTime } from '../../utils/workoutFormatters';
 
 type PostingState = 'idle' | 'posting' | 'posted';
 
@@ -290,18 +291,6 @@ export const CyclingTrackerScreen: React.FC<CyclingTrackerScreenProps> = ({
       }
     };
   }, []);
-
-  // Helper function for time formatting
-  const formatElapsedTime = (seconds: number): string => {
-    const hours = Math.floor(seconds / 3600);
-    const minutes = Math.floor((seconds % 3600) / 60);
-    const secs = Math.floor(seconds % 60);
-
-    if (hours > 0) {
-      return `${hours}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
-    }
-    return `${minutes}:${secs.toString().padStart(2, '0')}`;
-  };
 
   // Load user profile for social sharing
   useEffect(() => {

--- a/src/screens/activity/HikingTrackerScreen.tsx
+++ b/src/screens/activity/HikingTrackerScreen.tsx
@@ -37,6 +37,7 @@ import { CountdownOverlay } from '../../components/activity/CountdownOverlay';
 import { ControlBar } from '../../components/activity/ControlBar';
 import { theme } from '../../styles/theme';
 import { StepDebugOverlay } from '../../components/debug/StepDebugOverlay';
+import { formatElapsedTime } from '../../utils/workoutFormatters';
 
 interface HikingTrackerScreenProps {
   onWorkoutStateChange?: (isActive: boolean) => void;
@@ -223,17 +224,6 @@ export const HikingTrackerScreen: React.FC<HikingTrackerScreenProps> = ({
       }
     };
   }, []);
-
-  const formatElapsedTime = (seconds: number): string => {
-    const hours = Math.floor(seconds / 3600);
-    const minutes = Math.floor((seconds % 3600) / 60);
-    const secs = Math.floor(seconds % 60);
-
-    if (hours > 0) {
-      return `${hours}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
-    }
-    return `${minutes}:${secs.toString().padStart(2, '0')}`;
-  };
 
   // AppState listener for background/foreground transitions
   useEffect(() => {

--- a/src/screens/activity/RunningTrackerScreen.tsx
+++ b/src/screens/activity/RunningTrackerScreen.tsx
@@ -58,6 +58,7 @@ import { CountdownOverlay } from '../../components/activity/CountdownOverlay';
 // Debug overlays for GPS and step diagnosis
 import { ActivityDebugOverlay } from '../../components/debug/ActivityDebugOverlay';
 import { StepDebugOverlay } from '../../components/debug/StepDebugOverlay';
+import { formatElapsedTime } from '../../utils/workoutFormatters';
 
 type PostingState = 'idle' | 'posting' | 'posted';
 
@@ -585,18 +586,6 @@ export const RunningTrackerScreen: React.FC<RunningTrackerScreenProps> = ({
     startMetricsInterval();
   };
 
-  const formatElapsedTime = (seconds: number): string => {
-    const hours = Math.floor(seconds / 3600);
-    const minutes = Math.floor((seconds % 3600) / 60);
-    const secs = Math.floor(seconds % 60);
-
-    if (hours > 0) {
-      return `${hours}:${minutes.toString().padStart(2, '0')}:${secs
-        .toString()
-        .padStart(2, '0')}`;
-    }
-    return `${minutes}:${secs.toString().padStart(2, '0')}`;
-  };
 
   const pauseTracking = async () => {
     if (!isPaused) {

--- a/src/screens/activity/WalkingTrackerScreen.tsx
+++ b/src/screens/activity/WalkingTrackerScreen.tsx
@@ -54,6 +54,7 @@ import { UnifiedSigningService } from '../../services/auth/UnifiedSigningService
 import { theme } from '../../styles/theme';
 import { KM_PER_STEP } from '../../constants/appConstants';
 import { StepDebugOverlay } from '../../components/debug/StepDebugOverlay';
+import { formatElapsedTime } from '../../utils/workoutFormatters';
 
 type PostingState = 'idle' | 'posting' | 'posted';
 
@@ -302,18 +303,6 @@ export const WalkingTrackerScreen: React.FC<WalkingTrackerScreenProps> = ({
       }
     };
   }, []);
-
-  // Helper function for time formatting
-  const formatElapsedTime = (seconds: number): string => {
-    const hours = Math.floor(seconds / 3600);
-    const minutes = Math.floor((seconds % 3600) / 60);
-    const secs = Math.floor(seconds % 60);
-
-    if (hours > 0) {
-      return `${hours}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
-    }
-    return `${minutes}:${secs.toString().padStart(2, '0')}`;
-  };
 
   // Load user profile for social sharing
   useEffect(() => {

--- a/src/utils/workoutFormatters.ts
+++ b/src/utils/workoutFormatters.ts
@@ -1,0 +1,10 @@
+export function formatElapsedTime(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = Math.floor(seconds % 60);
+
+  if (hours > 0) {
+    return `${hours}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+  }
+  return `${minutes}:${secs.toString().padStart(2, '0')}`;
+}


### PR DESCRIPTION
Automated draft PR addressing #455 (HIGH finding — `formatElapsedTime` byte-identical across all four activity tracker screens).

## Summary
- Created `src/utils/workoutFormatters.ts` with a single exported `formatElapsedTime(seconds: number): string` function
- Removed the byte-identical local definition from `RunningTrackerScreen.tsx` (was line 588), `WalkingTrackerScreen.tsx` (was line 307), `CyclingTrackerScreen.tsx` (was line 295), and `HikingTrackerScreen.tsx` (was line 227)
- Added `import { formatElapsedTime } from '../../utils/workoutFormatters'` to each of the four screens

## How this addresses the issue
Fixes HIGH finding #2 from the 2026-07-09 simplify sweep (#455): all four activity tracker screens independently defined the same `formatElapsedTime` function with byte-identical logic. The function converts seconds to `H:MM:SS` or `M:SS` format — verified by reading all four definitions before implementing. Follows the same pattern as `src/utils/distanceFormatter.ts` for shared formatting utilities.

## Verification
- [x] Typecheck passes (no errors — `tsc --noEmit` clean)
- [x] Diff under 100 lines (14 added, 47 deleted across 5 files = 61 total)
- [x] Single concern (deduplicate `formatElapsedTime` across tracker screens)
- [x] No new dependencies
- [ ] Human review needed before merge

Closes #455

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-07-09
findings_count: 1
severity: critical=0 high=1 medium=0 low=0
self_score:
  specificity: 10
  actionability: 10
  signal_to_noise: 9
  false_positive_risk: 10
  coverage: 7
overall: 9.2
notes: #452 had an existing PR; #455 HIGH finding (formatElapsedTime dedup) was the cleanest unaddressed fix — issue confirmed byte-identical implementations, verified by reading all four before implementing. Other #455 findings (Season1Service deletion >100 lines, dead feature flags, vim swap file) left for future runs.
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_01C65t8cb2HLRntPVAzfWZ7b)_