### PR TITLE
Auto-PR: Fix reward docs divergence from code (REWARD_RULES.md + USER_FLOW.md)

### DIFF
--- a/docs/REWARD_RULES.md
+++ b/docs/REWARD_RULES.md
@@ -4,8 +4,8 @@ Single source of truth for reward logic across the app, website, and backend.
 
 ## Daily Reward
 
-- **Amount:** 50 sats per qualifying workout
-- **Applies to:** All users (no tiers, no subscriptions)
+- **Amount:** Distance-tiered — 5K → 500 sats, 10K → 1000 sats, Half marathon → 2100 sats, Marathon → 4200 sats
+- **Applies to:** All users — reward scales by distance milestone, no subscription required
 - **Daily limit:** 1 reward per user per day
 
 ## Event Rewards
@@ -22,7 +22,7 @@ Cardio only — running, walking, cycling, hiking.
 
 Daily steps (5,000+) also qualify as a walking workout via the daily step submission path.
 
-No distance minimum. No duration minimum.
+Minimum distance: 5 km. Workouts below 5 km (including non-GPS activities with no recorded distance) earn no reward. No minimum duration beyond what the anti-cheat validator enforces.
 
 ## Payout Destination
 

--- a/docs/USER_FLOW.md
+++ b/docs/USER_FLOW.md
@@ -134,7 +134,7 @@ If user enables Private Mode in Settings:
 ## 5. Reward Flow
 
 ### Overview
-Users earn rewards for qualifying workouts. Rewards are funded by sponsors and sent to the user's chosen destination.
+Users earn rewards for qualifying workouts. Rewards are funded by RUNSTR and sent to the user's lightning address.
 
 ### Trigger
 Two paths:


### PR DESCRIPTION
Automated draft PR addressing #536.

## Summary

- **REWARD_RULES.md**: Fix reward amount (was `50 sats` — 10× too low) and add distance-tier table matching `REWARD_DISTANCE_TIERS` in `src/config/rewards.ts`
- **REWARD_RULES.md**: Replace "No distance minimum" with the accurate 5 km minimum enforced by `MIN_WORKOUT_DISTANCE_METERS: 5000`
- **USER_FLOW.md**: Replace "funded by sponsors" (contradicts REWARD_RULES.md) with "funded by RUNSTR"

## How this addresses the issue

All three changes sync `docs/REWARD_RULES.md` and `docs/USER_FLOW.md` with the current values in `src/config/rewards.ts`. Findings verified by reading both the docs and the code constants (`DAILY_WORKOUT_REWARD: 500`, `REWARD_DISTANCE_TIERS`, `MIN_WORKOUT_DISTANCE_METERS: 5000`) before writing any fix.

## Verification

- [x] Typecheck passes (no new errors vs baseline — only pre-existing env errors from missing `expo/tsconfig.base` in cloud container; no TypeScript files were touched)
- [x] Diff under 100 lines (4 insertions, 4 deletions across 2 files)
- [x] Single concern (reward documentation accuracy)
- [ ] Human review needed before merge

Closes #536

---

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-08-14
findings_count: 3
severity: critical=0 high=2 medium=1 low=0
self_score:
  specificity: 9
  actionability: 10
  signal_to_noise: 9
  false_positive_risk: 10
  coverage: 8
overall: 9.2
notes: All three findings verified against actual code before implementing; only wrinkle is the "single concern" criterion — issue is technically a bundle but all findings are in reward docs, so treated as one concern.
-->

---
_Generated by [Claude Code](https://claude.ai/code/session_017QUYAvC6nRoLfr3ZeoYAUv)_