### PR TITLE
Auto-PR: Remove stale LeaderboardBaselineService from ARCHITECTURE.md

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -275,7 +275,6 @@ Competition Management (ALL Supabase-based at runtime):
   DailyLeaderboardService        Built-in daily leaderboards (5K/10K/Half/Marathon/Steps)
   StepCompetitionService         Step-based competitions
   PendingSubmissionService       Retry failed Supabase submissions
-  LeaderboardBaselineService     Pre-compute baselines for long events
   AutoJoinService                Auto-join matching competitions on workout submit
 
 Hardcoded Events:


### PR DESCRIPTION
Automated draft PR addressing #504.

## Summary
- Removes `LeaderboardBaselineService` from the Competition & Leaderboard Services table in `docs/ARCHITECTURE.md`
- The service was removed from the startup path in commit `5a84833` (Jul 3); its only remaining caller is `useSeason2.ts`, which is dead Season-2 code
- No code changes — documentation-only fix

## How this addresses the issue
The docs sweep (#504) flagged `LeaderboardBaselineService` as misleadingly listed among active competition services. Removing it prevents future developers from assuming it's a load-bearing competition service.

## Verification
- [x] Typecheck passes (no new errors vs baseline)
- [x] Diff under 100 lines (1 line deleted)
- [x] Single concern
- [ ] Human review needed before merge

Closes #504

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-07-31
findings_count: 1
severity: critical=0 high=0 medium=1 low=0
self_score:
  specificity: 9
  actionability: 10
  signal_to_noise: 9
  false_positive_risk: 9
  coverage: 7
overall: 8.8
notes: Issue #501 already had PR #502; picked the cleanest single-concern finding from #504 (stale doc entry, 1-line deletion, no code risk).
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_013ffUW932CuZz4nwcwuY6Jo)_