### PR TITLE
Auto-PR: HealthConnect metric validation parity with HealthKit

### DIFF
--- a/src/services/fitness/healthConnectService.ts
+++ b/src/services/fitness/healthConnectService.ts
@@ -11,6 +11,7 @@ import { inferActivityTypeSimple, correctWalkingMislabel } from '../../utils/act
 import { SubmittedIdStore } from '../../utils/SubmittedIdStore';
 import { SupabaseCompetitionService } from '../backend/SupabaseCompetitionService';
 import { buildRewardTags } from '../../utils/rewardTags';
+import { isValidWorkoutMetrics } from '../../utils/rewardEligibility';
 
 // Environment-based logging utility
 const isDevelopment = __DEV__;
@@ -809,7 +810,7 @@ export class HealthConnectService {
       // the workout can exist in cache but still needs retry.
       if (!w.id || submittedIds.has(w.id)) return false;
       if (!w.activityType || !CARDIO_TYPES.includes(w.activityType)) return false;
-      if (!w.totalDistance || w.totalDistance <= 0) return false;
+      if (!isValidWorkoutMetrics(w.totalDistance, w.duration)) return false;
       return true;
     });
 


### PR DESCRIPTION
Automated draft PR addressing #461 (finding M-1).

## Summary

- Add `import { isValidWorkoutMetrics } from '../../utils/rewardEligibility'` to `healthConnectService.ts`
- Replace the loose lower-bound-only guard (`totalDistance > 0`) with `isValidWorkoutMetrics(w.totalDistance, w.duration)`, matching the existing HealthKit path
- Blocks corrupt/infinite/NaN-large distances and out-of-range durations from Health Connect source apps before they reach `submitWorkoutSimple`

## How this addresses the issue

Issue #461 M-1 identifies that `healthConnectService.ts:812` only checks `totalDistance > 0`, while `HealthKitBackgroundService.ts:175` calls `isValidWorkoutMetrics()` which enforces `distance ≤ 200,000 m`, `duration ≤ 86,400 s`, and rejects non-finite values. This PR closes that gap with a single-line swap.

## Verification

- [x] Typecheck passes (0 errors — no regression vs baseline)
- [x] Diff under 100 lines (3 lines changed, 1 file)
- [x] Single concern
- [ ] Human review needed before merge

Closes #461

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-07-13
findings_count: 1
severity: critical=0 high=0 medium=1 low=0
self_score:
  specificity: 9
  actionability: 10
  signal_to_noise: 9
  false_positive_risk: 10
  coverage: 8
overall: 9.2
notes: Issue #461 had one clearly mechanical M-1 finding with exact file:line and a prescriptive 3-line fix; all other in-window issues had existing auto-pr branches already.
-->

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkuYcuTTwtrfLYCd9JYqvX)_