### PR TITLE
Auto-PR: Fix stale archive references in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ Centralized documentation for the RUNSTR REWARDS project, including implementati
 ## Documentation Categories
 
 ### Project Overview
-- **ROADMAP.md** - Project roadmap and future plans
+- **ROADMAP.md** *(archived)* - Project roadmap and future plans
 
 ### Integration Guides
 - **AMBER_INTEGRATION.md** - Amber signer integration guide
@@ -24,69 +24,68 @@ Centralized documentation for the RUNSTR REWARDS project, including implementati
 - **ENVIRONMENT_SETUP.md** - Environment variables and secrets setup
 
 ### Testing Documentation
-- **PHASE_1_2_TESTING_GUIDE.md** - Complete testing guide for Phase 1 & 2
+- **PHASE_1_2_TESTING_GUIDE.md** *(archived)* - Complete testing guide for Phase 1 & 2
 - **PRE_LAUNCH_REVIEW_GUIDE.md** - Pre-launch review workflow
-- **PRE_LAUNCH_REVIEW_SCRIPT.md** - Claude's manual review script
+- **PRE_LAUNCH_REVIEW_SCRIPT.md** *(archived)* - Claude's manual review script
 - **CLAUDE_REVIEW_PROMPT.md** - Ready-to-paste Claude review prompt
-- **AMBER_TEST_SUITE.md** - Amber integration test suite
-- **AUDIT_REPORT.md** - Automated audit results
-- **TEST_SCRIPTS_SUMMARY.md** - Test scripts documentation
-- **NOTIFICATION_TESTING.md** - Notification testing guide
-- **PHASE1_TESTING_GUIDE.md** - Phase 1 specific testing
+- **AMBER_TEST_SUITE.md** *(archived)* - Amber integration test suite
+- **AUDIT_REPORT.md** *(archived)* - Automated audit results
+- **TEST_SCRIPTS_SUMMARY.md** *(archived)* - Test scripts documentation
+- **NOTIFICATION_TESTING.md** *(archived)* - Notification testing guide
+- **PHASE1_TESTING_GUIDE.md** *(archived)* - Phase 1 specific testing
 
 ### Deployment & Publishing
-- **ZAPSTORE_PUBLISHING.md** - ZapStore publishing guide
-- **APP_STORE_RESPONSE.md** - App Store submission responses
+- **ZAPSTORE_PUBLISHING.md** *(archived)* - ZapStore publishing guide
+- **APP_STORE_RESPONSE.md** *(archived)* - App Store submission responses
 
 ### Architecture & Planning
 - **DATA_ARCHITECTURE_AND_CACHING_STRATEGY.md** - Data architecture and caching design
-- **CACHING_MIGRATION_GUIDE.md** - Cache migration from legacy to unified system
-- **DATABASE_IMPLEMENTATION_PLAN.md** - Database architecture strategy (deprecated)
-- **NOSTR_FITNESS_ECOSYSTEM_VISION.md** - Vision for Nostr fitness ecosystem
-- **NOSTR_MVP_STRATEGY.md** - MVP strategy for Nostr implementation
+- **CACHING_MIGRATION_GUIDE.md** *(archived)* - Cache migration from legacy to unified system
+- **DATABASE_IMPLEMENTATION_PLAN.md** *(archived)* - Database architecture strategy (deprecated)
+- **NOSTR_FITNESS_ECOSYSTEM_VISION.md** *(archived)* - Vision for Nostr fitness ecosystem
+- **NOSTR_MVP_STRATEGY.md** *(archived)* - MVP strategy for Nostr implementation
 - **Decentralized-Fitness.md** - Decentralized fitness platform concepts
-- **ZAP_ARENA_VISION.md** - Zap Arena competition system vision
+- **ZAP_ARENA_VISION.md** *(archived)* - Zap Arena competition system vision
 - **WORKOUT_ARCHITECTURE.md** - Workout data architecture
 - **TEAM_MANAGEMENT_SYSTEM.md** - Team management system design
 
 ### Implementation Guides
-- **PHASE_2_IMPLEMENTATION_GUIDE.md** - Phase 2 development guide
-- **PHASE2_IMPLEMENTATION.md** - Phase 2 implementation details
-- **COMPETITION_REWARDS_IMPLEMENTATION.md** - Competition rewards system
-- **COMPETITION_SIMPLIFICATION.md** - Competition system simplification
-- **WALLET_PERSISTENCE_IMPROVEMENTS.md** - Wallet persistence improvements
-- **ACTIVITY_TRACKING_SIMPLIFICATION.md** - Activity tracking simplification
-- **nutzap-plan.md** - NutZap integration planning
+- **PHASE_2_IMPLEMENTATION_GUIDE.md** *(archived)* - Phase 2 development guide
+- **PHASE2_IMPLEMENTATION.md** *(archived)* - Phase 2 implementation details
+- **COMPETITION_REWARDS_IMPLEMENTATION.md** *(archived)* - Competition rewards system
+- **COMPETITION_SIMPLIFICATION.md** *(archived)* - Competition system simplification
+- **WALLET_PERSISTENCE_IMPROVEMENTS.md** *(archived)* - Wallet persistence improvements
+- **ACTIVITY_TRACKING_SIMPLIFICATION.md** *(archived)* - Activity tracking simplification
+- **nutzap-plan.md** *(archived)* - NutZap integration planning
 - **events-and-leagues.md** - Events and leagues system
 
 ### Setup & Configuration
-- **SETUP_INSTRUCTIONS.md** - Project setup and configuration
-- **METRO_XCODE_DEBUGGING_GUIDE.md** - Metro bundler and Xcode debugging
-- **APPLY_MIGRATION_INSTRUCTIONS.md** - Database migration instructions
+- **SETUP_INSTRUCTIONS.md** *(archived)* - Project setup and configuration
+- **METRO_XCODE_DEBUGGING_GUIDE.md** *(archived)* - Metro bundler and Xcode debugging
+- **APPLY_MIGRATION_INSTRUCTIONS.md** *(archived)* - Database migration instructions
 
 ### Problem Solving & Fixes
-- **1301_FITNESS_NOTES_BREAKTHROUGH.md** - Kind 1301 event breakthrough
-- **1301-PROBLEM-SOLVING.md** - Kind 1301 problem solving
-- **ACTIVITY_FILTERING_FIX_SUMMARY.md** - Activity filtering fixes
-- **CAPTAIN_DETECTION_FIX_ATTEMPTS.md** - Captain detection fix attempts
-- **CAPTAIN_DETECTION_INVESTIGATION.md** - Captain detection investigation
-- **TEAM_CREATION_ISSUE_SUMMARY.md** - Team creation issues
-- **TEAM_CREATION_RESOLUTION_SUMMARY.md** - Team creation resolution
-- **SUPABASE_FIX.md** - Supabase-related fixes (deprecated)
-- **PERFORMANCE_FIX_40S_FREEZE.md** - 40-second freeze performance fix
+- **1301_FITNESS_NOTES_BREAKTHROUGH.md** *(archived)* - Kind 1301 event breakthrough
+- **1301-PROBLEM-SOLVING.md** *(archived)* - Kind 1301 problem solving
+- **ACTIVITY_FILTERING_FIX_SUMMARY.md** *(archived)* - Activity filtering fixes
+- **CAPTAIN_DETECTION_FIX_ATTEMPTS.md** *(archived)* - Captain detection fix attempts
+- **CAPTAIN_DETECTION_INVESTIGATION.md** *(archived)* - Captain detection investigation
+- **TEAM_CREATION_ISSUE_SUMMARY.md** *(archived)* - Team creation issues
+- **TEAM_CREATION_RESOLUTION_SUMMARY.md** *(archived)* - Team creation resolution
+- **PERFORMANCE_FIX_40S_FREEZE.md** *(archived)* - 40-second freeze performance fix
 
 ### Issue Tracking & Bug Reports
-- **GITHUB_ISSUE_CAPTAIN_NOTIFICATIONS.md** - Captain notification issue
-- **github-issue-wallet-duplication.md** - Wallet duplication issue
+- **GITHUB_ISSUE_CAPTAIN_NOTIFICATIONS.md** *(archived)* - Captain notification issue
+- **github-issue-wallet-duplication.md** *(archived)* - Wallet duplication issue
 - **FITNESS_TRACKER_MEMORY.md** - Fitness tracker memory management
 
 ### Development History & Progress
 - **LESSONS_LEARNED.md** - Lessons learned during development
-- **LESSONS_FROM_REFERENCE_IMPLEMENTATION.md** - Lessons from reference apps
-- **ENHANCED_TEAM_DISCOVERY_SUMMARY.md** - Team discovery implementation
-- **RUNSTR_PROGRESS_REPORT.md** - Project progress reports
-- **MVP Plan.md** - Original MVP planning
-- **september-to-do-list.md** - September development todos
+- **LESSONS_FROM_REFERENCE_IMPLEMENTATION.md** *(archived)* - Lessons from reference apps
+- **ENHANCED_TEAM_DISCOVERY_SUMMARY.md** *(archived)* - Team discovery implementation
+- **RUNSTR_PROGRESS_REPORT.md** *(archived)* - Project progress reports
+- **MVP Plan.md** *(archived)* - Original MVP planning
+- **september-to-do-list.md** *(archived)* - September development todos
 - **NOSTR_AGENT_MEMORY.md** - Nostr agent development memory
 
 ## File Statistics


### PR DESCRIPTION
Automated draft PR addressing #473 (finding #5 — stale archive references in `docs/README.md`).

## Summary

- Marks 40 entries in `docs/README.md` as `*(archived)*` — each of these files lives in `docs/archive/` but was listed without any indication of its archived status
- Deletes the `SUPABASE_FIX.md` entry, which does not exist anywhere in the repo
- All changes are to `docs/README.md` only; no source code touched

## How this addresses the issue

Issue #473 finding #5 identified that `docs/README.md:20–60` lists ~12+ documents as active that actually live in `docs/archive/`. The audit confirmed each file's location by cross-referencing `ls docs/archive/`. This PR applies the fix-direction from the issue: add "(archived)" labels to stale entries and remove the non-existent `SUPABASE_FIX.md` entry.

## Verification

- [x] Typecheck passes (2 pre-existing tsconfig env errors, unchanged from baseline)
- [x] Diff under 100 lines (41 added, 42 deleted = 83 total)
- [x] Single concern (docs/README.md archive label cleanup only)
- [x] No new dependencies
- [ ] Human review needed before merge

Closes #473

---

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-07-22
findings_count: 1
severity: critical=0 high=0 medium=0 low=1
self_score:
  specificity: 9
  actionability: 10
  signal_to_noise: 9
  false_positive_risk: 10
  coverage: 8
overall: 9.2
notes: Picked finding #5 from #473 (docs/README.md stale archive refs) — cross-verified every entry against the actual filesystem before marking; SUPABASE_FIX.md confirmed absent from both docs/ and docs/archive/; diff is 83 lines (under 100 limit).
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_0132XYV4dugbcDTYf9jmqLt1)_