### PR TITLE
Auto-PR: Replace local isValidLightningAddress copies with canonical import

### DIFF
--- a/src/components/club/CaptainSettingsModal.tsx
+++ b/src/components/club/CaptainSettingsModal.tsx
@@ -20,6 +20,7 @@ import { nostrProfileService } from '../../services/nostr/NostrProfileService';
 import type { NostrProfile } from '../../services/nostr/NostrProfileService';
 import { Avatar } from '../ui/Avatar';
 import type { Club, ClubMembership } from '../../types/club';
+import { isValidLightningAddress } from '../../utils/lnurl';
 
 interface CaptainSettingsModalProps {
   visible: boolean;
@@ -27,11 +28,6 @@ interface CaptainSettingsModalProps {
   club: Club;
   userNpub: string;
   onClubUpdated?: () => void;
-}
-
-function isValidLightningAddress(addr: string): boolean {
-  if (!addr) return true;
-  return /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(addr);
 }
 
 export const CaptainSettingsModal: React.FC<CaptainSettingsModalProps> = ({

--- a/src/components/creation/SimpleTeamCreationModal.tsx
+++ b/src/components/creation/SimpleTeamCreationModal.tsx
@@ -26,16 +26,12 @@ import { isSupabaseConfigured } from '../../utils/supabase';
 import { callEdgeFunction } from '../../utils/edgeFunctions';
 import { ClubWalletService } from '../../services/club/ClubWalletService';
 import { pickBannerImage, uploadBannerImage } from '../../services/club/ClubBannerStorageService';
+import { isValidLightningAddress } from '../../utils/lnurl';
 
 interface SimpleTeamCreationModalProps {
   visible: boolean;
   onClose: () => void;
   onTeamCreated?: (teamId: string) => void;
-}
-
-function isValidLightningAddress(address: string): boolean {
-  if (!address) return true; // Optional field
-  return /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(address);
 }
 
 export const SimpleTeamCreationModal: React.FC<SimpleTeamCreationModalProps> = ({
@@ -85,7 +81,7 @@ export const SimpleTeamCreationModal: React.FC<SimpleTeamCreationModalProps> = (
 
   const isValid =
     teamName.trim().length > 0 &&
-    isValidLightningAddress(lightningAddress);
+    (!lightningAddress || isValidLightningAddress(lightningAddress));
 
   const handleCreate = useCallback(async () => {
     if (isSubmittingRef.current) return; // Synchronous check prevents double-submit


### PR DESCRIPTION
Automated draft PR addressing #485.

## Summary

- Removed duplicate `isValidLightningAddress` function from `CaptainSettingsModal.tsx` (line 32) and `SimpleTeamCreationModal.tsx` (line 36)
- Both files now import the canonical `isValidLightningAddress` from `src/utils/lnurl.ts`
- Adjusted `SimpleTeamCreationModal`'s `isValid` expression to `(!lightningAddress || isValidLightningAddress(lightningAddress))` — preserves the optional-field behavior (empty address = team can still be created) that the local copy had via its early `if (!address) return true` guard

## How this addresses the issue

Issue #485 finding 1 identified two private copies of `isValidLightningAddress` that bypass the canonical export at `src/utils/lnurl.ts:275`. This PR removes both copies and imports the shared util, with a one-line guard in `SimpleTeamCreationModal` to preserve the existing "lightning address is optional" UX.

## Verification

- [x] Typecheck passes (0 errors, no new errors vs baseline)
- [x] Diff under 100 lines (3 insertions, 11 deletions — 14 lines total)
- [x] Single concern
- [ ] Human review needed before merge

Closes #485

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-08-05
findings_count: 1
severity: critical=0 high=1 medium=0 low=0
self_score:
  specificity: 9
  actionability: 9
  signal_to_noise: 9
  false_positive_risk: 9
  coverage: 7
overall: 8.6
notes: Found one clearly scoped auto-pr-ok item in #485; noticed a subtle empty-string behavior difference between local copies and canonical util that the issue body glossed over — handled with a one-line guard rather than silently breaking optional-field UX.
-->