### PR TITLE
Auto-PR: Replace local isValidLightningAddress copies with canonical import

### DIFF
--- a/src/components/club/CaptainSettingsModal.tsx
+++ b/src/components/club/CaptainSettingsModal.tsx
@@ -20,6 +20,7 @@ import { nostrProfileService } from '../../services/nostr/NostrProfileService';
 import type { NostrProfile } from '../../services/nostr/NostrProfileService';
 import { Avatar } from '../ui/Avatar';
 import type { Club, ClubMembership } from '../../types/club';
+import { isValidLightningAddress } from '../../utils/lnurl';
 
 interface CaptainSettingsModalProps {
   visible: boolean;
@@ -27,11 +28,6 @@ interface CaptainSettingsModalProps {
   club: Club;
   userNpub: string;
   onClubUpdated?: () => void;
-}
-
-function isValidLightningAddress(addr: string): boolean {
-  if (!addr) return true;
-  return /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(addr);
 }
 
 export const CaptainSettingsModal: React.FC<CaptainSettingsModalProps> = ({

--- a/src/components/creation/SimpleTeamCreationModal.tsx
+++ b/src/components/creation/SimpleTeamCreationModal.tsx
@@ -26,16 +26,12 @@ import { isSupabaseConfigured } from '../../utils/supabase';
 import { callEdgeFunction } from '../../utils/edgeFunctions';
 import { ClubWalletService } from '../../services/club/ClubWalletService';
 import { pickBannerImage, uploadBannerImage } from '../../services/club/ClubBannerStorageService';
+import { isValidLightningAddress } from '../../utils/lnurl';
 
 interface SimpleTeamCreationModalProps {
   visible: boolean;
   onClose: () => void;
   onTeamCreated?: (teamId: string) => void;
-}
-
-function isValidLightningAddress(address: string): boolean {
-  if (!address) return true; // Optional field
-  return /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(address);
 }
 
 export const SimpleTeamCreationModal: React.FC<SimpleTeamCreationModalProps> = ({
@@ -85,7 +81,7 @@ export const SimpleTeamCreationModal: React.FC<SimpleTeamCreationModalProps> = (
 
   const isValid =
     teamName.trim().length > 0 &&
-    isValidLightningAddress(lightningAddress);
+    (!lightningAddress || isValidLightningAddress(lightningAddress));
 
   const handleCreate = useCallback(async () => {
     if (isSubmittingRef.current) return; // Synchronous check prevents double-submit


### PR DESCRIPTION
Automated draft PR addressing #485 (finding 1 — `isValidLightningAddress` local copies).

## Summary
- Removed private `isValidLightningAddress` function from `CaptainSettingsModal.tsx` (was 4 lines)
- Removed private `isValidLightningAddress` function from `SimpleTeamCreationModal.tsx` (was 4 lines)
- Both files now import the canonical `isValidLightningAddress` from `src/utils/lnurl.ts`

## How this addresses the issue
The two local copies were functionally equivalent regex checks that bypassed the exported canonical validator in `lnurl.ts`. This PR replaces them with a direct import of the exported function, making the validation consistent across the codebase.

One behavioral note: the canonical function returns `false` for empty strings, while the old local copies returned `true` (treating the field as optional). In `CaptainSettingsModal.tsx` the call site already guards against empty strings (`if (updates.lightning_address && ...)`), so no behavior change. In `SimpleTeamCreationModal.tsx` the `isValid` expression was updated from `isValidLightningAddress(address)` to `(!address || isValidLightningAddress(address))` to preserve the optional-field semantics.

## Verification
- [x] Typecheck passes (no new errors vs baseline — only pre-existing `expo/tsconfig.base` and deprecated `baseUrl` warnings)
- [x] Diff under 100 lines (14 lines changed: 3 added, 11 removed)
- [x] Single concern
- [ ] Human review needed before merge

Closes #485

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-07-27
findings_count: 1
severity: critical=0 high=1 medium=0 low=0
self_score:
  specificity: 9
  actionability: 10
  signal_to_noise: 10
  false_positive_risk: 9
  coverage: 8
overall: 9.2
notes: Canonical function has a subtle empty-string behavior difference vs local copies; discovered during code reading and handled at call site — not flagged in the issue, required a small extra adjustment beyond the described pure import swap.
-->

---
_Generated by [Claude Code](https://claude.ai/code/session_017BHJRCqXjeYPx4yb7TLUFU)_