### PR TITLE
Auto-PR: Add isValidWorkoutMetrics guard to HealthConnect submitter

### DIFF
--- a/src/services/fitness/healthConnectService.ts
+++ b/src/services/fitness/healthConnectService.ts
@@ -8,6 +8,7 @@ import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { WorkoutType } from '../../types/workout';
 import { inferActivityTypeSimple, correctWalkingMislabel } from '../../utils/activityInference';
+import { isValidWorkoutMetrics } from '../../utils/rewardEligibility';
 import { SubmittedIdStore } from '../../utils/SubmittedIdStore';
 import { SupabaseCompetitionService } from '../backend/SupabaseCompetitionService';
 import { buildRewardTags } from '../../utils/rewardTags';
@@ -809,7 +810,7 @@ export class HealthConnectService {
       // the workout can exist in cache but still needs retry.
       if (!w.id || submittedIds.has(w.id)) return false;
       if (!w.activityType || !CARDIO_TYPES.includes(w.activityType)) return false;
-      if (!w.totalDistance || w.totalDistance <= 0) return false;
+      if (!isValidWorkoutMetrics(w.totalDistance, w.duration)) return false;
       return true;
     });
 


### PR DESCRIPTION
Automated draft PR addressing #461 (M-1).

## Summary
- Imports `isValidWorkoutMetrics` from `src/utils/rewardEligibility` into `healthConnectService.ts`
- Replaces the bare lower-bound check (`totalDistance > 0`) in the `submitNewWorkoutsToSupabase` filter with the full `isValidWorkoutMetrics(w.totalDistance, w.duration)` guard
- Mirrors the same guard already used by the HealthKit path (`HealthKitBackgroundService.ts:175`)

## How this addresses the issue

Issue #461 M-1 identified that the HealthConnect workout filter only checked `totalDistance > 0`, while the HealthKit path calls `isValidWorkoutMetrics` which additionally enforces `distance ≤ 200,000 m`, `duration ≤ 86,400 s`, and rejects non-finite values. A corrupt Health Connect source app returning `Infinity` or an absurdly large distance would pass the old filter and reach `SupabaseCompetitionService.submitWorkoutSimple` unchecked. This 2-line change closes the gap and makes both sync paths consistent.

## Verification
- [x] Typecheck passes (pre-existing infra warnings only — no new errors vs baseline)
- [x] Diff under 100 lines (2 lines changed, 1 file)
- [x] Single concern (metric validation parity between HealthKit and HealthConnect paths)
- [ ] Human review needed before merge

Closes #461

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-07-24
findings_count: 1
severity: critical=0 high=0 medium=1 low=0
self_score:
  specificity: 10
  actionability: 10
  signal_to_noise: 10
  false_positive_risk: 10
  coverage: 7
overall: 9.4
notes: Picked M-1 from #461 — 2-line verified fix with clear HealthKit mirror; coverage docked because the issue was a single-finding sweep so no triage was needed, and 41 open auto-pr-ok issues with none in the 14-day window except recent ones suggests the eligibility window may be worth revisiting in meta-learn.
-->

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4AtvtGas64mRuRb6a6hA6)_