### PR TITLE
Auto-PR: Fix stale reward amounts and distance rules in REWARD_RULES.md

### DIFF
--- a/docs/REWARD_RULES.md
+++ b/docs/REWARD_RULES.md
@@ -4,8 +4,8 @@ Single source of truth for reward logic across the app, website, and backend.
 
 ## Daily Reward
 
-- **Amount:** 50 sats per qualifying workout
-- **Applies to:** All users (no tiers, no subscriptions)
+- **Amount:** Distance-tiered — 5K → 500 sats, 10K → 1,000 sats, Half marathon → 2,100 sats, Marathon → 4,200 sats
+- **Applies to:** All users — reward scales by distance milestone, no subscription required
 - **Daily limit:** 1 reward per user per day
 
 ## Event Rewards
@@ -22,7 +22,7 @@ Cardio only — running, walking, cycling, hiking.
 
 Daily steps (5,000+) also qualify as a walking workout via the daily step submission path.
 
-No distance minimum. No duration minimum.
+**Distance minimum:** 5 km — workouts under 5 km do not qualify for any reward. No duration minimum.
 
 ## Payout Destination
 


### PR DESCRIPTION
Automated draft PR addressing #536.

## Summary
- Updated `Amount` bullet from the outdated flat "50 sats" to the current distance-tiered structure (5K→500, 10K→1,000, Half→2,100, Marathon→4,200 sats)
- Updated `Applies to` description to reflect that reward scales by distance milestone
- Corrected `Qualifying Activities` section: replaced "No distance minimum" with the enforced 5 km minimum from `src/config/rewards.ts`

## How this addresses the issue
Issue #536 identified two HIGH contradictions between `docs/REWARD_RULES.md` and `src/config/rewards.ts`: the doc claimed a flat 50-sat reward (code has 500 as the 5K base plus tiered amounts) and asserted no distance minimum (code enforces `MIN_WORKOUT_DISTANCE_METERS: 5000`). Both are corrected here.

## Verification
- [x] Docs-only change — no typecheck required
- [x] All values verified against `src/config/rewards.ts` (`DAILY_WORKOUT_REWARD: 500`, `REWARD_DISTANCE_TIERS`, `MIN_WORKOUT_DISTANCE_METERS: 5000`)
- [x] Diff under 100 lines (6 lines changed)
- [x] Single concern (REWARD_RULES.md accuracy)
- [ ] Human review needed before merge

Closes #536

---

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-08-19
findings_count: 1
severity: critical=0 high=2 medium=0 low=0
self_score:
  specificity: 9
  actionability: 9
  signal_to_noise: 9
  false_positive_risk: 10
  coverage: 8
overall: 9.0
notes: Docs-only fix with values verified against source code; both findings confirmed accurate before implementation.
-->

---
_Generated by [Claude Code](https://claude.ai/code/session_014iDUcvvQeiCUP27Trg3V2C)_