### PR TITLE
Auto-PR: fix green-tinted existingAccountBox palette in PPQAccountSetupModal

### DIFF
--- a/src/components/ai/PPQAccountSetupModal.tsx
+++ b/src/components/ai/PPQAccountSetupModal.tsx
@@ -362,12 +362,12 @@ const styles = StyleSheet.create({
   existingAccountBox: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: '#0a1a0a',
+    backgroundColor: theme.colors.cardBackground,
     padding: 16,
     borderRadius: 10,
     marginBottom: 16,
     borderWidth: 1,
-    borderColor: '#1a3a1a',
+    borderColor: theme.colors.border,
   },
   existingAccountContent: {
     marginLeft: 12,


### PR DESCRIPTION
Automated draft PR addressing #452 (Critical finding C1 — `existingAccountBox` uses green-tinted hex colors not in the approved palette).

## Summary
- Replaced `backgroundColor: '#0a1a0a'` with `theme.colors.cardBackground` (`#0a0a0a`) in `existingAccountBox` style
- Replaced `borderColor: '#1a3a1a'` with `theme.colors.border` (`#1a1a1a`) in `existingAccountBox` style

## How this addresses the issue
The `existingAccountBox` container in `PPQAccountSetupModal` (shown when PPQ.AI finds an existing account) used two green-tinted hardcoded hex values (`#0a1a0a`, `#1a3a1a`) that violate the black/orange-only palette rule. The success text inside already used `theme.colors.success` (orange) correctly — only the container background and border needed updating. Both are replaced with their exact on-brand equivalents from the theme system.

## Verification
- [x] Typecheck passes (pre-existing `tsconfig.json` env errors only — no new errors; `theme.colors.cardBackground` and `theme.colors.border` are typed `string` in the theme)
- [x] Diff under 100 lines (2 insertions, 2 deletions — 1 file)
- [x] Single concern (palette violation in `existingAccountBox` style block)
- [x] No new dependencies
- [ ] Human review needed before merge

Closes #452

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-07-10
findings_count: 1
severity: critical=1 high=0 medium=0 low=0
self_score:
  specificity: 10
  actionability: 10
  signal_to_noise: 9
  false_positive_risk: 10
  coverage: 7
overall: 9.2
notes: Issues #455 and #458 were filed today (too fresh) or exceeded 100-line budget; #452 C1 (green palette violation in existingAccountBox) was the cleanest Critical fix — 2 line changes in 1 file with no ambiguity.
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_01FyjkL99DgG98buYJ6jug7i)_