### PR TITLE
Auto-PR: Register FitnessTestResults in authenticated stack

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -206,6 +206,7 @@ import { LevelDetailScreen } from './screens/LevelDetailScreen';
 import { SavedRoutesScreen } from './screens/routes/SavedRoutesScreen';
 import { AdvancedAnalyticsScreen } from './screens/AdvancedAnalyticsScreen';
 import { HealthProfileScreen } from './screens/HealthProfileScreen';
+import { FitnessTestResultsScreen } from './screens/FitnessTestResultsScreen';
 import { EinundzwanzigDetailScreen } from './screens/events/EinundzwanzigDetailScreen';
 import { DynamicEventDetailScreen } from './screens/events/DynamicEventDetailScreen';
 import { Season2Screen } from './screens/season2/Season2Screen';
@@ -278,6 +279,7 @@ type AuthenticatedStackParamList = {
   SavedRoutes: { activityType?: 'running' | 'cycling' | 'walking' };
   AdvancedAnalytics: undefined;
   HealthProfile: undefined;
+  FitnessTestResults: { testId: string };
   EinundzwanzigDetail: undefined;
   Season2: undefined;
   Season3: undefined;
@@ -513,6 +515,15 @@ const AuthenticatedNavigator: React.FC = () => {
           headerShown: false,
         }}
         component={HealthProfileScreen}
+      />
+
+      {/* Fitness Test Results Screen - Displays completed fitness test results */}
+      <AuthenticatedStack.Screen
+        name="FitnessTestResults"
+        options={{
+          headerShown: false,
+        }}
+        component={FitnessTestResultsScreen}
       />
 
       {/* Einundzwanzig Fitness Challenge Detail Screen */}


### PR DESCRIPTION
Automated draft PR addressing #554 (audit finding H-1).

## Summary

- Import `FitnessTestResultsScreen` inside `src/App.tsx`.
- Add `FitnessTestResults: { testId: string }` to `AuthenticatedStackParamList`.
- Register a `<AuthenticatedStack.Screen name="FitnessTestResults" …>` next to `HealthProfile` so the route resolves for authenticated users.

## How this addresses the issue

`AdvancedAnalyticsScreen.tsx:225` calls `navigate('FitnessTestResults', { testId })` after a fitness test finishes, but that route was only registered in `AppNavigator` (unauthenticated stack). The two navigators never coexist, so authenticated users hit a "screen not found" React Navigation error on test completion. The `as any` cast at that call site was hiding the missing route from TypeScript. Registering the screen in the authenticated stack (mirroring `AppNavigator.tsx:329-337`) makes the navigate call succeed for the same authenticated users who launched the test.

The `as any` cast in `AdvancedAnalyticsScreen.tsx` is left in place for now — removing it would require typing `useNavigation` with the param list, which is out of scope for this <100-line fix.

## Verification

- [x] Typecheck passes (0 errors — matches the clean baseline stated in #554)
- [x] Diff under 100 lines (1 file, +11 lines)
- [x] Single concern
- [ ] Human review needed before merge

Closes #554

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-08-24
findings_count: 1
severity: critical=0 high=1 medium=0 low=0
self_score:
  specificity: 10
  actionability: 10
  signal_to_noise: 9
  false_positive_risk: 9
  coverage: 8
overall: 9.2
notes: Issue #554 H-1 had precise file:line evidence and a concrete fix direction, which made this a clean single-file registration; kept as-any cast in AdvancedAnalyticsScreen to stay inside the 100-line/single-concern envelope.
-->

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3uAH7iQ5gL6Yv31VESr9Z)_