### PR TITLE
Auto-PR: Replace duplicate isValidLightningAddress with canonical import

### DIFF
--- a/src/components/club/CaptainSettingsModal.tsx
+++ b/src/components/club/CaptainSettingsModal.tsx
@@ -20,6 +20,7 @@ import { nostrProfileService } from '../../services/nostr/NostrProfileService';
 import type { NostrProfile } from '../../services/nostr/NostrProfileService';
 import { Avatar } from '../ui/Avatar';
 import type { Club, ClubMembership } from '../../types/club';
+import { isValidLightningAddress } from '../../utils/lnurl';
 
 interface CaptainSettingsModalProps {
   visible: boolean;
@@ -27,11 +28,6 @@ interface CaptainSettingsModalProps {
   club: Club;
   userNpub: string;
   onClubUpdated?: () => void;
-}
-
-function isValidLightningAddress(addr: string): boolean {
-  if (!addr) return true;
-  return /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(addr);
 }
 
 export const CaptainSettingsModal: React.FC<CaptainSettingsModalProps> = ({

--- a/src/components/creation/SimpleTeamCreationModal.tsx
+++ b/src/components/creation/SimpleTeamCreationModal.tsx
@@ -26,16 +26,12 @@ import { isSupabaseConfigured } from '../../utils/supabase';
 import { callEdgeFunction } from '../../utils/edgeFunctions';
 import { ClubWalletService } from '../../services/club/ClubWalletService';
 import { pickBannerImage, uploadBannerImage } from '../../services/club/ClubBannerStorageService';
+import { isValidLightningAddress } from '../../utils/lnurl';
 
 interface SimpleTeamCreationModalProps {
   visible: boolean;
   onClose: () => void;
   onTeamCreated?: (teamId: string) => void;
-}
-
-function isValidLightningAddress(address: string): boolean {
-  if (!address) return true; // Optional field
-  return /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(address);
 }
 
 export const SimpleTeamCreationModal: React.FC<SimpleTeamCreationModalProps> = ({
@@ -85,7 +81,7 @@ export const SimpleTeamCreationModal: React.FC<SimpleTeamCreationModalProps> = (
 
   const isValid =
     teamName.trim().length > 0 &&
-    isValidLightningAddress(lightningAddress);
+    (!lightningAddress || isValidLightningAddress(lightningAddress));
 
   const handleCreate = useCallback(async () => {
     if (isSubmittingRef.current) return; // Synchronous check prevents double-submit


### PR DESCRIPTION
Automated draft PR addressing #485 (finding 1).

## Summary

- Deleted private `isValidLightningAddress` copies from `CaptainSettingsModal.tsx` and `SimpleTeamCreationModal.tsx`
- Added `import { isValidLightningAddress } from '../../utils/lnurl'` to both files
- Updated the unguarded call in `SimpleTeamCreationModal.tsx:81` to `(!lightningAddress || isValidLightningAddress(lightningAddress))` to preserve the "empty = optional = valid" behavior that the local copy had

## How this addresses the issue

Issue #485 finding 1 explicitly flagged these two private copies as redundant vs. the canonical `lnurl.ts:275` export and marked the fix as `auto-pr-ok`. The only behavioral subtlety is that the local copies returned `true` for empty strings (optional field); the `SimpleTeamCreationModal` unguarded call site needed an explicit empty-string guard added (`!lightningAddress ||`) to maintain this behavior. Both `CaptainSettingsModal` call sites were already guarded.

## Verification

- [x] Typecheck passes (0 errors — clean)
- [x] Diff under 100 lines (3 insertions, 11 deletions)
- [x] Single concern — import deduplication only
- [ ] Human review needed before merge

Closes #485

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-08-04
findings_count: 1
severity: critical=0 high=1 medium=0 low=0
self_score:
  specificity: 9
  actionability: 9
  signal_to_noise: 9
  false_positive_risk: 9
  coverage: 8
overall: 8.8
notes: Behavioral difference in empty-string handling required a call-site guard in SimpleTeamCreationModal that the issue did not flag; all other call sites were already guarded.
-->

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJvf2KSNoakxbxS7grMJSb)_