### PR TITLE
Auto-PR: InlineCommentList isSending mutex never released on throw

### DIFF
--- a/src/components/social/InlineCommentList.tsx
+++ b/src/components/social/InlineCommentList.tsx
@@ -60,41 +60,43 @@ export const InlineCommentList: React.FC<InlineCommentListProps> = ({
     Keyboard.dismiss();
     setIsSending(true);
 
-    const userName = await AsyncStorage.getItem('@runstr:display_name');
-    const userAvatar = await AsyncStorage.getItem('@runstr:profile_picture');
+    try {
+      const userName = await AsyncStorage.getItem('@runstr:display_name');
+      const userAvatar = await AsyncStorage.getItem('@runstr:profile_picture');
 
-    const optimistic: WorkoutComment = {
-      id: `optimistic-${Date.now()}`,
-      event_id: eventId,
-      npub: userNpub,
-      content: trimmed,
-      author_name: userName || null,
-      author_avatar: userAvatar || null,
-      created_at: new Date().toISOString(),
-    };
+      const optimistic: WorkoutComment = {
+        id: `optimistic-${Date.now()}`,
+        event_id: eventId,
+        npub: userNpub,
+        content: trimmed,
+        author_name: userName || null,
+        author_avatar: userAvatar || null,
+        created_at: new Date().toISOString(),
+      };
 
-    setOptimisticComments((prev) => [optimistic, ...prev]);
+      setOptimisticComments((prev) => [optimistic, ...prev]);
 
-    const result = await WorkoutInteractionService.getInstance().addComment(
-      eventId,
-      userNpub,
-      trimmed,
-      userName || undefined,
-      userAvatar || undefined,
-    );
+      const result = await WorkoutInteractionService.getInstance().addComment(
+        eventId,
+        userNpub,
+        trimmed,
+        userName || undefined,
+        userAvatar || undefined,
+      );
 
-    if (result) {
-      // Replace optimistic entry with the real one and notify parent
-      setOptimisticComments((prev) => prev.filter((c) => c.id !== optimistic.id));
-      setComments((prev) => [result, ...prev]);
-      onCommentAdded?.();
-    } else {
-      setOptimisticComments((prev) => prev.filter((c) => c.id !== optimistic.id));
-      setInputText(trimmed);
-      Toast.show({ type: 'error', text1: 'Comment not sent', visibilityTime: 2000 });
+      if (result) {
+        // Replace optimistic entry with the real one and notify parent
+        setOptimisticComments((prev) => prev.filter((c) => c.id !== optimistic.id));
+        setComments((prev) => [result, ...prev]);
+        onCommentAdded?.();
+      } else {
+        setOptimisticComments((prev) => prev.filter((c) => c.id !== optimistic.id));
+        setInputText(trimmed);
+        Toast.show({ type: 'error', text1: 'Comment not sent', visibilityTime: 2000 });
+      }
+    } finally {
+      setIsSending(false);
     }
-
-    setIsSending(false);
   }, [inputText, isSending, eventId, userNpub, onCommentAdded]);
 
   if (!expanded) return null;


### PR DESCRIPTION
Automated draft PR addressing #569.

## Summary

- Wraps the async body of `handleSend` in `InlineCommentList` in a `try/finally` block so `setIsSending(false)` is always called, even when `AsyncStorage.getItem` or `addComment` throws.
- Prevents the comment input and Send button from being permanently locked after any network error or unexpected exception.
- Single-file change; no logic changes to the happy path — only error-path behaviour fixed.

## How this addresses the issue

Issue #569 H-1 identified that `setIsSending(true)` on line 61 is never paired with a guaranteed `setIsSending(false)` — any throw between those two calls leaves `isSending = true` for the component's lifetime, making the text input uneditable and the Send button disabled until the user collapses and re-expands the comment section. Moving `setIsSending(false)` into a `finally` block guarantees release.

## Verification

- [x] Typecheck passes (0 errors — no regression vs baseline)
- [x] Diff under 100 lines (2 lines net change: added `try {` and replaced `setIsSending(false)` with `} finally { setIsSending(false); }`)
- [x] Single concern
- [ ] Human review needed before merge

Closes #569

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-08-31
findings_count: 1
severity: critical=0 high=1 medium=0 low=0
self_score:
  specificity: 9
  actionability: 10
  signal_to_noise: 9
  false_positive_risk: 10
  coverage: 8
overall: 9.2
notes: Issue #569 H-1 was a clear, verifiable single-file fix; typecheck came back clean with 0 errors.
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_019QSe1Qqazcz7wvk1rhosqC)_