### PR TITLE
Auto-PR: Remove stale AppStateManager guard in CyclingTrackerScreen

### DIFF
--- a/src/screens/activity/CyclingTrackerScreen.tsx
+++ b/src/screens/activity/CyclingTrackerScreen.tsx
@@ -543,11 +543,9 @@ export const CyclingTrackerScreen: React.FC<CyclingTrackerScreenProps> = ({
 
   // FIXED: Get elapsed time directly from refs to avoid stale closure
   const updateMetricsFromSession = () => {
-    // CRITICAL: Don't update UI if app is backgrounded
-    const appStateManager = AppStateManager;
-    if (!appStateManager.isActive()) {
-      return;
-    }
+    // NOTE: AppStateManager.isActive() check intentionally removed — iOS sends spurious
+    // background events while the screen is visible, which froze cycling metrics permanently.
+    // Interval lifecycle in useEffect handles background/foreground correctly instead.
 
     const session = simpleRunTracker.getCurrentSession();
     if (session) {


### PR DESCRIPTION
Automated draft PR addressing #539 (M-4).

## Summary
- Removes the `AppStateManager.isActive()` early-return guard from `updateMetricsFromSession()` in `CyclingTrackerScreen.tsx`
- Replaces it with a comment explaining why the check is intentionally absent
- Matches the fix already applied to `RunningTrackerScreen` (which has an identical comment at line 237)

## How this addresses the issue
iOS occasionally fires spurious `background` app-state events while the screen is visible. With the guard in place, any such event permanently freezes all cycling metrics (distance, speed, elevation, duration) until the next foreground event fires. `RunningTrackerScreen` diagnosed and removed this same guard; `CyclingTrackerScreen` retained it. This PR brings cycling into parity.

## Verification
- [x] Typecheck passes (0 errors — no regression vs baseline)
- [x] Diff under 100 lines (1 file, 3 insertions / 5 deletions, net −2 lines)
- [x] Single concern: remove one stale guard, one file
- [x] `AppStateManager` import retained — still used by the `useEffect` at line 374 for legitimate background/foreground transitions
- [ ] Human review needed before merge

Closes #539

---

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-08-17
findings_count: 1
severity: critical=0 high=0 medium=1 low=0
self_score:
  specificity: 9
  actionability: 9
  signal_to_noise: 9
  false_positive_risk: 9
  coverage: 7
overall: 8.6
notes: Issue #539 is a bundle of findings; picked the one explicitly marked auto-pr-ok (M-4) and verified against the pattern already established in RunningTrackerScreen before editing.
-->

---
_Generated by [Claude Code](https://claude.ai/code/session_01TidjeqqEKPvbkCoFEB45xK)_