### PR TITLE
Auto-PR: Remove duplicate formatDuration copies, use canonical

### DIFF
--- a/src/components/profile/WorkoutStatsSheet.tsx
+++ b/src/components/profile/WorkoutStatsSheet.tsx
@@ -21,6 +21,7 @@ import {
   type CardioPR,
 } from '../../services/analytics/PersonalRecordsService';
 import { useUnitPreference } from '../../hooks/useUnitPreference';
+import { formatDuration } from '../../types/satlantis';
 
 interface WorkoutStatsSheetProps {
   visible: boolean;
@@ -123,19 +124,6 @@ export const WorkoutStatsSheet: React.FC<WorkoutStatsSheetProps> = ({
       const miles = meters * 0.000621371;
       return `${miles.toFixed(1)} ${distanceLabel}`;
     }
-  };
-
-  const formatDuration = (seconds: number): string => {
-    const hours = Math.floor(seconds / 3600);
-    const minutes = Math.floor((seconds % 3600) / 60);
-    const secs = Math.floor(seconds % 60);
-
-    if (hours > 0) {
-      return `${hours}:${minutes.toString().padStart(2, '0')}:${secs
-        .toString()
-        .padStart(2, '0')}`;
-    }
-    return `${minutes}:${secs.toString().padStart(2, '0')}`;
   };
 
   const formatPRTime = (seconds: number): string => {

--- a/src/components/profile/shared/WorkoutCard.tsx
+++ b/src/components/profile/shared/WorkoutCard.tsx
@@ -8,6 +8,7 @@ import { View, Text, StyleSheet } from 'react-native';
 import { theme } from '../../../styles/theme';
 import type { WorkoutType } from '../../../types/workout';
 import { formatDistance } from '../../../utils/distanceFormatter';
+import { formatDuration } from '../../../types/satlantis';
 import { useUnitPreference } from '../../../hooks/useUnitPreference';
 
 interface Workout {
@@ -46,15 +47,6 @@ export const WorkoutCard: React.FC<WorkoutCardProps> = React.memo(({
   children,
 }) => {
   const { unitSystem } = useUnitPreference();
-
-  const formatDuration = (seconds: number): string => {
-    const h = Math.floor(seconds / 3600);
-    const m = Math.floor((seconds % 3600) / 60);
-    const s = seconds % 60;
-    return h > 0
-      ? `${h}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`
-      : `${m}:${s.toString().padStart(2, '0')}`;
-  };
 
   const formatDate = (dateString: string): string => {
     const workoutDate = new Date(dateString);


### PR DESCRIPTION
Automated draft PR addressing #563.

## Summary
- Deleted local `formatDuration` arrow function from `WorkoutCard.tsx` (line 50) and imported the canonical export from `src/types/satlantis.ts`
- Deleted local `formatDuration` arrow function from `WorkoutStatsSheet.tsx` (line 128) and imported the same canonical export
- Both private copies were functionally identical to the canonical function

## How this addresses the issue
Issue #563 flagged these two files as containing duplicate `formatDuration` implementations not covered by prior PRs (#534, #552). This PR completes the cleanup for the two newly-identified copies.

## Verification
- [x] Typecheck passes (no new errors vs baseline)
- [x] Diff under 100 lines (2 insertions, 22 deletions = 24 lines total)
- [x] Single concern
- [ ] Human review needed before merge

Closes #563

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-08-27
findings_count: 1
severity: critical=0 high=1 medium=0 low=0
self_score:
  specificity: 9
  actionability: 9
  signal_to_noise: 9
  false_positive_risk: 9
  coverage: 7
overall: 8.6
notes: Skipped npubToHex finding because canonical returns string|null vs local string — swapping would require null-handling at call sites and widen diff; formatDuration-only fix stayed well within 100-line budget.
-->