### PR TITLE
Auto-PR: Fix stale docs — reward tiers, minimums, destination picker, tab names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,9 @@ Never use "cryptocurrency", "blockchain", or "decentralized" in user-facing cont
 
 ## Product Structure
 
-**Three-Tab Navigation:** Profile (workouts, history, settings) · Social (feed, Fitness Clubs) · Events (daily leaderboard, club events)
+**Three-Tab Navigation:** Home (workouts, history, settings) · Social (feed, Fitness Clubs) · Leaderboard (daily leaderboard, club events)
 
-**Social Pillar:** Three surfaces — the Nostr feed (workout posts, zaps, likes, reposts), Fitness Clubs (captain-run groups with chat + events), and Events (daily leaderboard + club events). The pillar spans both the Social tab and the Events tab.
+**Social Pillar:** Three surfaces — the Nostr feed (workout posts, zaps, likes, reposts), Fitness Clubs (captain-run groups with chat + events), and Events (daily leaderboard + club events). The pillar spans both the Social tab and the Leaderboard tab.
 
 **Activities:** Cardio only — Run, Walk, Cycle, Hike with GPS tracking.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -81,9 +81,9 @@ App.tsx
                                 |    |
                                 |    +-- BottomTabNavigator
                                 |         |
-                                |         +-- Profile Tab (eager load)
-                                |         +-- Social Tab  (React.lazy)
-                                |         +-- Events Tab  (React.lazy)
+                                |         +-- Home Tab        (eager load)
+                                |         +-- Social Tab      (React.lazy)
+                                |         +-- Leaderboard Tab (React.lazy)
                                 |
                                 +-- Modal Screens (~21 reachable)
                                      |

--- a/docs/REWARD_RULES.md
+++ b/docs/REWARD_RULES.md
@@ -4,7 +4,16 @@ Single source of truth for reward logic across the app, website, and backend.
 
 ## Daily Reward
 
-- **Amount:** 50 sats per qualifying workout
+Rewards are distance-tiered — a workout earns the highest milestone it crosses:
+
+| Distance | Reward |
+|----------|--------|
+| Marathon (42.2K+) | 4,200 sats |
+| Half marathon (21.1K+) | 2,100 sats |
+| 10K+ | 1,000 sats |
+| 5K – 9.99K | 500 sats |
+| Under 5K | 0 (does not qualify) |
+
 - **Applies to:** All users (no tiers, no subscriptions)
 - **Daily limit:** 1 reward per user per day
 
@@ -22,17 +31,17 @@ Cardio only — running, walking, cycling, hiking.
 
 Daily steps (5,000+) also qualify as a walking workout via the daily step submission path.
 
-No distance minimum. No duration minimum.
+Minimum distance: 5K (5,000 m). Minimum duration: 60 seconds. Workouts below either threshold earn nothing.
 
 ## Payout Destination
 
-Rewards are sent via LNURL to the user's lightning address. There is no destination picker — no charities, no projects, no AI credits, no splits.
+Rewards are sent via LNURL to the destination the user selects on the Rewards screen. The destination picker offers three options:
 
-Address resolution priority:
-1. Stored address (from Settings) if set
-2. Nostr profile lud16 otherwise
+1. **Your lightning address** — default; either the stored address (from Settings) or the user's Nostr profile lud16
+2. **Charity** — routes to the selected charity's lightning address (default: ALS Network)
+3. **PPQ.AI** — rewards are paid to a PPQ.AI bolt11 invoice instead of a Lightning address
 
-If neither is available, the user cannot receive rewards until they paste one into Settings.
+If no lightning address is available and no alternative is selected, the user cannot receive rewards until they paste one into Settings.
 
 ## Implementation Notes
 


### PR DESCRIPTION
Automated draft PR addressing #566.

## Summary

- **`docs/REWARD_RULES.md`**: Replace wrong flat "50 sats" claim with the actual distance-tiered table (5K=500, 10K=1000, half=2100, marathon=4200 sats); replace "No distance minimum" with actual 5K/60s minimums; document the live destination picker (user address → charity → PPQ.AI) instead of the outdated "no picker" claim.
- **`docs/ARCHITECTURE.md`**: Update BottomTabNavigator tree from stale tab names (Profile, Events) to live names (Home, Leaderboard).
- **`CLAUDE.md`**: Update Three-Tab Navigation and Social Pillar descriptions to match live tab names (Home · Social · Leaderboard).

## How this addresses the issue

Issue #566 identified three HIGH contradictions in `REWARD_RULES.md` that would actively mislead a contributor, and one MEDIUM stale tab-name discrepancy across `ARCHITECTURE.md` and `CLAUDE.md`. This PR fixes all four. Finding #5 (CHANGELOG unreleased entries) is left for human judgment on whether to add an `[Unreleased]` section or bump the version.

## Verification

- [x] Typecheck passes (`npm run typecheck` — zero errors, zero new errors)
- [x] Diff under 100 lines (33 lines changed)
- [x] Single concern (doc staleness from issue #566)
- [x] No new dependencies, no native config changes
- [ ] Human review needed before merge

Closes #566

---

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-09-01
findings_count: 4
severity: critical=0 high=3 medium=1 low=0
self_score:
  specificity: 9
  actionability: 9
  signal_to_noise: 9
  false_positive_risk: 9
  coverage: 8
overall: 8.8
notes: All 4 implemented findings verified against live code before editing; finding #5 (CHANGELOG) skipped as it requires a version bump decision, not a docs edit.
-->

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWqTZQFVt9QEELYRYRNtfw)_