### PR TITLE
Auto-PR: Fix stale elapsedTime in Walking/Hiking error-path catch blocks

### DIFF
--- a/src/screens/activity/HikingTrackerScreen.tsx
+++ b/src/screens/activity/HikingTrackerScreen.tsx
@@ -428,7 +428,7 @@ export const HikingTrackerScreen: React.FC<HikingTrackerScreenProps> = ({
       setWorkoutData({
         type: 'hiking',
         distance: session.distance,
-        duration: elapsedTime,
+        duration: finalDuration,
         calories,
         elevation: session.elevationGain || 0,
         steps,

--- a/src/screens/activity/WalkingTrackerScreen.tsx
+++ b/src/screens/activity/WalkingTrackerScreen.tsx
@@ -797,7 +797,7 @@ export const WalkingTrackerScreen: React.FC<WalkingTrackerScreenProps> = ({
       setWorkoutData({
         type: 'walking',
         distance: session.distance,
-        duration: elapsedTime,
+        duration: finalDuration,
         calories,
         elevation: session.elevationGain || 0,
         steps,


### PR DESCRIPTION
Automated draft PR addressing #476 (M-1 — Walking and Hiking tracker error-paths use stale `elapsedTime` after partial fix).

## Summary
- `WalkingTrackerScreen.tsx:800` — changed `duration: elapsedTime` → `duration: finalDuration` in the error-path `catch` block of `showWorkoutSummary`
- `HikingTrackerScreen.tsx:431` — same one-line fix in the equivalent catch block

## How this addresses the issue

Both screens already compute `const finalDuration = session.duration || elapsedTime` at the top of `showWorkoutSummary`, so `finalDuration` is already in scope in the catch block. The happy-path `setWorkoutData` call was using `finalDuration` correctly (as part of an earlier fix), but the error-path catch block was still reading the raw `elapsedTime` state — which diverges from `session.duration` after any pause/resume. This meant the workout summary modal would show the wrong elapsed time whenever the local save threw an error. The fix is identical to the one already applied to `CyclingTrackerScreen` in commit `4a94817`.

## Verification
- [x] Typecheck passes (0 errors — `tsc --noEmit` clean)
- [x] Diff under 100 lines (2 lines changed across 2 files)
- [x] Single concern (error-path stale elapsedTime, same bug in two sibling screens)
- [x] No new dependencies
- [ ] Human review needed before merge

Closes #476

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-07-20
findings_count: 1
severity: critical=0 high=0 medium=1 low=0
self_score:
  specificity: 10
  actionability: 10
  signal_to_noise: 10
  false_positive_risk: 10
  coverage: 8
overall: 9.6
notes: #476 M-1 was an ideal target — 2-line fix with exact precedent in CyclingTrackerScreen; #455 already had PR #456; #452 noted as having an existing PR per prior run log; chose newest eligible issue with a single, verifiable, mechanical fix.
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_01AJr3PYEisyHuk5Guo2udoM)_