### PR TITLE
Auto-PR: Fix comment input lock when async throws in handleSend

### DIFF
--- a/src/components/social/InlineCommentList.tsx
+++ b/src/components/social/InlineCommentList.tsx
@@ -60,41 +60,43 @@ export const InlineCommentList: React.FC<InlineCommentListProps> = ({
     Keyboard.dismiss();
     setIsSending(true);
 
-    const userName = await AsyncStorage.getItem('@runstr:display_name');
-    const userAvatar = await AsyncStorage.getItem('@runstr:profile_picture');
+    try {
+      const userName = await AsyncStorage.getItem('@runstr:display_name');
+      const userAvatar = await AsyncStorage.getItem('@runstr:profile_picture');
 
-    const optimistic: WorkoutComment = {
-      id: `optimistic-${Date.now()}`,
-      event_id: eventId,
-      npub: userNpub,
-      content: trimmed,
-      author_name: userName || null,
-      author_avatar: userAvatar || null,
-      created_at: new Date().toISOString(),
-    };
+      const optimistic: WorkoutComment = {
+        id: `optimistic-${Date.now()}`,
+        event_id: eventId,
+        npub: userNpub,
+        content: trimmed,
+        author_name: userName || null,
+        author_avatar: userAvatar || null,
+        created_at: new Date().toISOString(),
+      };
 
-    setOptimisticComments((prev) => [optimistic, ...prev]);
+      setOptimisticComments((prev) => [optimistic, ...prev]);
 
-    const result = await WorkoutInteractionService.getInstance().addComment(
-      eventId,
-      userNpub,
-      trimmed,
-      userName || undefined,
-      userAvatar || undefined,
-    );
+      const result = await WorkoutInteractionService.getInstance().addComment(
+        eventId,
+        userNpub,
+        trimmed,
+        userName || undefined,
+        userAvatar || undefined,
+      );
 
-    if (result) {
-      // Replace optimistic entry with the real one and notify parent
-      setOptimisticComments((prev) => prev.filter((c) => c.id !== optimistic.id));
-      setComments((prev) => [result, ...prev]);
-      onCommentAdded?.();
-    } else {
-      setOptimisticComments((prev) => prev.filter((c) => c.id !== optimistic.id));
-      setInputText(trimmed);
-      Toast.show({ type: 'error', text1: 'Comment not sent', visibilityTime: 2000 });
+      if (result) {
+        // Replace optimistic entry with the real one and notify parent
+        setOptimisticComments((prev) => prev.filter((c) => c.id !== optimistic.id));
+        setComments((prev) => [result, ...prev]);
+        onCommentAdded?.();
+      } else {
+        setOptimisticComments((prev) => prev.filter((c) => c.id !== optimistic.id));
+        setInputText(trimmed);
+        Toast.show({ type: 'error', text1: 'Comment not sent', visibilityTime: 2000 });
+      }
+    } finally {
+      setIsSending(false);
     }
-
-    setIsSending(false);
   }, [inputText, isSending, eventId, userNpub, onCommentAdded]);
 
   if (!expanded) return null;


### PR DESCRIPTION
Automated draft PR addressing #569.

## Summary
- Wraps the entire async body of `handleSend` in `InlineCommentList.tsx` inside a `try/finally` block
- `setIsSending(false)` is now called unconditionally in `finally`, even if any `await` throws
- Prevents the comment input from permanently locking after a network error or AsyncStorage exception

## How this addresses the issue
Issue #569 H-1 identifies that `setIsSending(true)` at line 61 is never unwound when any awaited call (AsyncStorage at lines 63–64, or `addComment` at line 78) throws — leaving `isSending = true` for the lifetime of the component. The `TextInput` becomes uneditable and the Send button stays disabled until the section is collapsed and re-expanded.

## Verification
- [x] Typecheck passes (no new errors vs baseline)
- [x] Diff under 100 lines (36 insertions / 34 deletions — restructure only, no logic change)
- [x] Single concern
- [ ] Human review needed before merge

Closes #569

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-09-02
findings_count: 1
severity: critical=0 high=1 medium=0 low=0
self_score:
  specificity: 9
  actionability: 9
  signal_to_noise: 9
  false_positive_risk: 9
  coverage: 7
overall: 8.6
notes: Picked H-1 from #569 (4-line try/finally fix). Typecheck clean. Coverage docked because I reviewed only 4 of 8 eligible issue bodies before picking; the chosen fix was clear enough to proceed.
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRXZZTQVUMTuwKhhsdVJGj

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRXZZTQVUMTuwKhhsdVJGj)_