### PR TITLE
Auto-PR: Add upper-bound validation to HealthConnect workout filter

### DIFF
--- a/src/services/fitness/healthConnectService.ts
+++ b/src/services/fitness/healthConnectService.ts
@@ -11,6 +11,7 @@ import { inferActivityTypeSimple, correctWalkingMislabel } from '../../utils/act
 import { SubmittedIdStore } from '../../utils/SubmittedIdStore';
 import { SupabaseCompetitionService } from '../backend/SupabaseCompetitionService';
 import { buildRewardTags } from '../../utils/rewardTags';
+import { isValidWorkoutMetrics } from '../../utils/rewardEligibility';
 
 // Environment-based logging utility
 const isDevelopment = __DEV__;
@@ -809,7 +810,7 @@ export class HealthConnectService {
       // the workout can exist in cache but still needs retry.
       if (!w.id || submittedIds.has(w.id)) return false;
       if (!w.activityType || !CARDIO_TYPES.includes(w.activityType)) return false;
-      if (!w.totalDistance || w.totalDistance <= 0) return false;
+      if (!isValidWorkoutMetrics(w.totalDistance, w.duration)) return false;
       return true;
     });
 


### PR DESCRIPTION
Automated draft PR addressing #461.

## Summary
- Imports `isValidWorkoutMetrics` from `src/utils/rewardEligibility.ts` into `healthConnectService.ts`
- Replaces the lower-bound-only distance check (`totalDistance > 0`) with the full `isValidWorkoutMetrics(w.totalDistance, w.duration)` guard that enforces `distance ≤ 200,000 m`, `duration ≤ 86,400 s`, and rejects non-finite values (Infinity, NaN)
- Brings the HealthConnect path in line with the existing HealthKit path, which already uses this guard

## How this addresses the issue
Issue #461 (M-1) identified that the HealthConnect workout submitter only checked `totalDistance > 0`, allowing corrupt values like `Infinity` to pass through and reach `SupabaseCompetitionService.submitWorkoutSimple`, risking leaderboard integrity. The fix mirrors the guard already in `HealthKitBackgroundService.ts:175`.

## Verification
- [x] Typecheck passes (0 errors — clean, matches baseline)
- [x] Diff under 100 lines (3 lines changed: 1 import + 1 guard replacement)
- [x] Single concern
- [ ] Human review needed before merge

Closes #461

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-07-15
findings_count: 1
severity: critical=0 high=0 medium=1 low=0
self_score:
  specificity: 9
  actionability: 10
  signal_to_noise: 10
  false_positive_risk: 10
  coverage: 8
overall: 9.4
notes: Issue #461 had exactly one finding (M-1) with a fully specified fix; implementation was straightforward. Coverage slightly below 10 because only the single qualifying issue was attempted per one-PR-per-run rule.
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_01MLEwAs1hVwk9uooYm9sLtf)_