### PR TITLE
Auto-PR: Remove "Bitcoin tips" / "zaps" from lightning address helper text

### DIFF
--- a/src/screens/ProfileEditScreen.tsx
+++ b/src/screens/ProfileEditScreen.tsx
@@ -379,8 +379,8 @@ export const ProfileEditScreen: React.FC = () => {
                   color={theme.colors.textMuted}
                 />
                 <Text style={styles.helperText}>
-                  Your Lightning address allows others to send you Bitcoin tips
-                  (zaps). This is where you'll receive rewards, challenge
+                  Your lightning address lets others send you rewards directly.
+                  This is where you'll receive workout rewards, challenge
                   winnings, and donations.
                 </Text>
               </View>


### PR DESCRIPTION
Automated draft PR addressing #467 (Design consistency sweep — finding #5).

## Summary
- Removes "Bitcoin" from in-app user-facing helper text in `ProfileEditScreen.tsx:382`
- Removes "(zaps)" — Nostr jargon — from the same string
- Keeps the useful context about rewards, challenge winnings, and donations
- Lowercases "Lightning" → "lightning" per terminology table

## How this addresses the issue
Issue #467 finding #5 flagged `src/screens/ProfileEditScreen.tsx:382`: the helper text under the lightning address field read *"Your Lightning address allows others to send you Bitcoin tips (zaps)."* The CLAUDE.md terminology table bans "Bitcoin" and "sats" in in-app copy; "zaps" is Nostr jargon that violates the terminology firewall.

The new text: *"Your lightning address lets others send you rewards directly. This is where you'll receive workout rewards, challenge winnings, and donations."*

## Verification
- [x] Typecheck passes (0 errors, no new errors vs baseline)
- [x] Diff under 100 lines (2 lines changed, 1 file)
- [x] Single concern (one string, one file)
- [x] No new dependencies
- [ ] Human review needed before merge

Closes #467 (partial — addresses finding #5; remaining findings need separate PRs)

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-07-17
findings_count: 1
severity: critical=0 high=0 medium=1 low=0
self_score:
  specificity: 9
  actionability: 10
  signal_to_noise: 9
  false_positive_risk: 10
  coverage: 7
overall: 9.0
notes: All open auto-pr-ok issues are multi-finding sweeps; picked the most localized single finding (one file, one string) from #467; prior attempts on #461 (3 branches) suggested skipping it.
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_013TdJsXnMqqfQAELJeLJSRm)_