### PR TITLE
Auto-PR: Fix stale reward rules docs — amounts and eligibility

### DIFF
--- a/docs/REWARD_RULES.md
+++ b/docs/REWARD_RULES.md
@@ -4,8 +4,8 @@ Single source of truth for reward logic across the app, website, and backend.
 
 ## Daily Reward
 
-- **Amount:** 50 sats per qualifying workout
-- **Applies to:** All users (no tiers, no subscriptions)
+- **Amount:** Distance-tiered — 5K → 500 sats, 10K → 1000 sats, Half marathon → 2100 sats, Marathon → 4200 sats
+- **Applies to:** All users — reward scales by distance milestone, no subscription required
 - **Daily limit:** 1 reward per user per day
 
 ## Event Rewards
@@ -22,7 +22,7 @@ Cardio only — running, walking, cycling, hiking.
 
 Daily steps (5,000+) also qualify as a walking workout via the daily step submission path.
 
-No distance minimum. No duration minimum.
+Minimum distance: 5 km. Workouts below 5 km (including non-GPS activities with no recorded distance) earn no reward. No minimum duration beyond what the anti-cheat validator enforces.
 
 ## Payout Destination
 

--- a/docs/USER_FLOW.md
+++ b/docs/USER_FLOW.md
@@ -134,7 +134,7 @@ If user enables Private Mode in Settings:
 ## 5. Reward Flow
 
 ### Overview
-Users earn rewards for qualifying workouts. Rewards are funded by sponsors and sent to the user's chosen destination.
+Users earn rewards for qualifying workouts. Rewards are funded by RUNSTR and sent to the user's lightning address.
 
 ### Trigger
 Two paths:


### PR DESCRIPTION
Automated draft PR addressing #536.

## Summary
- `docs/REWARD_RULES.md`: Replace flat "50 sats" amount with the distance-tier table matching `src/config/rewards.ts` (5K→500, 10K→1000, Half→2100, Marathon→4200)
- `docs/REWARD_RULES.md`: Replace "No distance minimum" with the actual 5 km minimum enforced by `MIN_WORKOUT_DISTANCE_METERS`
- `docs/USER_FLOW.md`: Replace "funded by sponsors" (contradicts REWARD_RULES.md) with "funded by RUNSTR"

## How this addresses the issue
All three HIGH/MEDIUM findings in #536 are stale doc text that diverged from the code in `src/config/rewards.ts`. The fixes bring both docs into agreement with the canonical code and with each other — no logic changed, no code touched.

## Verification
- [x] Typecheck passes (no new errors vs baseline — doc-only change, 0 TS errors)
- [x] Diff under 100 lines (8 lines changed across 2 files)
- [x] Single concern (reward rules documentation accuracy)
- [ ] Human review needed before merge

Closes #536

---

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-08-26
findings_count: 3
severity: critical=0 high=2 medium=1 low=0
self_score:
  specificity: 9
  actionability: 9
  signal_to_noise: 9
  false_positive_risk: 10
  coverage: 8
overall: 9.0
notes: Doc-only fix was clean; the only ambiguity was whether to treat 3 findings as "single concern" — all three are stale-doc corrections to the same topic in adjacent files, so grouped them.
-->

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd7ST254MUdN7nWRoMV64x)_