### PR TITLE
Auto-PR: Fix isSending permanent lock in InlineCommentList

### DIFF
--- a/src/components/social/InlineCommentList.tsx
+++ b/src/components/social/InlineCommentList.tsx
@@ -60,41 +60,43 @@ export const InlineCommentList: React.FC<InlineCommentListProps> = ({
     Keyboard.dismiss();
     setIsSending(true);
 
-    const userName = await AsyncStorage.getItem('@runstr:display_name');
-    const userAvatar = await AsyncStorage.getItem('@runstr:profile_picture');
+    try {
+      const userName = await AsyncStorage.getItem('@runstr:display_name');
+      const userAvatar = await AsyncStorage.getItem('@runstr:profile_picture');
 
-    const optimistic: WorkoutComment = {
-      id: `optimistic-${Date.now()}`,
-      event_id: eventId,
-      npub: userNpub,
-      content: trimmed,
-      author_name: userName || null,
-      author_avatar: userAvatar || null,
-      created_at: new Date().toISOString(),
-    };
+      const optimistic: WorkoutComment = {
+        id: `optimistic-${Date.now()}`,
+        event_id: eventId,
+        npub: userNpub,
+        content: trimmed,
+        author_name: userName || null,
+        author_avatar: userAvatar || null,
+        created_at: new Date().toISOString(),
+      };
 
-    setOptimisticComments((prev) => [optimistic, ...prev]);
+      setOptimisticComments((prev) => [optimistic, ...prev]);
 
-    const result = await WorkoutInteractionService.getInstance().addComment(
-      eventId,
-      userNpub,
-      trimmed,
-      userName || undefined,
-      userAvatar || undefined,
-    );
+      const result = await WorkoutInteractionService.getInstance().addComment(
+        eventId,
+        userNpub,
+        trimmed,
+        userName || undefined,
+        userAvatar || undefined,
+      );
 
-    if (result) {
-      // Replace optimistic entry with the real one and notify parent
-      setOptimisticComments((prev) => prev.filter((c) => c.id !== optimistic.id));
-      setComments((prev) => [result, ...prev]);
-      onCommentAdded?.();
-    } else {
-      setOptimisticComments((prev) => prev.filter((c) => c.id !== optimistic.id));
-      setInputText(trimmed);
-      Toast.show({ type: 'error', text1: 'Comment not sent', visibilityTime: 2000 });
+      if (result) {
+        // Replace optimistic entry with the real one and notify parent
+        setOptimisticComments((prev) => prev.filter((c) => c.id !== optimistic.id));
+        setComments((prev) => [result, ...prev]);
+        onCommentAdded?.();
+      } else {
+        setOptimisticComments((prev) => prev.filter((c) => c.id !== optimistic.id));
+        setInputText(trimmed);
+        Toast.show({ type: 'error', text1: 'Comment not sent', visibilityTime: 2000 });
+      }
+    } finally {
+      setIsSending(false);
     }
-
-    setIsSending(false);
   }, [inputText, isSending, eventId, userNpub, onCommentAdded]);
 
   if (!expanded) return null;


### PR DESCRIPTION
Automated draft PR addressing #569 (H-1 finding).

## Summary
- Wraps the async body of `handleSend` in `try/finally` so `setIsSending(false)` is guaranteed to fire even when `AsyncStorage.getItem` or `addComment` throws
- Previously, any unhandled rejection (network loss, Supabase error) left `isSending = true` for the component's lifetime, permanently disabling the `TextInput` and Send button
- User had to collapse and re-expand the comment section to recover; now the input always re-enables

## How this addresses the issue
Issue #569 H-1 identified that `setIsSending(false)` at line 97 of `InlineCommentList.tsx` is never reached on any throw between `setIsSending(true)` (line 61) and itself, leaving the comment input permanently locked. The fix adds `try/finally` so the mutex releases unconditionally.

## Verification
- [x] Typecheck passes (no new errors vs baseline — 0 errors total)
- [x] Diff under 100 lines (2 lines net change; indentation shift only)
- [x] Single concern (one bug, one file)
- [ ] Human review needed before merge

Closes #569

<!-- CRON-RUN-LOG
agent: auto-pr
run_date: 2026-09-04
findings_count: 1
severity: critical=0 high=1 medium=0 low=0
self_score:
  specificity: 9
  actionability: 10
  signal_to_noise: 9
  false_positive_risk: 10
  coverage: 7
overall: 9.0
notes: All auto-pr-ok issues were sweep bundles; picked the single H-1 finding from #569 that was explicitly scoped to one file and 4 lines — worked well.
-->

https://claude.ai/code/session_01BRimdu9Wod1sJis7m35xxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRimdu9Wod1sJis7m35xxW)_