### PR TITLE
Auto-PR: Remove commented-out Wavlake auth code in PlaylistBrowser

### DIFF
--- a/src/components/music/PlaylistBrowser.tsx
+++ b/src/components/music/PlaylistBrowser.tsx
@@ -198,14 +198,6 @@ export const PlaylistBrowser: React.FC = React.memo(() => {
     serverName: string;
   } | null>(null);
 
-  // NOTE: Library state disabled - Wavlake library API not publicly available yet
-  // const [likedTracks, setLikedTracks] = useState<WavlakeTrack[]>([]);
-  // const [userPlaylists, setUserPlaylists] = useState<UserPlaylist[]>([]);
-  // const [isAuthenticated, setIsAuthenticated] = useState(false);
-  // const [isLoadingLibrary, setIsLoadingLibrary] = useState(false);
-  // const [isCreatePlaylistOpen, setIsCreatePlaylistOpen] = useState(false);
-  // const [addToPlaylistTrack, setAddToPlaylistTrack] = useState<WavlakeTrack | null>(null);
-
   // UI state
   const [selectedPlaylist, setSelectedPlaylist] = useState<PlaylistId>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -467,12 +459,6 @@ export const PlaylistBrowser: React.FC = React.memo(() => {
   const goBackToBrowse = useCallback(() => {
     setSelectedPlaylist(null);
   }, []);
-
-  /**
-   * NOTE: Track options disabled - Wavlake library API not publicly available yet
-   */
-  // const handleTrackOptions = useCallback((track: WavlakeTrack) => { ... }, []);
-  // const handlePlaylistCreated = useCallback(() => { ... }, []);
 
   /**
    * Render Your Library section


### PR DESCRIPTION
Automated draft PR addressing #578.

## Summary
- Deletes 8 lines of commented-out Wavlake library state declarations (`likedTracks`, `userPlaylists`, `isAuthenticated`, `isLoadingLibrary`, `isCreatePlaylistOpen`, `addToPlaylistTrack`) at `PlaylistBrowser.tsx:202–207`
- Deletes 2 commented-out stub handlers (`handleTrackOptions`, `handlePlaylistCreated`) at `PlaylistBrowser.tsx:474–475`
- Removes orphaned NOTE/JSDoc comment blocks that introduced those lines

## How this addresses the issue
Issue #578 identified these 8 commented-out lines as dead code — the Wavlake library API was never publicly released, no active code references these variables or handlers, and the stub handlers contain no logic (`{ ... }`). The fix is a pure deletion with zero behavior change.

## Verification
- [x] Typecheck passes (no new errors vs baseline)
- [x] Diff under 100 lines (14 deletions, 0 additions)
- [x] Single concern — one file, one class of dead code
- [ ] Human review needed before merge

Closes #578

https://claude.ai/code/session_013WeAWgxLuSFnd22xKh6KJb

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-09-03
findings_count: 1
severity: critical=0 high=0 medium=1 low=0
self_score:
  specificity: 9
  actionability: 10
  signal_to_noise: 10
  false_positive_risk: 10
  coverage: 8
overall: 9.4
notes: Issue body explicitly flagged the target as auto-pr-ok with exact line numbers; deletion verified clean with tsc --noEmit; JSDoc/NOTE orphan comments also removed for cleanliness.
-->


---
_Generated by [Claude Code](https://claude.ai/code/session_013WeAWgxLuSFnd22xKh6KJb)_